### PR TITLE
Add D2Lang Unicode tolower

### DIFF
--- a/1.00.txt
+++ b/1.00.txt
@@ -20,13 +20,13 @@ D2Lang.dll	UnicodeChar_IsAlpha	Offset	0x103C	?isAlpha@Unicode@@QBEHXZ	Unicode::i
 D2Lang.dll	UnicodeChar_IsNewLine	Offset	0x1073	?isNewline@Unicode@@QBEHXZ	Unicode::isNewline
 D2Lang.dll	UnicodeChar_IsPipe	Offset	0x1087	?isPipe@Unicode@@QBEHXZ	Unicode::isPipe
 D2Lang.dll	UnicodeChar_IsWhitespace	Offset	0x1032	?isWhitespace@Unicode@@QBEHXZ	Unicode::isWhitespace
-D2Lang.dll	UnicodeChar_ToLower	Offset	0x1014	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	UnicodeString_Compare	Offset	0x1050	?strcmp@Unicode@@SIHPBU1@0@Z	Unicode::strcmp
 D2Lang.dll	UnicodeString_CompareIgnoreCase	Offset	0x100A	?stricmp@Unicode@@SIHPBU1@0@Z	Unicode::stricmp
 D2Lang.dll	UnicodeString_FindChar	Offset	0x101E	?strchr@Unicode@@SIPAU1@PBU1@U1@@Z	Unicode::strchr
 D2Lang.dll	UnicodeString_Format	Offset	0x1046	?sprintf@Unicode@@SAXHPAU1@PBU1@ZZ	Unicode::sprintf
 D2Lang.dll	Unicode_strcat	Offset	0x10B4		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x1055	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
+D2Lang.dll	Unicode_tolower	Offset	0x1014	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	UnicodeString_NCompareIgnoreCase	Offset	0x1091	?strnicmp@Unicode@@SIHPBU1@0I@Z	Unicode::strnicmp
 D2Lang.dll	UnloadSysMap	Offset	0x104B	?unloadSysMap@Unicode@@SIXXZ	Unicode::unloadSysMap
 D2Win.dll	MainMenuMousePositionX	Offset	0x72A90		

--- a/1.03.txt
+++ b/1.03.txt
@@ -10,5 +10,6 @@ D2Client.dll	IsNewStatsButtonPressed	Offset	0x13DB2C
 D2GFX.dll	ResolutionMode	Offset	0x2A990	"0 = 640x480, 1 = Main Menu 800x600"	
 D2Lang.dll	Unicode_strcat	Offset	0x10B4		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x1055	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
+D2Lang.dll	Unicode_tolower	Offset	0x1014	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Win.dll	MainMenuMousePositionX	Offset	0x72A98		
 D2Win.dll	MainMenuMousePositionY	Offset	0x72A9C		

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -10,5 +10,6 @@ D2Client.dll	IsNewStatsButtonPressed	Offset	0xF01F4
 D2GFX.dll	ResolutionMode	Offset	0x1D060	"0 = 640x480, 1 = Main Menu 800x600"	
 D2Lang.dll	Unicode_strcat	Offset	0x13A0		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x1490	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
+D2Lang.dll	Unicode_tolower	Offset	0x10E0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Win.dll	MainMenuMousePositionX	Offset	0x5BCB8		
 D2Win.dll	MainMenuMousePositionY	Offset	0x5BCBC		

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -10,5 +10,6 @@ D2Client.dll	IsNewStatsButtonPressed	Offset	0x11FE84
 D2GFX.dll	ResolutionMode	Offset	0x1D210	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
 D2Lang.dll	Unicode_strcat	Offset	0x13A0		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x1490	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
+D2Lang.dll	Unicode_tolower	Offset	0x10E0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Win.dll	MainMenuMousePositionX	Offset	0x618A0		
 D2Win.dll	MainMenuMousePositionY	Offset	0x618A4		

--- a/1.10.txt
+++ b/1.10.txt
@@ -10,5 +10,6 @@ D2Client.dll	IsNewStatsButtonPressed	Offset	0x115BBC
 D2GFX.dll	ResolutionMode	Offset	0x1D26C	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
 D2Lang.dll	Unicode_strcat	Offset	0x13F0		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x14C0	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
+D2Lang.dll	Unicode_tolower	Offset	0x10E0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Win.dll	MainMenuMousePositionX	Offset	0x5E234		
 D2Win.dll	MainMenuMousePositionY	Offset	0x5E238		

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -10,5 +10,6 @@ D2Client.dll	IsNewStatsButtonPressed	Offset	0x11C344
 D2GFX.dll	ResolutionMode	Offset	0x1D454	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
 D2Lang.dll	Unicode_strcat	Offset	0xA610		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0xA6E0	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
+D2Lang.dll	Unicode_tolower	Offset	0x10C0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Win.dll	MainMenuMousePositionX	Offset	0x5C700		
 D2Win.dll	MainMenuMousePositionY	Offset	0x5C704		

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -13,5 +13,6 @@ D2Lang.dll	CreateD2UnicodeChar	Ordinal	10000
 D2Lang.dll	CreateD2UnicodeCharWithValue	Ordinal			
 D2Lang.dll	Unicode_strcat	Offset	0xAFE0		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0xB0B0	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
+D2Lang.dll	Unicode_tolower	Offset	0x10C0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Win.dll	MainMenuMousePositionX	Offset	0x21488		
 D2Win.dll	MainMenuMousePositionY	Offset	0x2148C		

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -10,5 +10,6 @@ D2Client.dll	IsNewStatsButtonPressed	Offset	0x11D318
 D2GFX.dll	ResolutionMode	Offset	0x14A40	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
 D2Lang.dll	Unicode_strcat	Offset	0x8B90		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x8C60	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
+D2Lang.dll	Unicode_tolower	Offset	0x10C0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Win.dll	MainMenuMousePositionX	Offset	0x8DB1C		
 D2Win.dll	MainMenuMousePositionY	Offset	0x8DB20		

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -10,5 +10,6 @@ D2Client.dll	IsNewStatsButtonPressed	Offset	0x3B736C
 D2GFX.dll	ResolutionMode	Offset	0x3BFD40	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
 D2Lang.dll	Unicode_strcat	Offset	0x123C50		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x123D50	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
+D2Lang.dll	Unicode_tolower	Offset	0xADD70	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Win.dll	MainMenuMousePositionX	Offset	0x3CC62C		
 D2Win.dll	MainMenuMousePositionY	Offset	0x3CC630		

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -10,5 +10,6 @@ D2Client.dll	IsNewStatsButtonPressed	Offset	0x3C02E4
 D2GFX.dll	ResolutionMode	Offset	0x3C8CB8	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
 D2Lang.dll	Unicode_strcat	Offset	0x126700		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x126800	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
+D2Lang.dll	Unicode_tolower	Offset	0xB15F3	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Win.dll	MainMenuMousePositionX	Offset	0x3D55A4		
 D2Win.dll	MainMenuMousePositionY	Offset	0x3D55A8		


### PR DESCRIPTION
These are the following function definitions:
### All Versions
```C
UnicodeChar* Unicode_tolower(const UnicodeChar* this, UnicodeChar* dest)
```
  - `this` in ecx
  - Remaining parameters on the stack
    - Callee cleans the stack

In versions prior to 1.14A, its name was `Unicode::toLower`. The function converts the character stored in `this` to its lowercase form. The lowercase form character is then stored into the 2nd parameter, which is returned at the end of the function.

The following 1.00 screenshot shows that the function's 1st parameter is of type `UnicodeChar*`, stored in ecx. Since it is not modified, it is eligible for the `const` modifier.
![D2Lang_Unicode_toLower_01](https://user-images.githubusercontent.com/26683324/56773617-cffee800-6773-11e9-9f1e-72ab2139ce1b.PNG)

The following 1.00 screenshot shows that the function's 2nd parameter is of type `UnicodeChar*`, stored on the stack. This screenshot also shows that the return value is the 2nd parameter.
![D2Lang_Unicode_toLower_02](https://user-images.githubusercontent.com/26683324/56773618-cffee800-6773-11e9-8735-db014a1d6274.PNG)

The following 1.14D shows that the function requires manual manipulation of the stack before it can be safely called. Despite this, all other features of the function remain intact.
![D2Lang_Unicode_toLower_03](https://user-images.githubusercontent.com/26683324/56773619-cffee800-6773-11e9-909f-9b60d4c9d589.PNG)
