### PR TITLE
Add D2Lang GetStringByIndex

### DIFF
--- a/1.00.txt
+++ b/1.00.txt
@@ -24,6 +24,7 @@ D2Lang.dll	UnicodeString_Compare	Offset	0x1050	?strcmp@Unicode@@SIHPBU1@0@Z	Unic
 D2Lang.dll	UnicodeString_CompareIgnoreCase	Offset	0x100A	?stricmp@Unicode@@SIHPBU1@0@Z	Unicode::stricmp
 D2Lang.dll	UnicodeString_FindChar	Offset	0x101E	?strchr@Unicode@@SIPAU1@PBU1@U1@@Z	Unicode::strchr
 D2Lang.dll	UnicodeString_Format	Offset	0x1046	?sprintf@Unicode@@SAXHPAU1@PBU1@ZZ	Unicode::sprintf
+D2Lang.dll	GetStringByIndex	Ordinal	10004		
 D2Lang.dll	Unicode_strcat	Offset	0x10B4		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x1055	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x1014	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower

--- a/1.03.txt
+++ b/1.03.txt
@@ -8,6 +8,7 @@ D2Client.dll	IsHelpScreenOpen	Offset	0x143590
 D2Client.dll	IsNewSkillButtonPressed	Offset	0x13DB30		
 D2Client.dll	IsNewStatsButtonPressed	Offset	0x13DB2C		
 D2GFX.dll	ResolutionMode	Offset	0x2A990	"0 = 640x480, 1 = Main Menu 800x600"	
+D2Lang.dll	GetStringByIndex	Ordinal	10004		
 D2Lang.dll	Unicode_strcat	Offset	0x10B4		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x1055	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x1014	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -8,6 +8,7 @@ D2Client.dll	IsHelpScreenOpen	Offset	0xF4DF8
 D2Client.dll	IsNewSkillButtonPressed	Offset	0xF01F8		
 D2Client.dll	IsNewStatsButtonPressed	Offset	0xF01F4		
 D2GFX.dll	ResolutionMode	Offset	0x1D060	"0 = 640x480, 1 = Main Menu 800x600"	
+D2Lang.dll	GetStringByIndex	Ordinal	10004		
 D2Lang.dll	Unicode_strcat	Offset	0x13A0		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x1490	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10E0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -8,6 +8,7 @@ D2Client.dll	IsHelpScreenOpen	Offset	0x124938
 D2Client.dll	IsNewSkillButtonPressed	Offset	0x11FE88		
 D2Client.dll	IsNewStatsButtonPressed	Offset	0x11FE84		
 D2GFX.dll	ResolutionMode	Offset	0x1D210	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
+D2Lang.dll	GetStringByIndex	Ordinal	10004		
 D2Lang.dll	Unicode_strcat	Offset	0x13A0		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x1490	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10E0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower

--- a/1.10.txt
+++ b/1.10.txt
@@ -8,6 +8,7 @@ D2Client.dll	IsHelpScreenOpen	Offset	0x11A72C
 D2Client.dll	IsNewSkillButtonPressed	Offset	0x115BC0		
 D2Client.dll	IsNewStatsButtonPressed	Offset	0x115BBC		
 D2GFX.dll	ResolutionMode	Offset	0x1D26C	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
+D2Lang.dll	GetStringByIndex	Ordinal	10004		
 D2Lang.dll	Unicode_strcat	Offset	0x13F0		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x14C0	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10E0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -8,6 +8,7 @@ D2Client.dll	IsHelpScreenOpen	Offset	0x102BDC
 D2Client.dll	IsNewSkillButtonPressed	Offset	0x11C348		
 D2Client.dll	IsNewStatsButtonPressed	Offset	0x11C344		
 D2GFX.dll	ResolutionMode	Offset	0x1D454	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
+D2Lang.dll	GetStringByIndex	Ordinal	10005		
 D2Lang.dll	Unicode_strcat	Offset	0xA610		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0xA6E0	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10C0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -11,6 +11,7 @@ D2Client.dll	IsNewStatsButtonPressed	Offset	0x11C308
 D2GFX.dll	ResolutionMode	Offset	0x11260	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
 D2Lang.dll	CreateD2UnicodeChar	Ordinal	10000		
 D2Lang.dll	CreateD2UnicodeCharWithValue	Ordinal			
+D2Lang.dll	GetStringByIndex	Ordinal	10003		
 D2Lang.dll	Unicode_strcat	Offset	0xAFE0		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0xB0B0	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10C0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -8,6 +8,7 @@ D2Client.dll	IsHelpScreenOpen	Offset	0x11C914
 D2Client.dll	IsNewSkillButtonPressed	Offset	0x11D31C		
 D2Client.dll	IsNewStatsButtonPressed	Offset	0x11D318		
 D2GFX.dll	ResolutionMode	Offset	0x14A40	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
+D2Lang.dll	GetStringByIndex	Ordinal	10004		
 D2Lang.dll	Unicode_strcat	Offset	0x8B90		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x8C60	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10C0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -8,6 +8,7 @@ D2Client.dll	IsHelpScreenOpen	Offset	0x3998CC
 D2Client.dll	IsNewSkillButtonPressed	Offset	0x3B7370		
 D2Client.dll	IsNewStatsButtonPressed	Offset	0x3B736C		
 D2GFX.dll	ResolutionMode	Offset	0x3BFD40	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
+D2Lang.dll	GetStringByIndex	Offset	0x121EE0		
 D2Lang.dll	Unicode_strcat	Offset	0x123C50		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x123D50	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0xADD70	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -8,6 +8,7 @@ D2Client.dll	IsHelpScreenOpen	Offset	0x3A2844
 D2Client.dll	IsNewSkillButtonPressed	Offset	0x3C02E8		
 D2Client.dll	IsNewStatsButtonPressed	Offset	0x3C02E4		
 D2GFX.dll	ResolutionMode	Offset	0x3C8CB8	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
+D2Lang.dll	GetStringByIndex	Offset	0x124A30		
 D2Lang.dll	Unicode_strcat	Offset	0x126700		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x126800	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0xB15F3	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower


### PR DESCRIPTION
These are the following function definitions:
### All Versions
```C
const UnicodeChar* D2Lang_GetStringByIndex(unsigned int id)
```
- `id` in ecx

The function searches through the Unicode string tables specific to the game's locale using the specified ID and returns a `UnicodeChar*`.

The following 1.00 screenshot shows that the 1st parameter is stored in ecx.
![D2Lang_GetStringByIndex_01](https://user-images.githubusercontent.com/26683324/56845897-e775c800-687c-11e9-8509-4896c9bd7d84.PNG)

And so does the following 1.05B screenshot. The 1.05B screenshot also shows that the 1st parameter is of type `uint32_t`.
![D2Lang_GetStringByIndex_06](https://user-images.githubusercontent.com/26683324/56846134-00cc4380-6880-11e9-9e71-a6bd18a6eb7e.PNG)

The following two 1.00 screenshots show that the return type is `UnicodeChar*`. The return value is loaded, shared, and reused, which necessitates adding the `const` modifier to the return type.
![D2Lang_GetStringByIndex_03](https://user-images.githubusercontent.com/26683324/56845899-eba1e580-687c-11e9-8470-3c257203a5e9.PNG)
![D2Lang_GetStringByIndex_05](https://user-images.githubusercontent.com/26683324/56845965-d9747700-687d-11e9-8f84-914d5b6ec32a.PNG)

The following 1.00 screenshot supports the name chosen for this function.
![D2Lang_GetStringByIndex_07](https://user-images.githubusercontent.com/26683324/57988359-2e9d4600-7a42-11e9-8a94-1205cbe68fdc.PNG)
