### PR TITLE
Add D2DDraw DisplayWidth and DisplayHeight

### DIFF
--- a/1.00.txt
+++ b/1.00.txt
@@ -8,6 +8,8 @@ D2Client.dll	IsHelpScreenOpen	Offset	0x1436C0
 D2Client.dll	IsNewSkillButtonPressed	Offset	0x13DDF8		
 D2Client.dll	IsNewStatsButtonPressed	Offset	0x13DDF4		
 D2Client.dll	ScreenXShift	Ordinal	0x1348AC		
+D2DDraw.dll	DisplayHeight	Offset	0x190D0		
+D2DDraw.dll	DisplayWidth	Offset	0x190D8		
 D2GFX.dll	ResolutionMode	Offset	0x2A950	"0 = 640x480, 1 = Main Menu 800x600"	
 D2Lang.dll	GetLocaleText	Ordinal	10004		
 D2Lang.dll	ToUnicodeString	Offset	0x1118	?toUnicode@Unicode@@SIPAU1@PAU1@PBDH@Z	Unicode::toUnicode

--- a/1.03.txt
+++ b/1.03.txt
@@ -7,6 +7,8 @@ D2Client.dll	IsGameMenuOpen	Offset	0x143530
 D2Client.dll	IsHelpScreenOpen	Offset	0x143590		
 D2Client.dll	IsNewSkillButtonPressed	Offset	0x13DB30		
 D2Client.dll	IsNewStatsButtonPressed	Offset	0x13DB2C		
+D2DDraw.dll	DisplayHeight	Offset	0x190D0		
+D2DDraw.dll	DisplayWidth	Offset	0x190D8		
 D2GFX.dll	ResolutionMode	Offset	0x2A990	"0 = 640x480, 1 = Main Menu 800x600"	
 D2Lang.dll	GetStringByIndex	Ordinal	10004		
 D2Lang.dll	Unicode_strcat	Offset	0x10B4		Unicode::strcat

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -7,6 +7,8 @@ D2Client.dll	IsGameMenuOpen	Offset	0xF4D98
 D2Client.dll	IsHelpScreenOpen	Offset	0xF4DF8		
 D2Client.dll	IsNewSkillButtonPressed	Offset	0xF01F8		
 D2Client.dll	IsNewStatsButtonPressed	Offset	0xF01F4		
+D2DDraw.dll	DisplayHeight	Offset	0x116F8		
+D2DDraw.dll	DisplayWidth	Offset	0x11700		
 D2GFX.dll	ResolutionMode	Offset	0x1D060	"0 = 640x480, 1 = Main Menu 800x600"	
 D2Lang.dll	GetStringByIndex	Ordinal	10004		
 D2Lang.dll	Unicode_strcat	Offset	0x13A0		Unicode::strcat

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -7,6 +7,8 @@ D2Client.dll	IsGameMenuOpen	Offset	0x1248D8
 D2Client.dll	IsHelpScreenOpen	Offset	0x124938		
 D2Client.dll	IsNewSkillButtonPressed	Offset	0x11FE88		
 D2Client.dll	IsNewStatsButtonPressed	Offset	0x11FE84		
+D2DDraw.dll	DisplayHeight	Offset	0x11768		
+D2DDraw.dll	DisplayWidth	Offset	0x11770		
 D2GFX.dll	ResolutionMode	Offset	0x1D210	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
 D2Lang.dll	GetStringByIndex	Ordinal	10004		
 D2Lang.dll	Unicode_strcat	Offset	0x13A0		Unicode::strcat

--- a/1.10.txt
+++ b/1.10.txt
@@ -7,6 +7,8 @@ D2Client.dll	IsGameMenuOpen	Offset	0x11A6CC
 D2Client.dll	IsHelpScreenOpen	Offset	0x11A72C		
 D2Client.dll	IsNewSkillButtonPressed	Offset	0x115BC0		
 D2Client.dll	IsNewStatsButtonPressed	Offset	0x115BBC		
+D2DDraw.dll	DisplayHeight	Offset	0x117A8		
+D2DDraw.dll	DisplayWidth	Offset	0x117B0		
 D2GFX.dll	ResolutionMode	Offset	0x1D26C	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
 D2Lang.dll	GetStringByIndex	Ordinal	10004		
 D2Lang.dll	Unicode_strcat	Offset	0x13F0		Unicode::strcat

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -7,6 +7,8 @@ D2Client.dll	IsGameMenuOpen	Offset	0x102B7C
 D2Client.dll	IsHelpScreenOpen	Offset	0x102BDC		
 D2Client.dll	IsNewSkillButtonPressed	Offset	0x11C348		
 D2Client.dll	IsNewStatsButtonPressed	Offset	0x11C344		
+D2DDraw.dll	DisplayHeight	Offset	0xFDCC		
+D2DDraw.dll	DisplayWidth	Offset	0xFDD4		
 D2GFX.dll	ResolutionMode	Offset	0x1D454	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
 D2Lang.dll	GetStringByIndex	Ordinal	10005		
 D2Lang.dll	Unicode_strcat	Offset	0xA610		Unicode::strcat

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -8,6 +8,8 @@ D2Client.dll	IsHelpScreenOpen	Offset	0xFAE04
 D2Client.dll	ScreenXShift	Offset	0x11C418		
 D2Client.dll	IsNewSkillButtonPressed	Offset	0x11C30C		
 D2Client.dll	IsNewStatsButtonPressed	Offset	0x11C308		
+D2DDraw.dll	DisplayHeight	Offset	0x101CC		
+D2DDraw.dll	DisplayWidth	Offset	0x101D4		
 D2GFX.dll	ResolutionMode	Offset	0x11260	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
 D2Lang.dll	CreateD2UnicodeChar	Ordinal	10000		
 D2Lang.dll	CreateD2UnicodeCharWithValue	Ordinal			

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -7,6 +7,8 @@ D2Client.dll	IsGameMenuOpen	Offset	0x11C8B4
 D2Client.dll	IsHelpScreenOpen	Offset	0x11C914		
 D2Client.dll	IsNewSkillButtonPressed	Offset	0x11D31C		
 D2Client.dll	IsNewStatsButtonPressed	Offset	0x11D318		
+D2DDraw.dll	DisplayHeight	Offset	0x100DC		
+D2DDraw.dll	DisplayWidth	Offset	0x100E4		
 D2GFX.dll	ResolutionMode	Offset	0x14A40	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
 D2Lang.dll	GetStringByIndex	Ordinal	10004		
 D2Lang.dll	Unicode_strcat	Offset	0x8B90		Unicode::strcat

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -7,6 +7,8 @@ D2Client.dll	IsGameMenuOpen	Offset	0x39986C
 D2Client.dll	IsHelpScreenOpen	Offset	0x3998CC		
 D2Client.dll	IsNewSkillButtonPressed	Offset	0x3B7370		
 D2Client.dll	IsNewStatsButtonPressed	Offset	0x3B736C		
+D2DDraw.dll	DisplayHeight	Offset	0x4782DC		
+D2DDraw.dll	DisplayWidth	Offset	0x4782E0		
 D2GFX.dll	ResolutionMode	Offset	0x3BFD40	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
 D2Lang.dll	GetStringByIndex	Offset	0x121EE0		
 D2Lang.dll	Unicode_strcat	Offset	0x123C50		Unicode::strcat

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -7,6 +7,8 @@ D2Client.dll	IsGameMenuOpen	Offset	0x3A27E4
 D2Client.dll	IsHelpScreenOpen	Offset	0x3A2844		
 D2Client.dll	IsNewSkillButtonPressed	Offset	0x3C02E8		
 D2Client.dll	IsNewStatsButtonPressed	Offset	0x3C02E4		
+D2DDraw.dll	DisplayHeight	Offset	0x481254		
+D2DDraw.dll	DisplayWidth	Offset	0x481258		
 D2GFX.dll	ResolutionMode	Offset	0x3C8CB8	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
 D2Lang.dll	GetStringByIndex	Offset	0x124A30		
 D2Lang.dll	Unicode_strcat	Offset	0x126700		Unicode::strcat


### PR DESCRIPTION
The addresses point to two int32_t (possibly). The data values are set to whatever the game display width and height are. Changing these values will cause the game window to adjust its resolution (but not game elements or textures), to the extent permitted by the display mode. These values are only used if the display mode is DirectDraw.

The addresses can be located by scanning for the appropriate width and height values, and repeatedly saving and exiting the game. It is suggested to change the ingame resolution to 640x480 when doing this.

In versions 1.14A and above, DirectDraw is no longer available, making these values unused. However, the game code and variables still remain, so a different method is used to locate these variables. Search for the string `SetDisplayMode failed!` and then locate the code snippit similar to the screenshots below.

The following 1.00 screenshot demonstrates that `D2DDraw_DisplayWidth` is a 4 byte variable and is used in a call to `SetDisplayMode`.
![D2DDraw_DisplayWidthAndHeight_02](https://user-images.githubusercontent.com/26683324/57502885-bc3ea000-72a2-11e9-9c9f-104addcab0a4.png)

The following 1.00 screenshot demonstrates that `D2DDraw_DisplayHeight` is a 4 byte variable and is used in a call to `SetDisplayMode`.
![D2DDraw_DisplayWidthAndHeight_01](https://user-images.githubusercontent.com/26683324/57502829-64a03480-72a2-11e9-94e5-4b01b82abe55.png)

The variables are possibly int32_t, and evidence suggests that this is so, but there isn't definite proof yet. The following 1.00 screenshot shows the very similar variables `D2Direct3D_DisplayWidth` and `D2Direct3D_DisplayHeight` being used as an int32_t.
![D2Direct3D_DisplayWidth_And_Height_01](https://user-images.githubusercontent.com/26683324/57555897-5a297d80-732a-11e9-8520-edc46659cb17.PNG)

The following 1.00 screenshot shows the similarity between the sets of variables.
![D2Direct3D_DisplayWidth_And_Height_02](https://user-images.githubusercontent.com/26683324/57556057-ce642100-732a-11e9-9dfc-eeb2ef568add.PNG)

Finally, the following 1.00 screenshot shows the same variable being logged as an int32_t, using `%d` instead of `%u` for an uint32_t.
![D2DDraw_DisplayWidthAndHeight_03](https://user-images.githubusercontent.com/26683324/57557200-189ad180-732e-11e9-8864-a6e6905b704e.PNG)
