### PR TITLE
Add D2Client IsNewSkillButtonPressed

### DIFF
--- a/1.00.txt
+++ b/1.00.txt
@@ -4,6 +4,7 @@ D2Client.dll	IngameMousePositionX	Offset	0x11AFF8
 D2Client.dll	IngameMousePositionY	Offset	0x11AFFC		
 D2Client.dll	IsGameMenuOpen	Offset	0x143660		
 D2Client.dll	IsHelpScreenOpen	Offset	0x1436C0		
+D2Client.dll	IsNewSkillButtonPressed	Offset	0x13DDF8		
 D2Client.dll	ScreenXShift	Ordinal	0x1348AC		
 D2GFX.dll	ResolutionMode	Offset	0x2A950	"0 = 640x480, 1 = Main Menu 800x600"	
 D2Lang.dll	GetLocaleText	Ordinal	10004		

--- a/1.03.txt
+++ b/1.03.txt
@@ -4,6 +4,7 @@ D2Client.dll	IngameMousePositionX	Offset	0x11ACA0
 D2Client.dll	IngameMousePositionY	Offset	0x11ACA4	
 D2Client.dll	IsGameMenuOpen	Offset	0x143530	
 D2Client.dll	IsHelpScreenOpen	Offset	0x143590	
+D2Client.dll	IsNewSkillButtonPressed	Offset	0x13DB30	
 D2GFX.dll	ResolutionMode	Offset	0x2A990	"0 = 640x480, 1 = Main Menu 800x600"
 D2Win.dll	MainMenuMousePositionX	Offset	0x72A98	
 D2Win.dll	MainMenuMousePositionY	Offset	0x72A9C	

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -4,6 +4,7 @@ D2Client.dll	IngameMousePositionX	Offset	0xD19A8
 D2Client.dll	IngameMousePositionY	Offset	0xD19AC	
 D2Client.dll	IsGameMenuOpen	Offset	0xF4D98	
 D2Client.dll	IsHelpScreenOpen	Offset	0xF4DF8	
+D2Client.dll	IsNewSkillButtonPressed	Offset	0xF01F8	
 D2GFX.dll	ResolutionMode	Offset	0x1D060	"0 = 640x480, 1 = Main Menu 800x600"
 D2Win.dll	MainMenuMousePositionX	Offset	0x5BCB8	
 D2Win.dll	MainMenuMousePositionY	Offset	0x5BCBC	

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -4,6 +4,7 @@ D2Client.dll	IngameMousePositionX	Offset	0x12B168
 D2Client.dll	IngameMousePositionY	Offset	0x12B16C	
 D2Client.dll	IsGameMenuOpen	Offset	0x1248D8	
 D2Client.dll	IsHelpScreenOpen	Offset	0x124938	
+D2Client.dll	IsNewSkillButtonPressed	Offset	0x11FE88	
 D2GFX.dll	ResolutionMode	Offset	0x1D210	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"
 D2Win.dll	MainMenuMousePositionX	Offset	0x618A0	
 D2Win.dll	MainMenuMousePositionY	Offset	0x618A4	

--- a/1.10.txt
+++ b/1.10.txt
@@ -4,6 +4,7 @@ D2Client.dll	IngameMousePositionX	Offset	0x121AE4
 D2Client.dll	IngameMousePositionY	Offset	0x121AE8	
 D2Client.dll	IsGameMenuOpen	Offset	0x11A6CC	
 D2Client.dll	IsHelpScreenOpen	Offset	0x11A72C	
+D2Client.dll	IsNewSkillButtonPressed	Offset	0x115BC0	
 D2GFX.dll	ResolutionMode	Offset	0x1D26C	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"
 D2Win.dll	MainMenuMousePositionX	Offset	0x5E234	
 D2Win.dll	MainMenuMousePositionY	Offset	0x5E238	

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -4,6 +4,7 @@ D2Client.dll	IngameMousePositionX	Offset	0x101638
 D2Client.dll	IngameMousePositionY	Offset	0x101634	
 D2Client.dll	IsGameMenuOpen	Offset	0x102B7C	
 D2Client.dll	IsHelpScreenOpen	Offset	0x102BDC	
+D2Client.dll	IsNewSkillButtonPressed	Offset	0x11C348	
 D2GFX.dll	ResolutionMode	Offset	0x1D454	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"
 D2Win.dll	MainMenuMousePositionX	Offset	0x5C700	
 D2Win.dll	MainMenuMousePositionY	Offset	0x5C704	

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -5,6 +5,7 @@ D2Client.dll	IngameMousePositionY	Offset	0x11B824
 D2Client.dll	IsGameMenuOpen	Offset	0xFADA4	
 D2Client.dll	IsHelpScreenOpen	Offset	0xFAE04	
 D2Client.dll	ScreenXShift	Offset	0x11C418	
+D2Client.dll	IsNewSkillButtonPressed	Offset	0x11C30C	
 D2GFX.dll	ResolutionMode	Offset	0x11260	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"
 D2Lang.dll	CreateD2UnicodeChar	Ordinal	10000	
 D2Lang.dll	CreateD2UnicodeCharWithValue	Ordinal		

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -4,6 +4,7 @@ D2Client.dll	IngameMousePositionX	Offset	0x11C950
 D2Client.dll	IngameMousePositionY	Offset	0x11C94C	
 D2Client.dll	IsGameMenuOpen	Offset	0x11C8B4	
 D2Client.dll	IsHelpScreenOpen	Offset	0x11C914	
+D2Client.dll	IsNewSkillButtonPressed	Offset	0x11D31C	
 D2GFX.dll	ResolutionMode	Offset	0x14A40	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"
 D2Win.dll	MainMenuMousePositionX	Offset	0x8DB1C	
 D2Win.dll	MainMenuMousePositionY	Offset	0x8DB20	

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -4,6 +4,7 @@ D2Client.dll	IngameMousePositionX	Offset	0x39DB38
 D2Client.dll	IngameMousePositionY	Offset	0x39DB34	
 D2Client.dll	IsGameMenuOpen	Offset	0x39986C	
 D2Client.dll	IsHelpScreenOpen	Offset	0x3998CC	
+D2Client.dll	IsNewSkillButtonPressed	Offset	0x3B7370	
 D2GFX.dll	ResolutionMode	Offset	0x3BFD40	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"
 D2Win.dll	MainMenuMousePositionX	Offset	0x3CC62C	
 D2Win.dll	MainMenuMousePositionY	Offset	0x3CC630	

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -4,6 +4,7 @@ D2Client.dll	IngameMousePositionX	Offset	0x3A6AB0
 D2Client.dll	IngameMousePositionY	Offset	0x3A6AAC	
 D2Client.dll	IsGameMenuOpen	Offset	0x3A27E4	
 D2Client.dll	IsHelpScreenOpen	Offset	0x3A2844	
+D2Client.dll	IsNewSkillButtonPressed	Offset	0x3C02E8	
 D2GFX.dll	ResolutionMode	Offset	0x3C8CB8	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"
 D2Win.dll	MainMenuMousePositionX	Offset	0x3D55A4	
 D2Win.dll	MainMenuMousePositionY	Offset	0x3D55A8	


### PR DESCRIPTION
The address points to an int32_t, but is treated like a bool. The data value is set to 0 if the New Skill button is not pressed, and 1 if the New Skill button is pressed.

The address can be located using a character with at least one skill point available to spend. Using this character, press and hold the New Skill button while pressing ALT-TAB to freeze the state of the button into its pressed state. To release the button from pressed state, click anywhere else. Scan for the values corresponding to the state of the New Skill button. The address's type is confirmed by the following 1.00 screenshot.

![D2Client_IsNewSkillButtonPressed](https://user-images.githubusercontent.com/26683324/55272383-14808c00-5279-11e9-8b00-9d01e5efaaea.PNG)

640x480, Pressed:
![D2Client_IsNewSkillButtonPressed3](https://user-images.githubusercontent.com/26683324/55272386-206c4e00-5279-11e9-92f7-041893c9a638.jpg)

800x600, Pressed:
![D2Client_IsNewSkillButtonPressed2](https://user-images.githubusercontent.com/26683324/55272385-1b0f0380-5279-11e9-936e-784e90aaec4a.jpg)
