### PR TITLE
Add D2Client IsAutomapOpen

### DIFF
--- a/1.00.txt
+++ b/1.00.txt
@@ -2,6 +2,7 @@ Library	Name	Locator Type	Locator Value	Comments
 D2Client.dll	DifficultyLevel	Offset	0x12EDDC	nDifficultyLevel	
 D2Client.dll	IngameMousePositionX	Offset	0x11AFF8		
 D2Client.dll	IngameMousePositionY	Offset	0x11AFFC		
+D2Client.dll	IsAutomapOpen	Offset	0x143664		
 D2Client.dll	IsGameMenuOpen	Offset	0x143660		
 D2Client.dll	IsHelpScreenOpen	Offset	0x1436C0		
 D2Client.dll	IsNewSkillButtonPressed	Offset	0x13DDF8		

--- a/1.03.txt
+++ b/1.03.txt
@@ -2,6 +2,7 @@ Library	Name	Locator Type	Locator Value	Comments
 D2Client.dll	DifficultyLevel	Offset	0x12EAC4	nDifficultyLevel
 D2Client.dll	IngameMousePositionX	Offset	0x11ACA0	
 D2Client.dll	IngameMousePositionY	Offset	0x11ACA4	
+D2Client.dll	IsAutomapOpen	Offset	0x143534	
 D2Client.dll	IsGameMenuOpen	Offset	0x143530	
 D2Client.dll	IsHelpScreenOpen	Offset	0x143590	
 D2Client.dll	IsNewSkillButtonPressed	Offset	0x13DB30	

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -2,6 +2,7 @@ Library	Name	Locator Type	Locator Value	Comments
 D2Client.dll	DifficultyLevel	Offset	0xE3024	nDifficultyLevel
 D2Client.dll	IngameMousePositionX	Offset	0xD19A8	
 D2Client.dll	IngameMousePositionY	Offset	0xD19AC	
+D2Client.dll	IsAutomapOpen	Offset	0xF4D9C	
 D2Client.dll	IsGameMenuOpen	Offset	0xF4D98	
 D2Client.dll	IsHelpScreenOpen	Offset	0xF4DF8	
 D2Client.dll	IsNewSkillButtonPressed	Offset	0xF01F8	

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -2,6 +2,7 @@ Library	Name	Locator Type	Locator Value	Comments
 D2Client.dll	DifficultyLevel	Offset	0x110BBC	nDifficultyLevel
 D2Client.dll	IngameMousePositionX	Offset	0x12B168	
 D2Client.dll	IngameMousePositionY	Offset	0x12B16C	
+D2Client.dll	IsAutomapOpen	Offset	0x1248DC	
 D2Client.dll	IsGameMenuOpen	Offset	0x1248D8	
 D2Client.dll	IsHelpScreenOpen	Offset	0x124938	
 D2Client.dll	IsNewSkillButtonPressed	Offset	0x11FE88	

--- a/1.10.txt
+++ b/1.10.txt
@@ -2,6 +2,7 @@ Library	Name	Locator Type	Locator Value	Comments
 D2Client.dll	DifficultyLevel	Offset	0x10795C	nDifficultyLevel
 D2Client.dll	IngameMousePositionX	Offset	0x121AE4	
 D2Client.dll	IngameMousePositionY	Offset	0x121AE8	
+D2Client.dll	IsAutomapOpen	Offset	0x11A6D0	
 D2Client.dll	IsGameMenuOpen	Offset	0x11A6CC	
 D2Client.dll	IsHelpScreenOpen	Offset	0x11A72C	
 D2Client.dll	IsNewSkillButtonPressed	Offset	0x115BC0	

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -2,6 +2,7 @@ Library	Name	Locator Type	Locator Value	Comments
 D2Client.dll	DifficultyLevel	Offset	0x11BFF4	nDifficultyLevel
 D2Client.dll	IngameMousePositionX	Offset	0x101638	
 D2Client.dll	IngameMousePositionY	Offset	0x101634	
+D2Client.dll	IsAutomapOpen	Offset	0x102B80	
 D2Client.dll	IsGameMenuOpen	Offset	0x102B7C	
 D2Client.dll	IsHelpScreenOpen	Offset	0x102BDC	
 D2Client.dll	IsNewSkillButtonPressed	Offset	0x11C348	

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -2,6 +2,7 @@ Library	Name	Locator Type	Locator Value	Comments
 D2Client.dll	DifficultyLevel	Offset	0x11C390	nDifficultyLevel
 D2Client.dll	IngameMousePositionX	Offset	0x11B828	
 D2Client.dll	IngameMousePositionY	Offset	0x11B824	
+D2Client.dll	IsAutomapOpen	Offset	0xFADA8	
 D2Client.dll	IsGameMenuOpen	Offset	0xFADA4	
 D2Client.dll	IsHelpScreenOpen	Offset	0xFAE04	
 D2Client.dll	ScreenXShift	Offset	0x11C418	

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -2,6 +2,7 @@ Library	Name	Locator Type	Locator Value	Comments
 D2Client.dll	DifficultyLevel	Offset	0x11D1D8	nDifficultyLevel
 D2Client.dll	IngameMousePositionX	Offset	0x11C950	
 D2Client.dll	IngameMousePositionY	Offset	0x11C94C	
+D2Client.dll	IsAutomapOpen	Offset	0x11C8B8	
 D2Client.dll	IsGameMenuOpen	Offset	0x11C8B4	
 D2Client.dll	IsHelpScreenOpen	Offset	0x11C914	
 D2Client.dll	IsNewSkillButtonPressed	Offset	0x11D31C	

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -2,6 +2,7 @@ Library	Name	Locator Type	Locator Value	Comments
 D2Client.dll	DifficultyLevel	Offset	0x397694	nDifficultyLevel
 D2Client.dll	IngameMousePositionX	Offset	0x39DB38	
 D2Client.dll	IngameMousePositionY	Offset	0x39DB34	
+D2Client.dll	IsAutomapOpen	Offset	0x399870	
 D2Client.dll	IsGameMenuOpen	Offset	0x39986C	
 D2Client.dll	IsHelpScreenOpen	Offset	0x3998CC	
 D2Client.dll	IsNewSkillButtonPressed	Offset	0x3B7370	

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -2,6 +2,7 @@ Library	Name	Locator Type	Locator Value	Comments
 D2Client.dll	DifficultyLevel	Offset	0x3A060C	nDifficultyLevel
 D2Client.dll	IngameMousePositionX	Offset	0x3A6AB0	
 D2Client.dll	IngameMousePositionY	Offset	0x3A6AAC	
+D2Client.dll	IsAutomapOpen	Offset	0x3A27E8	
 D2Client.dll	IsGameMenuOpen	Offset	0x3A27E4	
 D2Client.dll	IsHelpScreenOpen	Offset	0x3A2844	
 D2Client.dll	IsNewSkillButtonPressed	Offset	0x3C02E8	


### PR DESCRIPTION
The address points to an int32_t, but is treated like a bool. The data value is set to 0 if the Automap is not open, and 1 if the Automap is open.

The address can be located by opening and closing the Automap, scanning for the respective values mentioned above. The address's type is confirmed by the following 1.00 screenshot.

![D2Client_IsAutomapOpen](https://user-images.githubusercontent.com/26683324/56201845-981ad680-5ff6-11e9-926f-4d5e72b40ced.PNG)

Automap Disabled:
![D2Client_IsAutomapOpen1](https://user-images.githubusercontent.com/26683324/56201882-acf76a00-5ff6-11e9-8dcc-e29313c2ad23.jpg)

Automap Enabled:
![D2Client_IsAutomapOpen2](https://user-images.githubusercontent.com/26683324/56201893-b41e7800-5ff6-11e9-9686-d7c8ce034312.jpg)
