### PR TITLE
Add D2Client IsNewStatsButtonPressed

### DIFF
--- a/1.00.txt
+++ b/1.00.txt
@@ -6,6 +6,7 @@ D2Client.dll	IsAutomapOpen	Offset	0x143664
 D2Client.dll	IsGameMenuOpen	Offset	0x143660		
 D2Client.dll	IsHelpScreenOpen	Offset	0x1436C0		
 D2Client.dll	IsNewSkillButtonPressed	Offset	0x13DDF8		
+D2Client.dll	IsNewStatsButtonPressed	Offset	0x13DDF4		
 D2Client.dll	ScreenXShift	Ordinal	0x1348AC		
 D2GFX.dll	ResolutionMode	Offset	0x2A950	"0 = 640x480, 1 = Main Menu 800x600"	
 D2Lang.dll	GetLocaleText	Ordinal	10004		

--- a/1.03.txt
+++ b/1.03.txt
@@ -6,6 +6,7 @@ D2Client.dll	IsAutomapOpen	Offset	0x143534
 D2Client.dll	IsGameMenuOpen	Offset	0x143530	
 D2Client.dll	IsHelpScreenOpen	Offset	0x143590	
 D2Client.dll	IsNewSkillButtonPressed	Offset	0x13DB30	
+D2Client.dll	IsNewStatsButtonPressed	Offset	0x13DB2C	
 D2GFX.dll	ResolutionMode	Offset	0x2A990	"0 = 640x480, 1 = Main Menu 800x600"
 D2Win.dll	MainMenuMousePositionX	Offset	0x72A98	
 D2Win.dll	MainMenuMousePositionY	Offset	0x72A9C	

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -6,6 +6,7 @@ D2Client.dll	IsAutomapOpen	Offset	0xF4D9C
 D2Client.dll	IsGameMenuOpen	Offset	0xF4D98	
 D2Client.dll	IsHelpScreenOpen	Offset	0xF4DF8	
 D2Client.dll	IsNewSkillButtonPressed	Offset	0xF01F8	
+D2Client.dll	IsNewStatsButtonPressed	Offset	0xF01F4	
 D2GFX.dll	ResolutionMode	Offset	0x1D060	"0 = 640x480, 1 = Main Menu 800x600"
 D2Win.dll	MainMenuMousePositionX	Offset	0x5BCB8	
 D2Win.dll	MainMenuMousePositionY	Offset	0x5BCBC	

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -6,6 +6,7 @@ D2Client.dll	IsAutomapOpen	Offset	0x1248DC
 D2Client.dll	IsGameMenuOpen	Offset	0x1248D8	
 D2Client.dll	IsHelpScreenOpen	Offset	0x124938	
 D2Client.dll	IsNewSkillButtonPressed	Offset	0x11FE88	
+D2Client.dll	IsNewStatsButtonPressed	Offset	0x11FE84	
 D2GFX.dll	ResolutionMode	Offset	0x1D210	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"
 D2Win.dll	MainMenuMousePositionX	Offset	0x618A0	
 D2Win.dll	MainMenuMousePositionY	Offset	0x618A4	

--- a/1.10.txt
+++ b/1.10.txt
@@ -6,6 +6,7 @@ D2Client.dll	IsAutomapOpen	Offset	0x11A6D0
 D2Client.dll	IsGameMenuOpen	Offset	0x11A6CC	
 D2Client.dll	IsHelpScreenOpen	Offset	0x11A72C	
 D2Client.dll	IsNewSkillButtonPressed	Offset	0x115BC0	
+D2Client.dll	IsNewStatsButtonPressed	Offset	0x115BBC	
 D2GFX.dll	ResolutionMode	Offset	0x1D26C	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"
 D2Win.dll	MainMenuMousePositionX	Offset	0x5E234	
 D2Win.dll	MainMenuMousePositionY	Offset	0x5E238	

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -6,6 +6,7 @@ D2Client.dll	IsAutomapOpen	Offset	0x102B80
 D2Client.dll	IsGameMenuOpen	Offset	0x102B7C	
 D2Client.dll	IsHelpScreenOpen	Offset	0x102BDC	
 D2Client.dll	IsNewSkillButtonPressed	Offset	0x11C348	
+D2Client.dll	IsNewStatsButtonPressed	Offset	0x11C344	
 D2GFX.dll	ResolutionMode	Offset	0x1D454	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"
 D2Win.dll	MainMenuMousePositionX	Offset	0x5C700	
 D2Win.dll	MainMenuMousePositionY	Offset	0x5C704	

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -7,6 +7,7 @@ D2Client.dll	IsGameMenuOpen	Offset	0xFADA4
 D2Client.dll	IsHelpScreenOpen	Offset	0xFAE04	
 D2Client.dll	ScreenXShift	Offset	0x11C418	
 D2Client.dll	IsNewSkillButtonPressed	Offset	0x11C30C	
+D2Client.dll	IsNewStatsButtonPressed	Offset	0x11C308	
 D2GFX.dll	ResolutionMode	Offset	0x11260	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"
 D2Lang.dll	CreateD2UnicodeChar	Ordinal	10000	
 D2Lang.dll	CreateD2UnicodeCharWithValue	Ordinal		

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -6,6 +6,7 @@ D2Client.dll	IsAutomapOpen	Offset	0x11C8B8
 D2Client.dll	IsGameMenuOpen	Offset	0x11C8B4	
 D2Client.dll	IsHelpScreenOpen	Offset	0x11C914	
 D2Client.dll	IsNewSkillButtonPressed	Offset	0x11D31C	
+D2Client.dll	IsNewStatsButtonPressed	Offset	0x11D318	
 D2GFX.dll	ResolutionMode	Offset	0x14A40	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"
 D2Win.dll	MainMenuMousePositionX	Offset	0x8DB1C	
 D2Win.dll	MainMenuMousePositionY	Offset	0x8DB20	

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -6,6 +6,7 @@ D2Client.dll	IsAutomapOpen	Offset	0x399870
 D2Client.dll	IsGameMenuOpen	Offset	0x39986C	
 D2Client.dll	IsHelpScreenOpen	Offset	0x3998CC	
 D2Client.dll	IsNewSkillButtonPressed	Offset	0x3B7370	
+D2Client.dll	IsNewStatsButtonPressed	Offset	0x3B736C	
 D2GFX.dll	ResolutionMode	Offset	0x3BFD40	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"
 D2Win.dll	MainMenuMousePositionX	Offset	0x3CC62C	
 D2Win.dll	MainMenuMousePositionY	Offset	0x3CC630	

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -6,6 +6,7 @@ D2Client.dll	IsAutomapOpen	Offset	0x3A27E8
 D2Client.dll	IsGameMenuOpen	Offset	0x3A27E4	
 D2Client.dll	IsHelpScreenOpen	Offset	0x3A2844	
 D2Client.dll	IsNewSkillButtonPressed	Offset	0x3C02E8	
+D2Client.dll	IsNewStatsButtonPressed	Offset	0x3C02E4	
 D2GFX.dll	ResolutionMode	Offset	0x3C8CB8	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"
 D2Win.dll	MainMenuMousePositionX	Offset	0x3D55A4	
 D2Win.dll	MainMenuMousePositionY	Offset	0x3D55A8	


### PR DESCRIPTION
The address points to an int32_t, but is treated like a bool. The data value is set to 0 if the New Stats button is not pressed, and 1 if the New Stats button is pressed.

The address can be located using a character with at least one stat point available to spend. Using this character, press and hold the New Stats button while pressing ALT-TAB to freeze the state of the button into its pressed state. To release the button from pressed state, click anywhere else. Scan for the values corresponding to the state of the New Stats button. The address's type is confirmed by the following 1.00 screenshot.

![D2Client_IsNewStatsButtonPressed](https://user-images.githubusercontent.com/26683324/56252556-321d6600-606d-11e9-86d9-ed6ccc75bdd1.PNG)

640x480, Not Pressed:
![D2Client_IsNewStatsButtonPressed3](https://user-images.githubusercontent.com/26683324/56252572-406b8200-606d-11e9-9394-9873a806af44.jpg)

640x480, Pressed:
![D2Client_IsNewStatsButtonPressed2](https://user-images.githubusercontent.com/26683324/56252581-495c5380-606d-11e9-96a3-bb15ce387354.jpg)

800x600, Pressed:
![D2Client_IsNewStatsButtonPressed4](https://user-images.githubusercontent.com/26683324/56252593-524d2500-606d-11e9-9333-b779d955d918.jpg)