### PR TITLE
Add D2Client IsHelpScreenOpen

### DIFF
--- a/1.00.txt
+++ b/1.00.txt
@@ -3,6 +3,7 @@ D2Client.dll	DifficultyLevel	Offset	0x12EDDC	nDifficultyLevel
 D2Client.dll	IngameMousePositionX	Offset	0x11AFF8		
 D2Client.dll	IngameMousePositionY	Offset	0x11AFFC		
 D2Client.dll	IsGameMenuOpen	Offset	0x143660		
+D2Client.dll	IsHelpScreenOpen	Offset	0x1436C0		
 D2Client.dll	ScreenXShift	Ordinal	0x1348AC		
 D2GFX.dll	ResolutionMode	Offset	0x2A950	"0 = 640x480, 1 = Main Menu 800x600"	
 D2Lang.dll	GetLocaleText	Ordinal	10004		

--- a/1.03.txt
+++ b/1.03.txt
@@ -3,6 +3,7 @@ D2Client.dll	DifficultyLevel	Offset	0x12EAC4	nDifficultyLevel
 D2Client.dll	IngameMousePositionX	Offset	0x11ACA0	
 D2Client.dll	IngameMousePositionY	Offset	0x11ACA4	
 D2Client.dll	IsGameMenuOpen	Offset	0x143530	
+D2Client.dll	IsHelpScreenOpen	Offset	0x143590	
 D2GFX.dll	ResolutionMode	Offset	0x2A990	"0 = 640x480, 1 = Main Menu 800x600"
 D2Win.dll	MainMenuMousePositionX	Offset	0x72A98	
 D2Win.dll	MainMenuMousePositionY	Offset	0x72A9C	

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -3,6 +3,7 @@ D2Client.dll	DifficultyLevel	Offset	0xE3024	nDifficultyLevel
 D2Client.dll	IngameMousePositionX	Offset	0xD19A8	
 D2Client.dll	IngameMousePositionY	Offset	0xD19AC	
 D2Client.dll	IsGameMenuOpen	Offset	0xF4D98	
+D2Client.dll	IsHelpScreenOpen	Offset	0xF4DF8	
 D2GFX.dll	ResolutionMode	Offset	0x1D060	"0 = 640x480, 1 = Main Menu 800x600"
 D2Win.dll	MainMenuMousePositionX	Offset	0x5BCB8	
 D2Win.dll	MainMenuMousePositionY	Offset	0x5BCBC	

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -3,6 +3,7 @@ D2Client.dll	DifficultyLevel	Offset	0x110BBC	nDifficultyLevel
 D2Client.dll	IngameMousePositionX	Offset	0x12B168	
 D2Client.dll	IngameMousePositionY	Offset	0x12B16C	
 D2Client.dll	IsGameMenuOpen	Offset	0x1248D8	
+D2Client.dll	IsHelpScreenOpen	Offset	0x124938	
 D2GFX.dll	ResolutionMode	Offset	0x1D210	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"
 D2Win.dll	MainMenuMousePositionX	Offset	0x618A0	
 D2Win.dll	MainMenuMousePositionY	Offset	0x618A4	

--- a/1.10.txt
+++ b/1.10.txt
@@ -3,6 +3,7 @@ D2Client.dll	DifficultyLevel	Offset	0x10795C	nDifficultyLevel
 D2Client.dll	IngameMousePositionX	Offset	0x121AE4	
 D2Client.dll	IngameMousePositionY	Offset	0x121AE8	
 D2Client.dll	IsGameMenuOpen	Offset	0x11A6CC	
+D2Client.dll	IsHelpScreenOpen	Offset	0x11A72C	
 D2GFX.dll	ResolutionMode	Offset	0x1D26C	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"
 D2Win.dll	MainMenuMousePositionX	Offset	0x5E234	
 D2Win.dll	MainMenuMousePositionY	Offset	0x5E238	

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -3,6 +3,7 @@ D2Client.dll	DifficultyLevel	Offset	0x11BFF4	nDifficultyLevel
 D2Client.dll	IngameMousePositionX	Offset	0x101638	
 D2Client.dll	IngameMousePositionY	Offset	0x101634	
 D2Client.dll	IsGameMenuOpen	Offset	0x102B7C	
+D2Client.dll	IsHelpScreenOpen	Offset	0x102BDC	
 D2GFX.dll	ResolutionMode	Offset	0x1D454	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"
 D2Win.dll	MainMenuMousePositionX	Offset	0x5C700	
 D2Win.dll	MainMenuMousePositionY	Offset	0x5C704	

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -3,6 +3,7 @@ D2Client.dll	DifficultyLevel	Offset	0x11C390	nDifficultyLevel
 D2Client.dll	IngameMousePositionX	Offset	0x11B828	
 D2Client.dll	IngameMousePositionY	Offset	0x11B824	
 D2Client.dll	IsGameMenuOpen	Offset	0xFADA4	
+D2Client.dll	IsHelpScreenOpen	Offset	0xFAE04	
 D2Client.dll	ScreenXShift	Offset	0x11C418	
 D2GFX.dll	ResolutionMode	Offset	0x11260	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"
 D2Lang.dll	CreateD2UnicodeChar	Ordinal	10000	

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -3,6 +3,7 @@ D2Client.dll	DifficultyLevel	Offset	0x11D1D8	nDifficultyLevel
 D2Client.dll	IngameMousePositionX	Offset	0x11C950	
 D2Client.dll	IngameMousePositionY	Offset	0x11C94C	
 D2Client.dll	IsGameMenuOpen	Offset	0x11C8B4	
+D2Client.dll	IsHelpScreenOpen	Offset	0x11C914	
 D2GFX.dll	ResolutionMode	Offset	0x14A40	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"
 D2Win.dll	MainMenuMousePositionX	Offset	0x8DB1C	
 D2Win.dll	MainMenuMousePositionY	Offset	0x8DB20	

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -3,6 +3,7 @@ D2Client.dll	DifficultyLevel	Offset	0x397694	nDifficultyLevel
 D2Client.dll	IngameMousePositionX	Offset	0x39DB38	
 D2Client.dll	IngameMousePositionY	Offset	0x39DB34	
 D2Client.dll	IsGameMenuOpen	Offset	0x39986C	
+D2Client.dll	IsHelpScreenOpen	Offset	0x3998CC	
 D2GFX.dll	ResolutionMode	Offset	0x3BFD40	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"
 D2Win.dll	MainMenuMousePositionX	Offset	0x3CC62C	
 D2Win.dll	MainMenuMousePositionY	Offset	0x3CC630	

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -3,6 +3,7 @@ D2Client.dll	DifficultyLevel	Offset	0x3A060C	nDifficultyLevel
 D2Client.dll	IngameMousePositionX	Offset	0x3A6AB0	
 D2Client.dll	IngameMousePositionY	Offset	0x3A6AAC	
 D2Client.dll	IsGameMenuOpen	Offset	0x3A27E4	
+D2Client.dll	IsHelpScreenOpen	Offset	0x3A2844	
 D2GFX.dll	ResolutionMode	Offset	0x3C8CB8	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"
 D2Win.dll	MainMenuMousePositionX	Offset	0x3D55A4	
 D2Win.dll	MainMenuMousePositionY	Offset	0x3D55A8	


### PR DESCRIPTION
![D2Client_IsHelpScreenOpen2](https://user-images.githubusercontent.com/26683324/55271737-16455200-526f-11e9-8abd-a33d4f5226dc.jpg)

The address points to an int32_t, but is treated like a bool. The data value is set to 0 if the help screen is not opened, and 1 if the help screen is opened.

The address can be located by opening the help screen and closing it, scanning for the corresponding values. The address's type is confirmed by the following 1.00 screenshot.
![D2Client_IsHelpScreenOpen](https://user-images.githubusercontent.com/26683324/55271763-a1264c80-526f-11e9-8063-8c908bda7180.PNG)