### PR TITLE
Add D2Direct3D DisplayWidth and DisplayHeight

### DIFF
--- a/1.00.txt
+++ b/1.00.txt
@@ -10,6 +10,8 @@ D2Client.dll	IsNewStatsButtonPressed	Offset	0x13DDF4
 D2Client.dll	ScreenXShift	Ordinal	0x1348AC		
 D2DDraw.dll	DisplayHeight	Offset	0x190D0		
 D2DDraw.dll	DisplayWidth	Offset	0x190D8		
+D2Direct3D.dll	DisplayHeight	Offset	0x26930		
+D2Direct3D.dll	DisplayWidth	Offset	0x26674		
 D2GFX.dll	ResolutionMode	Offset	0x2A950	"0 = 640x480, 1 = Main Menu 800x600"	
 D2Lang.dll	GetLocaleText	Ordinal	10004		
 D2Lang.dll	ToUnicodeString	Offset	0x1118	?toUnicode@Unicode@@SIPAU1@PAU1@PBDH@Z	Unicode::toUnicode

--- a/1.03.txt
+++ b/1.03.txt
@@ -9,6 +9,8 @@ D2Client.dll	IsNewSkillButtonPressed	Offset	0x13DB30
 D2Client.dll	IsNewStatsButtonPressed	Offset	0x13DB2C		
 D2DDraw.dll	DisplayHeight	Offset	0x190D0		
 D2DDraw.dll	DisplayWidth	Offset	0x190D8		
+D2Direct3D.dll	DisplayHeight	Offset	0x26930		
+D2Direct3D.dll	DisplayWidth	Offset	0x26674		
 D2GFX.dll	ResolutionMode	Offset	0x2A990	"0 = 640x480, 1 = Main Menu 800x600"	
 D2Lang.dll	GetStringByIndex	Ordinal	10004		
 D2Lang.dll	Unicode_strcat	Offset	0x10B4		Unicode::strcat

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -9,6 +9,8 @@ D2Client.dll	IsNewSkillButtonPressed	Offset	0xF01F8
 D2Client.dll	IsNewStatsButtonPressed	Offset	0xF01F4		
 D2DDraw.dll	DisplayHeight	Offset	0x116F8		
 D2DDraw.dll	DisplayWidth	Offset	0x11700		
+D2Direct3D.dll	DisplayHeight	Offset	0x1A708		
+D2Direct3D.dll	DisplayWidth	Offset	0x1A44C		
 D2GFX.dll	ResolutionMode	Offset	0x1D060	"0 = 640x480, 1 = Main Menu 800x600"	
 D2Lang.dll	GetStringByIndex	Ordinal	10004		
 D2Lang.dll	Unicode_strcat	Offset	0x13A0		Unicode::strcat

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -9,6 +9,8 @@ D2Client.dll	IsNewSkillButtonPressed	Offset	0x11FE88
 D2Client.dll	IsNewStatsButtonPressed	Offset	0x11FE84		
 D2DDraw.dll	DisplayHeight	Offset	0x11768		
 D2DDraw.dll	DisplayWidth	Offset	0x11770		
+D2Direct3D.dll	DisplayHeight	Offset	0x1B708		
+D2Direct3D.dll	DisplayWidth	Offset	0x1B44C		
 D2GFX.dll	ResolutionMode	Offset	0x1D210	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
 D2Lang.dll	GetStringByIndex	Ordinal	10004		
 D2Lang.dll	Unicode_strcat	Offset	0x13A0		Unicode::strcat

--- a/1.10.txt
+++ b/1.10.txt
@@ -9,6 +9,8 @@ D2Client.dll	IsNewSkillButtonPressed	Offset	0x115BC0
 D2Client.dll	IsNewStatsButtonPressed	Offset	0x115BBC		
 D2DDraw.dll	DisplayHeight	Offset	0x117A8		
 D2DDraw.dll	DisplayWidth	Offset	0x117B0		
+D2Direct3D.dll	DisplayHeight	Offset	0x1A7AC		
+D2Direct3D.dll	DisplayWidth	Offset	0x1A4F0		
 D2GFX.dll	ResolutionMode	Offset	0x1D26C	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
 D2Lang.dll	GetStringByIndex	Ordinal	10004		
 D2Lang.dll	Unicode_strcat	Offset	0x13F0		Unicode::strcat

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -9,6 +9,8 @@ D2Client.dll	IsNewSkillButtonPressed	Offset	0x11C348
 D2Client.dll	IsNewStatsButtonPressed	Offset	0x11C344		
 D2DDraw.dll	DisplayHeight	Offset	0xFDCC		
 D2DDraw.dll	DisplayWidth	Offset	0xFDD4		
+D2Direct3D.dll	DisplayHeight	Offset	0x196F4		
+D2Direct3D.dll	DisplayWidth	Offset	0x19264		
 D2GFX.dll	ResolutionMode	Offset	0x1D454	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
 D2Lang.dll	GetStringByIndex	Ordinal	10005		
 D2Lang.dll	Unicode_strcat	Offset	0xA610		Unicode::strcat

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -10,6 +10,8 @@ D2Client.dll	IsNewSkillButtonPressed	Offset	0x11C30C
 D2Client.dll	IsNewStatsButtonPressed	Offset	0x11C308		
 D2DDraw.dll	DisplayHeight	Offset	0x101CC		
 D2DDraw.dll	DisplayWidth	Offset	0x101D4		
+D2Direct3D.dll	DisplayHeight	Offset	0x1AFD4		
+D2Direct3D.dll	DisplayWidth	Offset	0x1AB44		
 D2GFX.dll	ResolutionMode	Offset	0x11260	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
 D2Lang.dll	CreateD2UnicodeChar	Ordinal	10000		
 D2Lang.dll	CreateD2UnicodeCharWithValue	Ordinal			

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -9,6 +9,8 @@ D2Client.dll	IsNewSkillButtonPressed	Offset	0x11D31C
 D2Client.dll	IsNewStatsButtonPressed	Offset	0x11D318		
 D2DDraw.dll	DisplayHeight	Offset	0x100DC		
 D2DDraw.dll	DisplayWidth	Offset	0x100E4		
+D2Direct3D.dll	DisplayHeight	Offset	0x32DFC		
+D2Direct3D.dll	DisplayWidth	Offset	0x3296C		
 D2GFX.dll	ResolutionMode	Offset	0x14A40	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
 D2Lang.dll	GetStringByIndex	Ordinal	10004		
 D2Lang.dll	Unicode_strcat	Offset	0x8B90		Unicode::strcat

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -9,6 +9,8 @@ D2Client.dll	IsNewSkillButtonPressed	Offset	0x3B7370
 D2Client.dll	IsNewStatsButtonPressed	Offset	0x3B736C		
 D2DDraw.dll	DisplayHeight	Offset	0x4782DC		
 D2DDraw.dll	DisplayWidth	Offset	0x4782E0		
+D2Direct3D.dll	DisplayHeight	Offset	0x3C01C4		
+D2Direct3D.dll	DisplayWidth	Offset	0x3C01C0		
 D2GFX.dll	ResolutionMode	Offset	0x3BFD40	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
 D2Lang.dll	GetStringByIndex	Offset	0x121EE0		
 D2Lang.dll	Unicode_strcat	Offset	0x123C50		Unicode::strcat

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -9,6 +9,8 @@ D2Client.dll	IsNewSkillButtonPressed	Offset	0x3C02E8
 D2Client.dll	IsNewStatsButtonPressed	Offset	0x3C02E4		
 D2DDraw.dll	DisplayHeight	Offset	0x481254		
 D2DDraw.dll	DisplayWidth	Offset	0x481258		
+D2Direct3D.dll	DisplayHeight	Offset	0x3C913C		
+D2Direct3D.dll	DisplayWidth	Offset	0x3C9138		
 D2GFX.dll	ResolutionMode	Offset	0x3C8CB8	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
 D2Lang.dll	GetStringByIndex	Offset	0x124A30		
 D2Lang.dll	Unicode_strcat	Offset	0x126700		Unicode::strcat


### PR DESCRIPTION
The addresses point to two int32_t. The data values are set to whatever the game display width and height are. Changing these values will cause the game window to adjust its resolution (but not game elements or textures), to the extent permitted by the display mode. These values are only used if the display mode is Direct3D.

The addresses can be located by scanning for the appropriate width and height values, and repeatedly saving and exiting the game. It is suggested to change the ingame resolution to 640x480 when doing this.

The following 1.00 screenshot demonstrates that `D2Direct3D_DisplayWidth` is a 4 byte variable and is used in a call to `SetDisplayMode`.
![D2Direct3D_DisplayWidth_And_Height_04](https://user-images.githubusercontent.com/26683324/57561680-0591fc80-7342-11e9-8807-09dda4016940.PNG)

The following 1.00 screenshot demonstrates that `D2Direct3D_DisplayHeight` is a 4 byte variable and is used in a call to `SetDisplayMode`.
![D2Direct3D_DisplayWidth_And_Height_03](https://user-images.githubusercontent.com/26683324/57561685-0e82ce00-7342-11e9-880c-70861711fdf3.PNG)

The following 1.00 screenshot shows `D2Direct3D_DisplayWidth` and `D2Direct3D_DisplayHeight` being used as an int32_t.
![D2Direct3D_DisplayWidth_And_Height_01](https://user-images.githubusercontent.com/26683324/57561697-20fd0780-7342-11e9-9054-83db51263c3c.PNG)
