### PR TITLE
Add D2Lang Unicode strcat

### DIFF
--- a/1.00.txt
+++ b/1.00.txt
@@ -25,6 +25,7 @@ D2Lang.dll	UnicodeString_Compare	Offset	0x1050	?strcmp@Unicode@@SIHPBU1@0@Z	Unic
 D2Lang.dll	UnicodeString_CompareIgnoreCase	Offset	0x100A	?stricmp@Unicode@@SIHPBU1@0@Z	Unicode::stricmp
 D2Lang.dll	UnicodeString_FindChar	Offset	0x101E	?strchr@Unicode@@SIPAU1@PBU1@U1@@Z	Unicode::strchr
 D2Lang.dll	UnicodeString_Format	Offset	0x1046	?sprintf@Unicode@@SAXHPAU1@PBU1@ZZ	Unicode::sprintf
+D2Lang.dll	Unicode_strcat	Offset	0x10B4		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x1055	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	UnicodeString_NCompareIgnoreCase	Offset	0x1091	?strnicmp@Unicode@@SIHPBU1@0I@Z	Unicode::strnicmp
 D2Lang.dll	UnloadSysMap	Offset	0x104B	?unloadSysMap@Unicode@@SIXXZ	Unicode::unloadSysMap

--- a/1.03.txt
+++ b/1.03.txt
@@ -8,6 +8,7 @@ D2Client.dll	IsHelpScreenOpen	Offset	0x143590
 D2Client.dll	IsNewSkillButtonPressed	Offset	0x13DB30		
 D2Client.dll	IsNewStatsButtonPressed	Offset	0x13DB2C		
 D2GFX.dll	ResolutionMode	Offset	0x2A990	"0 = 640x480, 1 = Main Menu 800x600"	
+D2Lang.dll	Unicode_strcat	Offset	0x10B4		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x1055	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Win.dll	MainMenuMousePositionX	Offset	0x72A98		
 D2Win.dll	MainMenuMousePositionY	Offset	0x72A9C		

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -8,6 +8,7 @@ D2Client.dll	IsHelpScreenOpen	Offset	0xF4DF8
 D2Client.dll	IsNewSkillButtonPressed	Offset	0xF01F8		
 D2Client.dll	IsNewStatsButtonPressed	Offset	0xF01F4		
 D2GFX.dll	ResolutionMode	Offset	0x1D060	"0 = 640x480, 1 = Main Menu 800x600"	
+D2Lang.dll	Unicode_strcat	Offset	0x13A0		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x1490	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Win.dll	MainMenuMousePositionX	Offset	0x5BCB8		
 D2Win.dll	MainMenuMousePositionY	Offset	0x5BCBC		

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -8,6 +8,7 @@ D2Client.dll	IsHelpScreenOpen	Offset	0x124938
 D2Client.dll	IsNewSkillButtonPressed	Offset	0x11FE88		
 D2Client.dll	IsNewStatsButtonPressed	Offset	0x11FE84		
 D2GFX.dll	ResolutionMode	Offset	0x1D210	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
+D2Lang.dll	Unicode_strcat	Offset	0x13A0		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x1490	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Win.dll	MainMenuMousePositionX	Offset	0x618A0		
 D2Win.dll	MainMenuMousePositionY	Offset	0x618A4		

--- a/1.10.txt
+++ b/1.10.txt
@@ -8,6 +8,7 @@ D2Client.dll	IsHelpScreenOpen	Offset	0x11A72C
 D2Client.dll	IsNewSkillButtonPressed	Offset	0x115BC0		
 D2Client.dll	IsNewStatsButtonPressed	Offset	0x115BBC		
 D2GFX.dll	ResolutionMode	Offset	0x1D26C	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
+D2Lang.dll	Unicode_strcat	Offset	0x13F0		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x14C0	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Win.dll	MainMenuMousePositionX	Offset	0x5E234		
 D2Win.dll	MainMenuMousePositionY	Offset	0x5E238		

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -8,6 +8,7 @@ D2Client.dll	IsHelpScreenOpen	Offset	0x102BDC
 D2Client.dll	IsNewSkillButtonPressed	Offset	0x11C348		
 D2Client.dll	IsNewStatsButtonPressed	Offset	0x11C344		
 D2GFX.dll	ResolutionMode	Offset	0x1D454	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
+D2Lang.dll	Unicode_strcat	Offset	0xA610		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0xA6E0	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Win.dll	MainMenuMousePositionX	Offset	0x5C700		
 D2Win.dll	MainMenuMousePositionY	Offset	0x5C704		

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -11,6 +11,7 @@ D2Client.dll	IsNewStatsButtonPressed	Offset	0x11C308
 D2GFX.dll	ResolutionMode	Offset	0x11260	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
 D2Lang.dll	CreateD2UnicodeChar	Ordinal	10000		
 D2Lang.dll	CreateD2UnicodeCharWithValue	Ordinal			
+D2Lang.dll	Unicode_strcat	Offset	0xAFE0		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0xB0B0	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Win.dll	MainMenuMousePositionX	Offset	0x21488		
 D2Win.dll	MainMenuMousePositionY	Offset	0x2148C		

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -8,6 +8,7 @@ D2Client.dll	IsHelpScreenOpen	Offset	0x11C914
 D2Client.dll	IsNewSkillButtonPressed	Offset	0x11D31C		
 D2Client.dll	IsNewStatsButtonPressed	Offset	0x11D318		
 D2GFX.dll	ResolutionMode	Offset	0x14A40	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
+D2Lang.dll	Unicode_strcat	Offset	0x8B90		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x8C60	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Win.dll	MainMenuMousePositionX	Offset	0x8DB1C		
 D2Win.dll	MainMenuMousePositionY	Offset	0x8DB20		

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -8,6 +8,7 @@ D2Client.dll	IsHelpScreenOpen	Offset	0x3998CC
 D2Client.dll	IsNewSkillButtonPressed	Offset	0x3B7370		
 D2Client.dll	IsNewStatsButtonPressed	Offset	0x3B736C		
 D2GFX.dll	ResolutionMode	Offset	0x3BFD40	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
+D2Lang.dll	Unicode_strcat	Offset	0x123C50		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x123D50	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Win.dll	MainMenuMousePositionX	Offset	0x3CC62C		
 D2Win.dll	MainMenuMousePositionY	Offset	0x3CC630		

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -8,6 +8,7 @@ D2Client.dll	IsHelpScreenOpen	Offset	0x3A2844
 D2Client.dll	IsNewSkillButtonPressed	Offset	0x3C02E8		
 D2Client.dll	IsNewStatsButtonPressed	Offset	0x3C02E4		
 D2GFX.dll	ResolutionMode	Offset	0x3C8CB8	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
+D2Lang.dll	Unicode_strcat	Offset	0x126700		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x126800	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Win.dll	MainMenuMousePositionX	Offset	0x3D55A4		
 D2Win.dll	MainMenuMousePositionY	Offset	0x3D55A8		


### PR DESCRIPTION
The function appends a source `Unicode` string to the end of a destination `Unicode` string.

The function can be located by searching for the bytecode `B9 9D 0F 00 00`, which represents the x86 instruction `mov ecx, 4363`.  One of the instructions will have a call to the target function.

## Function Definitions
### All Versions
```C
UnicodeChar* Unicode_strcat(
    UnicodeChar* dest,
    const UnicodeChar* src
);
```
  - `dest` in ecx
  - `src` in edx

In versions prior to 1.14A, its name was `Unicode::strcat`. The function concatenates `src` to the end of `dest`.

## Screenshots
The following 1.00 screenshot shows that the function's 1st parameter is of type `UnicodeChar*`, stored in ecx. The screenshot also shows that the return type is `UnicodeChar*`, and this comes from `dest`.
![D2Lang_Unicode_strcat_01](https://user-images.githubusercontent.com/26683324/56721518-e8322100-66f9-11e9-888b-fd4d4208d45e.PNG)

The following 1.00 screenshot shows that the function's 2nd parameter is of type `UnicodeChar*`, stored in edx. Note that the 2nd parameter is never modified, making it eligible for the `const` modifier.
![D2Lang_Unicode_strcat_02](https://user-images.githubusercontent.com/26683324/56721521-eb2d1180-66f9-11e9-82d9-331c7aac8ece.PNG)

The following 1.00 screenshot shows how to locate the function.
![D2Lang_Unicode_strcat_02_(1 00)](https://user-images.githubusercontent.com/26683324/67166659-3e4ced80-f346-11e9-9aed-3fa6a354d951.PNG)
