### PR TITLE
Add D2Client IngameMousePosition

### DIFF
--- a/1.00.txt
+++ b/1.00.txt
@@ -1,5 +1,7 @@
 Library	Name	Locator Type	Locator Value	Comments	
 D2Client.dll	DifficultyLevel	Offset	0x12EDDC	nDifficultyLevel	
+D2Client.dll	IngameMousePositionX	Offset	0x11AFF8		
+D2Client.dll	IngameMousePositionY	Offset	0x11AFFC		
 D2Client.dll	ScreenXShift	Ordinal	0x1348AC		
 D2GFX.dll	ResolutionMode	Offset	0x2A950	"0 = 640x480, 1 = Main Menu 800x600"	
 D2Lang.dll	GetLocaleText	Ordinal	10004		

--- a/1.03.txt
+++ b/1.03.txt
@@ -1,5 +1,7 @@
 Library	Name	Locator Type	Locator Value	Comments
 D2Client.dll	DifficultyLevel	Offset	0x12EAC4	nDifficultyLevel
+D2Client.dll	IngameMousePositionX	Offset	0x11ACA0	
+D2Client.dll	IngameMousePositionY	Offset	0x11ACA4	
 D2GFX.dll	ResolutionMode	Offset	0x2A990	"0 = 640x480, 1 = Main Menu 800x600"
 D2Win.dll	MainMenuMousePositionX	Offset	0x72A98	
 D2Win.dll	MainMenuMousePositionY	Offset	0x72A9C	

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -1,5 +1,7 @@
 Library	Name	Locator Type	Locator Value	Comments
 D2Client.dll	DifficultyLevel	Offset	0xE3024	nDifficultyLevel
+D2Client.dll	IngameMousePositionX	Offset	0xD19A8	
+D2Client.dll	IngameMousePositionY	Offset	0xD19AC	
 D2GFX.dll	ResolutionMode	Offset	0x1D060	"0 = 640x480, 1 = Main Menu 800x600"
 D2Win.dll	MainMenuMousePositionX	Offset	0x5BCB8	
 D2Win.dll	MainMenuMousePositionY	Offset	0x5BCBC	

--- a/1.09B.txt
+++ b/1.09B.txt
@@ -1,5 +1,7 @@
 Library	Name	Locator Type	Locator Value	Comments
 D2Client.dll	DifficultyLevel	Offset	0x110BBC	nDifficultyLevel
+D2Client.dll	IngameMousePositionX	Offset	0x12B168	
+D2Client.dll	IngameMousePositionY	Offset	0x12B16C	
 D2GFX.dll	ResolutionMode	Offset	0x1D210	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"
 D2Win.dll	MainMenuMousePositionX	Offset	0x618A0	
 D2Win.dll	MainMenuMousePositionY	Offset	0x618A4	

--- a/1.10.txt
+++ b/1.10.txt
@@ -1,5 +1,7 @@
 Library	Name	Locator Type	Locator Value	Comments
 D2Client.dll	DifficultyLevel	Offset	0x10795C	nDifficultyLevel
+D2Client.dll	IngameMousePositionX	Offset	0x121AE4	
+D2Client.dll	IngameMousePositionY	Offset	0x121AE8	
 D2GFX.dll	ResolutionMode	Offset	0x1D26C	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"
 D2Win.dll	MainMenuMousePositionX	Offset	0x5E234	
 D2Win.dll	MainMenuMousePositionY	Offset	0x5E238	

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -1,5 +1,7 @@
 Library	Name	Locator Type	Locator Value	Comments
 D2Client.dll	DifficultyLevel	Offset	0x11BFF4	nDifficultyLevel
+D2Client.dll	IngameMousePositionX	Offset	0x101638	
+D2Client.dll	IngameMousePositionY	Offset	0x101634	
 D2GFX.dll	ResolutionMode	Offset	0x1D454	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"
 D2Win.dll	MainMenuMousePositionX	Offset	0x5C700	
 D2Win.dll	MainMenuMousePositionY	Offset	0x5C704	

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -1,5 +1,7 @@
 Library	Name	Locator Type	Locator Value	Comments
 D2Client.dll	DifficultyLevel	Offset	0x11C390	nDifficultyLevel
+D2Client.dll	IngameMousePositionX	Offset	0x11B828	
+D2Client.dll	IngameMousePositionY	Offset	0x11B824	
 D2Client.dll	ScreenXShift	Offset	0x11C418	
 D2GFX.dll	ResolutionMode	Offset	0x11260	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"
 D2Lang.dll	CreateD2UnicodeChar	Ordinal	10000	

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -1,5 +1,7 @@
 Library	Name	Locator Type	Locator Value	Comments
 D2Client.dll	DifficultyLevel	Offset	0x11D1D8	nDifficultyLevel
+D2Client.dll	IngameMousePositionX	Offset	0x11C950	
+D2Client.dll	IngameMousePositionY	Offset	0x11C94C	
 D2GFX.dll	ResolutionMode	Offset	0x14A40	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"
 D2Win.dll	MainMenuMousePositionX	Offset	0x8DB1C	
 D2Win.dll	MainMenuMousePositionY	Offset	0x8DB20	

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -1,5 +1,7 @@
 Library	Name	Locator Type	Locator Value	Comments
 D2Client.dll	DifficultyLevel	Offset	0x397694	nDifficultyLevel
+D2Client.dll	IngameMousePositionX	Offset	0x39DB38	
+D2Client.dll	IngameMousePositionY	Offset	0x39DB34	
 D2GFX.dll	ResolutionMode	Offset	0x3BFD40	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"
 D2Win.dll	MainMenuMousePositionX	Offset	0x3CC62C	
 D2Win.dll	MainMenuMousePositionY	Offset	0x3CC630	

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -1,5 +1,7 @@
 Library	Name	Locator Type	Locator Value	Comments
 D2Client.dll	DifficultyLevel	Offset	0x3A060C	nDifficultyLevel
+D2Client.dll	IngameMousePositionX	Offset	0x3A6AB0	
+D2Client.dll	IngameMousePositionY	Offset	0x3A6AAC	
 D2GFX.dll	ResolutionMode	Offset	0x3C8CB8	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"
 D2Win.dll	MainMenuMousePositionX	Offset	0x3D55A4	
 D2Win.dll	MainMenuMousePositionY	Offset	0x3D55A8	


### PR DESCRIPTION
Related to #2.

The addresses point to two int32_t. The data values are based on the position of the mouse cursor relative to the game window, with one representing the x-position, and the other representing the y-position. These values change ingame and are only accessed ingame.

The addresses can be located by repeatedly moving the mouse cursor to the upper left corner of the screen and scanning for values less than 240, and then moving the cursor to the lower right corner and scanning for values greater than 240. The addresses' types are confirmed by the following 1.00 screenshot.

![D2Client_MousePosition](https://user-images.githubusercontent.com/26683324/54888107-59f72080-4e57-11e9-9169-58c068f7f370.PNG)

Unlike #2, these values also appear to have the relative address positions of the x-position and y-position swapped, ever since 1.11.