### PR TITLE
Add D2Lang Unicode strlen

### DIFF
--- a/1.00.txt
+++ b/1.00.txt
@@ -25,7 +25,7 @@ D2Lang.dll	UnicodeString_Compare	Offset	0x1050	?strcmp@Unicode@@SIHPBU1@0@Z	Unic
 D2Lang.dll	UnicodeString_CompareIgnoreCase	Offset	0x100A	?stricmp@Unicode@@SIHPBU1@0@Z	Unicode::stricmp
 D2Lang.dll	UnicodeString_FindChar	Offset	0x101E	?strchr@Unicode@@SIPAU1@PBU1@U1@@Z	Unicode::strchr
 D2Lang.dll	UnicodeString_Format	Offset	0x1046	?sprintf@Unicode@@SAXHPAU1@PBU1@ZZ	Unicode::sprintf
-D2Lang.dll	UnicodeString_GetLength	Offset	0x1055	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
+D2Lang.dll	Unicode_strlen	Offset	0x1055	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	UnicodeString_NCompareIgnoreCase	Offset	0x1091	?strnicmp@Unicode@@SIHPBU1@0I@Z	Unicode::strnicmp
 D2Lang.dll	UnloadSysMap	Offset	0x104B	?unloadSysMap@Unicode@@SIXXZ	Unicode::unloadSysMap
 D2Win.dll	MainMenuMousePositionX	Offset	0x72A90		

--- a/1.03.txt
+++ b/1.03.txt
@@ -1,12 +1,13 @@
-Library	Name	Locator Type	Locator Value	Comments
-D2Client.dll	DifficultyLevel	Offset	0x12EAC4	nDifficultyLevel
-D2Client.dll	IngameMousePositionX	Offset	0x11ACA0	
-D2Client.dll	IngameMousePositionY	Offset	0x11ACA4	
-D2Client.dll	IsAutomapOpen	Offset	0x143534	
-D2Client.dll	IsGameMenuOpen	Offset	0x143530	
-D2Client.dll	IsHelpScreenOpen	Offset	0x143590	
-D2Client.dll	IsNewSkillButtonPressed	Offset	0x13DB30	
-D2Client.dll	IsNewStatsButtonPressed	Offset	0x13DB2C	
-D2GFX.dll	ResolutionMode	Offset	0x2A990	"0 = 640x480, 1 = Main Menu 800x600"
-D2Win.dll	MainMenuMousePositionX	Offset	0x72A98	
-D2Win.dll	MainMenuMousePositionY	Offset	0x72A9C	
+Library	Name	Locator Type	Locator Value	Comments	
+D2Client.dll	DifficultyLevel	Offset	0x12EAC4	nDifficultyLevel	
+D2Client.dll	IngameMousePositionX	Offset	0x11ACA0		
+D2Client.dll	IngameMousePositionY	Offset	0x11ACA4		
+D2Client.dll	IsAutomapOpen	Offset	0x143534		
+D2Client.dll	IsGameMenuOpen	Offset	0x143530		
+D2Client.dll	IsHelpScreenOpen	Offset	0x143590		
+D2Client.dll	IsNewSkillButtonPressed	Offset	0x13DB30		
+D2Client.dll	IsNewStatsButtonPressed	Offset	0x13DB2C		
+D2GFX.dll	ResolutionMode	Offset	0x2A990	"0 = 640x480, 1 = Main Menu 800x600"	
+D2Lang.dll	Unicode_strlen	Offset	0x1055	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
+D2Win.dll	MainMenuMousePositionX	Offset	0x72A98		
+D2Win.dll	MainMenuMousePositionY	Offset	0x72A9C		

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -1,12 +1,13 @@
-Library	Name	Locator Type	Locator Value	Comments
-D2Client.dll	DifficultyLevel	Offset	0xE3024	nDifficultyLevel
-D2Client.dll	IngameMousePositionX	Offset	0xD19A8	
-D2Client.dll	IngameMousePositionY	Offset	0xD19AC	
-D2Client.dll	IsAutomapOpen	Offset	0xF4D9C	
-D2Client.dll	IsGameMenuOpen	Offset	0xF4D98	
-D2Client.dll	IsHelpScreenOpen	Offset	0xF4DF8	
-D2Client.dll	IsNewSkillButtonPressed	Offset	0xF01F8	
-D2Client.dll	IsNewStatsButtonPressed	Offset	0xF01F4	
-D2GFX.dll	ResolutionMode	Offset	0x1D060	"0 = 640x480, 1 = Main Menu 800x600"
-D2Win.dll	MainMenuMousePositionX	Offset	0x5BCB8	
-D2Win.dll	MainMenuMousePositionY	Offset	0x5BCBC	
+Library	Name	Locator Type	Locator Value	Comments	
+D2Client.dll	DifficultyLevel	Offset	0xE3024	nDifficultyLevel	
+D2Client.dll	IngameMousePositionX	Offset	0xD19A8		
+D2Client.dll	IngameMousePositionY	Offset	0xD19AC		
+D2Client.dll	IsAutomapOpen	Offset	0xF4D9C		
+D2Client.dll	IsGameMenuOpen	Offset	0xF4D98		
+D2Client.dll	IsHelpScreenOpen	Offset	0xF4DF8		
+D2Client.dll	IsNewSkillButtonPressed	Offset	0xF01F8		
+D2Client.dll	IsNewStatsButtonPressed	Offset	0xF01F4		
+D2GFX.dll	ResolutionMode	Offset	0x1D060	"0 = 640x480, 1 = Main Menu 800x600"	
+D2Lang.dll	Unicode_strlen	Offset	0x1490	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
+D2Win.dll	MainMenuMousePositionX	Offset	0x5BCB8		
+D2Win.dll	MainMenuMousePositionY	Offset	0x5BCBC		

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -1,12 +1,13 @@
-Library	Name	Locator Type	Locator Value	Comments
-D2Client.dll	DifficultyLevel	Offset	0x110BBC	nDifficultyLevel
-D2Client.dll	IngameMousePositionX	Offset	0x12B168	
-D2Client.dll	IngameMousePositionY	Offset	0x12B16C	
-D2Client.dll	IsAutomapOpen	Offset	0x1248DC	
-D2Client.dll	IsGameMenuOpen	Offset	0x1248D8	
-D2Client.dll	IsHelpScreenOpen	Offset	0x124938	
-D2Client.dll	IsNewSkillButtonPressed	Offset	0x11FE88	
-D2Client.dll	IsNewStatsButtonPressed	Offset	0x11FE84	
-D2GFX.dll	ResolutionMode	Offset	0x1D210	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"
-D2Win.dll	MainMenuMousePositionX	Offset	0x618A0	
-D2Win.dll	MainMenuMousePositionY	Offset	0x618A4	
+Library	Name	Locator Type	Locator Value	Comments	
+D2Client.dll	DifficultyLevel	Offset	0x110BBC	nDifficultyLevel	
+D2Client.dll	IngameMousePositionX	Offset	0x12B168		
+D2Client.dll	IngameMousePositionY	Offset	0x12B16C		
+D2Client.dll	IsAutomapOpen	Offset	0x1248DC		
+D2Client.dll	IsGameMenuOpen	Offset	0x1248D8		
+D2Client.dll	IsHelpScreenOpen	Offset	0x124938		
+D2Client.dll	IsNewSkillButtonPressed	Offset	0x11FE88		
+D2Client.dll	IsNewStatsButtonPressed	Offset	0x11FE84		
+D2GFX.dll	ResolutionMode	Offset	0x1D210	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
+D2Lang.dll	Unicode_strlen	Offset	0x1490	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
+D2Win.dll	MainMenuMousePositionX	Offset	0x618A0		
+D2Win.dll	MainMenuMousePositionY	Offset	0x618A4		

--- a/1.10.txt
+++ b/1.10.txt
@@ -1,12 +1,13 @@
-Library	Name	Locator Type	Locator Value	Comments
-D2Client.dll	DifficultyLevel	Offset	0x10795C	nDifficultyLevel
-D2Client.dll	IngameMousePositionX	Offset	0x121AE4	
-D2Client.dll	IngameMousePositionY	Offset	0x121AE8	
-D2Client.dll	IsAutomapOpen	Offset	0x11A6D0	
-D2Client.dll	IsGameMenuOpen	Offset	0x11A6CC	
-D2Client.dll	IsHelpScreenOpen	Offset	0x11A72C	
-D2Client.dll	IsNewSkillButtonPressed	Offset	0x115BC0	
-D2Client.dll	IsNewStatsButtonPressed	Offset	0x115BBC	
-D2GFX.dll	ResolutionMode	Offset	0x1D26C	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"
-D2Win.dll	MainMenuMousePositionX	Offset	0x5E234	
-D2Win.dll	MainMenuMousePositionY	Offset	0x5E238	
+Library	Name	Locator Type	Locator Value	Comments	
+D2Client.dll	DifficultyLevel	Offset	0x10795C	nDifficultyLevel	
+D2Client.dll	IngameMousePositionX	Offset	0x121AE4		
+D2Client.dll	IngameMousePositionY	Offset	0x121AE8		
+D2Client.dll	IsAutomapOpen	Offset	0x11A6D0		
+D2Client.dll	IsGameMenuOpen	Offset	0x11A6CC		
+D2Client.dll	IsHelpScreenOpen	Offset	0x11A72C		
+D2Client.dll	IsNewSkillButtonPressed	Offset	0x115BC0		
+D2Client.dll	IsNewStatsButtonPressed	Offset	0x115BBC		
+D2GFX.dll	ResolutionMode	Offset	0x1D26C	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
+D2Lang.dll	Unicode_strlen	Offset	0x14C0	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
+D2Win.dll	MainMenuMousePositionX	Offset	0x5E234		
+D2Win.dll	MainMenuMousePositionY	Offset	0x5E238		

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -1,12 +1,13 @@
-Library	Name	Locator Type	Locator Value	Comments
-D2Client.dll	DifficultyLevel	Offset	0x11BFF4	nDifficultyLevel
-D2Client.dll	IngameMousePositionX	Offset	0x101638	
-D2Client.dll	IngameMousePositionY	Offset	0x101634	
-D2Client.dll	IsAutomapOpen	Offset	0x102B80	
-D2Client.dll	IsGameMenuOpen	Offset	0x102B7C	
-D2Client.dll	IsHelpScreenOpen	Offset	0x102BDC	
-D2Client.dll	IsNewSkillButtonPressed	Offset	0x11C348	
-D2Client.dll	IsNewStatsButtonPressed	Offset	0x11C344	
-D2GFX.dll	ResolutionMode	Offset	0x1D454	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"
-D2Win.dll	MainMenuMousePositionX	Offset	0x5C700	
-D2Win.dll	MainMenuMousePositionY	Offset	0x5C704	
+Library	Name	Locator Type	Locator Value	Comments	
+D2Client.dll	DifficultyLevel	Offset	0x11BFF4	nDifficultyLevel	
+D2Client.dll	IngameMousePositionX	Offset	0x101638		
+D2Client.dll	IngameMousePositionY	Offset	0x101634		
+D2Client.dll	IsAutomapOpen	Offset	0x102B80		
+D2Client.dll	IsGameMenuOpen	Offset	0x102B7C		
+D2Client.dll	IsHelpScreenOpen	Offset	0x102BDC		
+D2Client.dll	IsNewSkillButtonPressed	Offset	0x11C348		
+D2Client.dll	IsNewStatsButtonPressed	Offset	0x11C344		
+D2GFX.dll	ResolutionMode	Offset	0x1D454	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
+D2Lang.dll	Unicode_strlen	Offset	0xA6E0	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
+D2Win.dll	MainMenuMousePositionX	Offset	0x5C700		
+D2Win.dll	MainMenuMousePositionY	Offset	0x5C704		

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -1,15 +1,16 @@
-Library	Name	Locator Type	Locator Value	Comments
-D2Client.dll	DifficultyLevel	Offset	0x11C390	nDifficultyLevel
-D2Client.dll	IngameMousePositionX	Offset	0x11B828	
-D2Client.dll	IngameMousePositionY	Offset	0x11B824	
-D2Client.dll	IsAutomapOpen	Offset	0xFADA8	
-D2Client.dll	IsGameMenuOpen	Offset	0xFADA4	
-D2Client.dll	IsHelpScreenOpen	Offset	0xFAE04	
-D2Client.dll	ScreenXShift	Offset	0x11C418	
-D2Client.dll	IsNewSkillButtonPressed	Offset	0x11C30C	
-D2Client.dll	IsNewStatsButtonPressed	Offset	0x11C308	
-D2GFX.dll	ResolutionMode	Offset	0x11260	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"
-D2Lang.dll	CreateD2UnicodeChar	Ordinal	10000	
-D2Lang.dll	CreateD2UnicodeCharWithValue	Ordinal		
-D2Win.dll	MainMenuMousePositionX	Offset	0x21488	
-D2Win.dll	MainMenuMousePositionY	Offset	0x2148C	
+Library	Name	Locator Type	Locator Value	Comments	
+D2Client.dll	DifficultyLevel	Offset	0x11C390	nDifficultyLevel	
+D2Client.dll	IngameMousePositionX	Offset	0x11B828		
+D2Client.dll	IngameMousePositionY	Offset	0x11B824		
+D2Client.dll	IsAutomapOpen	Offset	0xFADA8		
+D2Client.dll	IsGameMenuOpen	Offset	0xFADA4		
+D2Client.dll	IsHelpScreenOpen	Offset	0xFAE04		
+D2Client.dll	ScreenXShift	Offset	0x11C418		
+D2Client.dll	IsNewSkillButtonPressed	Offset	0x11C30C		
+D2Client.dll	IsNewStatsButtonPressed	Offset	0x11C308		
+D2GFX.dll	ResolutionMode	Offset	0x11260	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
+D2Lang.dll	CreateD2UnicodeChar	Ordinal	10000		
+D2Lang.dll	CreateD2UnicodeCharWithValue	Ordinal			
+D2Lang.dll	Unicode_strlen	Offset	0xB0B0	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
+D2Win.dll	MainMenuMousePositionX	Offset	0x21488		
+D2Win.dll	MainMenuMousePositionY	Offset	0x2148C		

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -1,12 +1,13 @@
-Library	Name	Locator Type	Locator Value	Comments
-D2Client.dll	DifficultyLevel	Offset	0x11D1D8	nDifficultyLevel
-D2Client.dll	IngameMousePositionX	Offset	0x11C950	
-D2Client.dll	IngameMousePositionY	Offset	0x11C94C	
-D2Client.dll	IsAutomapOpen	Offset	0x11C8B8	
-D2Client.dll	IsGameMenuOpen	Offset	0x11C8B4	
-D2Client.dll	IsHelpScreenOpen	Offset	0x11C914	
-D2Client.dll	IsNewSkillButtonPressed	Offset	0x11D31C	
-D2Client.dll	IsNewStatsButtonPressed	Offset	0x11D318	
-D2GFX.dll	ResolutionMode	Offset	0x14A40	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"
-D2Win.dll	MainMenuMousePositionX	Offset	0x8DB1C	
-D2Win.dll	MainMenuMousePositionY	Offset	0x8DB20	
+Library	Name	Locator Type	Locator Value	Comments	
+D2Client.dll	DifficultyLevel	Offset	0x11D1D8	nDifficultyLevel	
+D2Client.dll	IngameMousePositionX	Offset	0x11C950		
+D2Client.dll	IngameMousePositionY	Offset	0x11C94C		
+D2Client.dll	IsAutomapOpen	Offset	0x11C8B8		
+D2Client.dll	IsGameMenuOpen	Offset	0x11C8B4		
+D2Client.dll	IsHelpScreenOpen	Offset	0x11C914		
+D2Client.dll	IsNewSkillButtonPressed	Offset	0x11D31C		
+D2Client.dll	IsNewStatsButtonPressed	Offset	0x11D318		
+D2GFX.dll	ResolutionMode	Offset	0x14A40	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
+D2Lang.dll	Unicode_strlen	Offset	0x8C60	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
+D2Win.dll	MainMenuMousePositionX	Offset	0x8DB1C		
+D2Win.dll	MainMenuMousePositionY	Offset	0x8DB20		

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -1,12 +1,13 @@
-Library	Name	Locator Type	Locator Value	Comments
-D2Client.dll	DifficultyLevel	Offset	0x397694	nDifficultyLevel
-D2Client.dll	IngameMousePositionX	Offset	0x39DB38	
-D2Client.dll	IngameMousePositionY	Offset	0x39DB34	
-D2Client.dll	IsAutomapOpen	Offset	0x399870	
-D2Client.dll	IsGameMenuOpen	Offset	0x39986C	
-D2Client.dll	IsHelpScreenOpen	Offset	0x3998CC	
-D2Client.dll	IsNewSkillButtonPressed	Offset	0x3B7370	
-D2Client.dll	IsNewStatsButtonPressed	Offset	0x3B736C	
-D2GFX.dll	ResolutionMode	Offset	0x3BFD40	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"
-D2Win.dll	MainMenuMousePositionX	Offset	0x3CC62C	
-D2Win.dll	MainMenuMousePositionY	Offset	0x3CC630	
+Library	Name	Locator Type	Locator Value	Comments	
+D2Client.dll	DifficultyLevel	Offset	0x397694	nDifficultyLevel	
+D2Client.dll	IngameMousePositionX	Offset	0x39DB38		
+D2Client.dll	IngameMousePositionY	Offset	0x39DB34		
+D2Client.dll	IsAutomapOpen	Offset	0x399870		
+D2Client.dll	IsGameMenuOpen	Offset	0x39986C		
+D2Client.dll	IsHelpScreenOpen	Offset	0x3998CC		
+D2Client.dll	IsNewSkillButtonPressed	Offset	0x3B7370		
+D2Client.dll	IsNewStatsButtonPressed	Offset	0x3B736C		
+D2GFX.dll	ResolutionMode	Offset	0x3BFD40	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
+D2Lang.dll	Unicode_strlen	Offset	0x123D50	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
+D2Win.dll	MainMenuMousePositionX	Offset	0x3CC62C		
+D2Win.dll	MainMenuMousePositionY	Offset	0x3CC630		

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -1,12 +1,13 @@
-Library	Name	Locator Type	Locator Value	Comments
-D2Client.dll	DifficultyLevel	Offset	0x3A060C	nDifficultyLevel
-D2Client.dll	IngameMousePositionX	Offset	0x3A6AB0	
-D2Client.dll	IngameMousePositionY	Offset	0x3A6AAC	
-D2Client.dll	IsAutomapOpen	Offset	0x3A27E8	
-D2Client.dll	IsGameMenuOpen	Offset	0x3A27E4	
-D2Client.dll	IsHelpScreenOpen	Offset	0x3A2844	
-D2Client.dll	IsNewSkillButtonPressed	Offset	0x3C02E8	
-D2Client.dll	IsNewStatsButtonPressed	Offset	0x3C02E4	
-D2GFX.dll	ResolutionMode	Offset	0x3C8CB8	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"
-D2Win.dll	MainMenuMousePositionX	Offset	0x3D55A4	
-D2Win.dll	MainMenuMousePositionY	Offset	0x3D55A8	
+Library	Name	Locator Type	Locator Value	Comments	
+D2Client.dll	DifficultyLevel	Offset	0x3A060C	nDifficultyLevel	
+D2Client.dll	IngameMousePositionX	Offset	0x3A6AB0		
+D2Client.dll	IngameMousePositionY	Offset	0x3A6AAC		
+D2Client.dll	IsAutomapOpen	Offset	0x3A27E8		
+D2Client.dll	IsGameMenuOpen	Offset	0x3A27E4		
+D2Client.dll	IsHelpScreenOpen	Offset	0x3A2844		
+D2Client.dll	IsNewSkillButtonPressed	Offset	0x3C02E8		
+D2Client.dll	IsNewStatsButtonPressed	Offset	0x3C02E4		
+D2GFX.dll	ResolutionMode	Offset	0x3C8CB8	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
+D2Lang.dll	Unicode_strlen	Offset	0x126800	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
+D2Win.dll	MainMenuMousePositionX	Offset	0x3D55A4		
+D2Win.dll	MainMenuMousePositionY	Offset	0x3D55A8		


### PR DESCRIPTION
The function returns the number of `UnicodeChar` in the specified `UnicodeChar` string.

The function can be located by scanning fo the bytes `B9 01 0D 00 00`, which is the x86 instruction `mov ecx, 3329`.

## Function Definitions
### All Versions
```C
int32_t Unicode_strlen(const UnicodeChar* str);
```
- `str` in ecx

In versions prior to 1.14A, its name is `Unicode::strlen`. The function reads an array of `UnicodeChar` to determine the number of characters in the null-terminated array.

## Screenshots
The following 1.14C screenshot shows that the function's 1st parameter is of type `UnicodeChar*`, stored in `ecx`. Note that the 1st parameter is never modified, making it eligible for the `const` modifier.
![D2Lang_Unicode_strlen2](https://user-images.githubusercontent.com/26683324/56466887-a7ba6680-63cc-11e9-9b22-9027c4115329.PNG)

The following 1.14C screenshot shows that its return type is an `int32_t`.
![D2Lang_Unicode_strlen](https://user-images.githubusercontent.com/26683324/56466758-ad16b180-63ca-11e9-96cf-efe798095af4.PNG)

The following 1.00 screenshot shows how to locate the function.
![D2Lang_Unicode_strlen_04_(1 00)](https://user-images.githubusercontent.com/26683324/67166648-21b0b580-f346-11e9-800a-1eba6d0079f8.PNG)
