### PR TITLE
Add D2GFX ResolutionMode

### DIFF
--- a/1.00.txt
+++ b/1.00.txt
@@ -1,6 +1,7 @@
 Library	Name	Locator Type	Locator Value	Comments	
 D2Client.dll	DifficultyLevel	Offset	0x12EDDC	nDifficultyLevel	
 D2Client.dll	ScreenXShift	Ordinal	0x1348AC		
+D2GFX.dll	ResolutionMode	Offset	0x2A950	"0 = 640x480, 1 = Main Menu 800x600"	
 D2Lang.dll	GetLocaleText	Ordinal	10004		
 D2Lang.dll	ToUnicodeString	Offset	0x1118	?toUnicode@Unicode@@SIPAU1@PAU1@PBDH@Z	Unicode::toUnicode
 D2Lang.dll	ConvertUnicodeToWin				

--- a/1.03.txt
+++ b/1.03.txt
@@ -1,2 +1,3 @@
 Library	Name	Locator Type	Locator Value	Comments
 D2Client.dll	DifficultyLevel	Offset	0x12EAC4	nDifficultyLevel
+D2GFX.dll	ResolutionMode	Offset	0x2A990	"0 = 640x480, 1 = Main Menu 800x600"

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -1,2 +1,3 @@
 Library	Name	Locator Type	Locator Value	Comments
 D2Client.dll	DifficultyLevel	Offset	0xE3024	nDifficultyLevel
+D2GFX.dll	ResolutionMode	Offset	0x1D060	"0 = 640x480, 1 = Main Menu 800x600"

--- a/1.09B.txt
+++ b/1.09B.txt
@@ -1,2 +1,3 @@
 Library	Name	Locator Type	Locator Value	Comments
 D2Client.dll	DifficultyLevel	Offset	0x110BBC	nDifficultyLevel
+D2GFX.dll	ResolutionMode	Offset	0x1D210	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"

--- a/1.10.txt
+++ b/1.10.txt
@@ -1,2 +1,3 @@
 Library	Name	Locator Type	Locator Value	Comments
 D2Client.dll	DifficultyLevel	Offset	0x10795C	nDifficultyLevel
+D2GFX.dll	ResolutionMode	Offset	0x1D26C	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -1,2 +1,3 @@
 Library	Name	Locator Type	Locator Value	Comments
 D2Client.dll	DifficultyLevel	Offset	0x11BFF4	nDifficultyLevel
+D2GFX.dll	ResolutionMode	Offset	0x1D454	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -1,5 +1,6 @@
 Library	Name	Locator Type	Locator Value	Comments
 D2Client.dll	DifficultyLevel	Offset	0x11C390	nDifficultyLevel
-D2Client.dll	ScreenXShift	Ordinal	0x11C418	
+D2Client.dll	ScreenXShift	Offset	0x11C418	
+D2GFX.dll	ResolutionMode	Offset	0x11260	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"
 D2Lang.dll	CreateD2UnicodeChar	Ordinal	10000	
 D2Lang.dll	CreateD2UnicodeCharWithValue	Ordinal		

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -1,2 +1,3 @@
 Library	Name	Locator Type	Locator Value	Comments
 D2Client.dll	DifficultyLevel	Offset	0x11D1D8	nDifficultyLevel
+D2GFX.dll	ResolutionMode	Offset	0x14A40	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -1,2 +1,3 @@
 Library	Name	Locator Type	Locator Value	Comments
 D2Client.dll	DifficultyLevel	Offset	0x397694	nDifficultyLevel
+D2GFX.dll	ResolutionMode	Offset	0x3BFD40	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -1,2 +1,3 @@
 Library	Name	Locator Type	Locator Value	Comments
 D2Client.dll	DifficultyLevel	Offset	0x3A060C	nDifficultyLevel
+D2GFX.dll	ResolutionMode	Offset	0x3C8CB8	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"


### PR DESCRIPTION
This address points to a uint32_t. The data may take on the following values:

- 0: Ingame, in 640x480 mode.
- 1: Main menu, in 800x600 mode.
- 2: Ingame, in 800x600 mode (1.07 and above).
- 3: Unused and unfinished. Ingame, in 1344x700 mode (1.07 and above).

The address can be found by changing resolution accordingly and scanning for the corresponding values. The address type is confirmed in 1.07 and above, and is noted in the following 1.09D screenshot.
![D2GFX_ResolutionMode](https://user-images.githubusercontent.com/26683324/54873398-b5130f80-4d92-11e9-8c09-1306ab71cf3d.PNG)
