### PR TITLE
Add D2Win MainMenuMousePosition

### DIFF
--- a/1.00.txt
+++ b/1.00.txt
@@ -21,5 +21,5 @@ D2Lang.dll	UnicodeString_Format	Offset	0x1046	?sprintf@Unicode@@SAXHPAU1@PBU1@ZZ
 D2Lang.dll	UnicodeString_GetLength	Offset	0x1055	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	UnicodeString_NCompareIgnoreCase	Offset	0x1091	?strnicmp@Unicode@@SIHPBU1@0I@Z	Unicode::strnicmp
 D2Lang.dll	UnloadSysMap	Offset	0x104B	?unloadSysMap@Unicode@@SIXXZ	Unicode::unloadSysMap
-D2Win.dll	MousePositionX	Offset	0x72A90		
-D2Win.dll	MousePositionY	Offset	0x72A94		
+D2Win.dll	MainMenuMousePositionX	Offset	0x72A90		
+D2Win.dll	MainMenuMousePositionY	Offset	0x72A94		

--- a/1.00.txt
+++ b/1.00.txt
@@ -21,3 +21,5 @@ D2Lang.dll	UnicodeString_Format	Offset	0x1046	?sprintf@Unicode@@SAXHPAU1@PBU1@ZZ
 D2Lang.dll	UnicodeString_GetLength	Offset	0x1055	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	UnicodeString_NCompareIgnoreCase	Offset	0x1091	?strnicmp@Unicode@@SIHPBU1@0I@Z	Unicode::strnicmp
 D2Lang.dll	UnloadSysMap	Offset	0x104B	?unloadSysMap@Unicode@@SIXXZ	Unicode::unloadSysMap
+D2Win.dll	MousePositionX	Offset	0x72A90		
+D2Win.dll	MousePositionY	Offset	0x72A94		

--- a/1.03.txt
+++ b/1.03.txt
@@ -1,3 +1,5 @@
 Library	Name	Locator Type	Locator Value	Comments
 D2Client.dll	DifficultyLevel	Offset	0x12EAC4	nDifficultyLevel
 D2GFX.dll	ResolutionMode	Offset	0x2A990	"0 = 640x480, 1 = Main Menu 800x600"
+D2Win.dll	MousePositionX	Offset	0x72A98	
+D2Win.dll	MousePositionY	Offset	0x72A9C	

--- a/1.03.txt
+++ b/1.03.txt
@@ -1,5 +1,5 @@
 Library	Name	Locator Type	Locator Value	Comments
 D2Client.dll	DifficultyLevel	Offset	0x12EAC4	nDifficultyLevel
 D2GFX.dll	ResolutionMode	Offset	0x2A990	"0 = 640x480, 1 = Main Menu 800x600"
-D2Win.dll	MousePositionX	Offset	0x72A98	
-D2Win.dll	MousePositionY	Offset	0x72A9C	
+D2Win.dll	MainMenuMousePositionX	Offset	0x72A98	
+D2Win.dll	MainMenuMousePositionY	Offset	0x72A9C	

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -1,3 +1,5 @@
 Library	Name	Locator Type	Locator Value	Comments
 D2Client.dll	DifficultyLevel	Offset	0xE3024	nDifficultyLevel
 D2GFX.dll	ResolutionMode	Offset	0x1D060	"0 = 640x480, 1 = Main Menu 800x600"
+D2Win.dll	MainMenuMousePositionX	Offset	0x5BCB8	
+D2Win.dll	MainMenuMousePositionY	Offset	0x5BCBC	

--- a/1.09B.txt
+++ b/1.09B.txt
@@ -1,3 +1,5 @@
 Library	Name	Locator Type	Locator Value	Comments
 D2Client.dll	DifficultyLevel	Offset	0x110BBC	nDifficultyLevel
 D2GFX.dll	ResolutionMode	Offset	0x1D210	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"
+D2Win.dll	MainMenuMousePositionX	Offset	0x618A0	
+D2Win.dll	MainMenuMousePositionY	Offset	0x618A4	

--- a/1.10.txt
+++ b/1.10.txt
@@ -1,3 +1,5 @@
 Library	Name	Locator Type	Locator Value	Comments
 D2Client.dll	DifficultyLevel	Offset	0x10795C	nDifficultyLevel
 D2GFX.dll	ResolutionMode	Offset	0x1D26C	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"
+D2Win.dll	MainMenuMousePositionX	Offset	0x5E234	
+D2Win.dll	MainMenuMousePositionY	Offset	0x5E238	

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -1,3 +1,5 @@
 Library	Name	Locator Type	Locator Value	Comments
 D2Client.dll	DifficultyLevel	Offset	0x11BFF4	nDifficultyLevel
 D2GFX.dll	ResolutionMode	Offset	0x1D454	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"
+D2Win.dll	MainMenuMousePositionX	Offset	0x5C700	
+D2Win.dll	MainMenuMousePositionY	Offset	0x5C704	

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -4,3 +4,5 @@ D2Client.dll	ScreenXShift	Offset	0x11C418
 D2GFX.dll	ResolutionMode	Offset	0x11260	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"
 D2Lang.dll	CreateD2UnicodeChar	Ordinal	10000	
 D2Lang.dll	CreateD2UnicodeCharWithValue	Ordinal		
+D2Win.dll	MainMenuMousePositionX	Offset	0x21488	
+D2Win.dll	MainMenuMousePositionY	Offset	0x2148C	

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -1,3 +1,5 @@
 Library	Name	Locator Type	Locator Value	Comments
 D2Client.dll	DifficultyLevel	Offset	0x11D1D8	nDifficultyLevel
 D2GFX.dll	ResolutionMode	Offset	0x14A40	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"
+D2Win.dll	MainMenuMousePositionX	Offset	0x8DB1C	
+D2Win.dll	MainMenuMousePositionY	Offset	0x8DB20	

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -1,3 +1,5 @@
 Library	Name	Locator Type	Locator Value	Comments
 D2Client.dll	DifficultyLevel	Offset	0x397694	nDifficultyLevel
 D2GFX.dll	ResolutionMode	Offset	0x3BFD40	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"
+D2Win.dll	MainMenuMousePositionX	Offset	0x3CC62C	
+D2Win.dll	MainMenuMousePositionY	Offset	0x3CC630	

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -1,3 +1,5 @@
 Library	Name	Locator Type	Locator Value	Comments
 D2Client.dll	DifficultyLevel	Offset	0x3A060C	nDifficultyLevel
 D2GFX.dll	ResolutionMode	Offset	0x3C8CB8	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"
+D2Win.dll	MainMenuMousePositionX	Offset	0x3D55A4	
+D2Win.dll	MainMenuMousePositionY	Offset	0x3D55A8	


### PR DESCRIPTION
The addresses point to two int32_t. The data values are based on the position of the mouse cursor relative to the game window, with one representing the x-position, and the other representing the y-position. These values change in both the main menu and ingame, despite their names. However, these data values are only accessed by the game in the main menu.

The addresses can be located by repeatedly moving the mouse cursor to the upper left corner of the screen and scanning for values less than 240, and then moving the cursor to the lower right corner and scanning for values greater than 240. The addresses' types are confirmed by the following 1.00 screenshot.
![D2Win_MousePosition](https://user-images.githubusercontent.com/26683324/54887727-76915980-4e53-11e9-806b-b32f85479f9a.PNG)
