### PR TITLE
Add D2Win LoadMPQ

### DIFF
--- a/1.00.txt
+++ b/1.00.txt
@@ -35,5 +35,6 @@ D2Lang.dll	Unicode_tolower	Offset	0x1014	?toLower@Unicode@@QBE?AU1@XZ	Unicode::t
 D2Lang.dll	Unicode_toupper	Offset	0x1154		Unicode::toUpper
 D2Lang.dll	UnicodeString_NCompareIgnoreCase	Offset	0x1091	?strnicmp@Unicode@@SIHPBU1@0I@Z	Unicode::strnicmp
 D2Lang.dll	UnloadSysMap	Offset	0x104B	?unloadSysMap@Unicode@@SIXXZ	Unicode::unloadSysMap
+D2Win.dll	LoadMPQ	Offset	0x1458A		
 D2Win.dll	MainMenuMousePositionX	Offset	0x72A90		
 D2Win.dll	MainMenuMousePositionY	Offset	0x72A94		

--- a/1.03.txt
+++ b/1.03.txt
@@ -17,5 +17,6 @@ D2Lang.dll	Unicode_strcat	Offset	0x10B4		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x1055	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x1014	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x1154		Unicode::toUpper
+D2Win.dll	LoadMPQ	Offset	0x146FA		
 D2Win.dll	MainMenuMousePositionX	Offset	0x72A98		
 D2Win.dll	MainMenuMousePositionY	Offset	0x72A9C		

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -17,5 +17,6 @@ D2Lang.dll	Unicode_strcat	Offset	0x13A0		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x1490	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10E0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10B0		Unicode::toUpper
+D2Win.dll	LoadMPQ	Offset	0x10595		
 D2Win.dll	MainMenuMousePositionX	Offset	0x5BCB8		
 D2Win.dll	MainMenuMousePositionY	Offset	0x5BCBC		

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -17,5 +17,6 @@ D2Lang.dll	Unicode_strcat	Offset	0x13A0		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x1490	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10E0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10B0		Unicode::toUpper
+D2Win.dll	LoadMPQ	Offset	0x142FB		
 D2Win.dll	MainMenuMousePositionX	Offset	0x618A0		
 D2Win.dll	MainMenuMousePositionY	Offset	0x618A4		

--- a/1.10.txt
+++ b/1.10.txt
@@ -17,5 +17,6 @@ D2Lang.dll	Unicode_strcat	Offset	0x13F0		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x14C0	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10E0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10B0		Unicode::toUpper
+D2Win.dll	LoadMPQ	Offset	0x12399		
 D2Win.dll	MainMenuMousePositionX	Offset	0x5E234		
 D2Win.dll	MainMenuMousePositionY	Offset	0x5E238		

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -17,5 +17,6 @@ D2Lang.dll	Unicode_strcat	Offset	0xA610		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0xA6E0	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10C0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10A0		Unicode::toUpper
+D2Win.dll	LoadMPQ	Offset	0x7E40		
 D2Win.dll	MainMenuMousePositionX	Offset	0x5C700		
 D2Win.dll	MainMenuMousePositionY	Offset	0x5C704		

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -20,5 +20,6 @@ D2Lang.dll	Unicode_strcat	Offset	0xAFE0		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0xB0B0	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10C0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10A0		Unicode::toUpper
+D2Win.dll	LoadMPQ	Offset	0x7E60		
 D2Win.dll	MainMenuMousePositionX	Offset	0x21488		
 D2Win.dll	MainMenuMousePositionY	Offset	0x2148C		

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -17,5 +17,6 @@ D2Lang.dll	Unicode_strcat	Offset	0x8B90		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x8C60	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10C0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10A0		Unicode::toUpper
+D2Win.dll	LoadMPQ	Offset	0x7E50		
 D2Win.dll	MainMenuMousePositionX	Offset	0x8DB1C		
 D2Win.dll	MainMenuMousePositionY	Offset	0x8DB20		

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -17,5 +17,6 @@ D2Lang.dll	Unicode_strcat	Offset	0x123C50		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x123D50	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0xADD70	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x29E40		Unicode::toUpper
+D2Win.dll	LoadMPQ	Offset	0x114FF7		
 D2Win.dll	MainMenuMousePositionX	Offset	0x3CC62C		
 D2Win.dll	MainMenuMousePositionY	Offset	0x3CC630		

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -17,5 +17,6 @@ D2Lang.dll	Unicode_strcat	Offset	0x126700		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x126800	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0xB15F3	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x2E650		Unicode::toUpper
+D2Win.dll	LoadMPQ	Offset	0x117332		
 D2Win.dll	MainMenuMousePositionX	Offset	0x3D55A4		
 D2Win.dll	MainMenuMousePositionY	Offset	0x3D55A8		


### PR DESCRIPTION
The function loads a specified MPQ archive into the game so that its content may be used. It returns a pointer that contains a handle to the MPQ archive.

The function can be located by scanning for the string `d2char.mpq` in non-writable regions and getting the address of the string. Afterwards, use the address of the string in another scan in non-writable regions to get all executable code that references that address.

These are the following function definitions:

1.00:
```C
MPQArchiveHandle* D2Win_LoadMPQ(
  const char* dll_file_name,
  const char* mpq_file_name,
  const char* mpq_name,
  int32_t unused,
  void* (*on_fail_callback)(void)
)
```
- `dll_file_name` in ecx
- `mpq_file_name` in edx
- Remaining parameters on the stack
  - Callee cleans the stack

The following 1.00 screenshot shows the calling convention, and the number of parameters. The return type is also shown to be a pointer type.
![D2Win_LoadMPQ_01](https://user-images.githubusercontent.com/26683324/57587598-54fc3800-74bc-11e9-9294-1665f56202d0.PNG)

The following 1.00 screenshot shows how each of the parameters are used. It also shows that the `unused` parameter is indeed unused.
![D2Win_LoadMPQ_02](https://user-images.githubusercontent.com/26683324/57587608-7b21d800-74bc-11e9-9f26-422cdbc7bad1.PNG)

The following 1.00 screenshot shows how the `on_fail_callback` variable is indeed a function pointer with the specified type.
![D2Win_LoadMPQ_03](https://user-images.githubusercontent.com/26683324/57587622-c2a86400-74bc-11e9-83ea-e75ba8c07f1f.PNG)

1.03:
```C
MPQArchiveHandle* D2Win_LoadMPQ(
  const char* dll_file_name,
  const char* mpq_file_name,
  const char* mpq_name,
  int32_t unused,
  bool32_t is_set_err_on_drive_query_fail,
  void* (*on_fail_callback)(void)
)
```
- `dll_file_name` in ecx
- `mpq_file_name` in edx
- Remaining parameters on the stack
  - Callee cleans the stack

The following 1.03 screenshot shows the calling convention, and the number of parameters. The return type is also shown to be a pointer type. Note the additional parameter `is_set_err_on_drive_query_fail` that is passed in.
![D2Win_LoadMPQ_04 (1 03)](https://user-images.githubusercontent.com/26683324/57587637-fa171080-74bc-11e9-92ac-10c55a0bb119.PNG)

The following 1.03 screenshot shows how each of the parameters are used. It also shows that the `unused` parameter is indeed unused.
![D2Win_LoadMPQ_05 (1 03)](https://user-images.githubusercontent.com/26683324/57587647-1e72ed00-74bd-11e9-976c-f13d1b8a5079.PNG)

The following 1.03 screenshot shows how the `on_fail_callback` variable is indeed a function pointer with the specified type.
![D2Win_LoadMPQ_06 (1 03)](https://user-images.githubusercontent.com/26683324/57587655-3ba7bb80-74bd-11e9-8794-1534970c441d.PNG)

1.09D:
```C
MPQArchiveHandle* D2Win_LoadMPQ(
    const char* dll_file_name,
    const char* mpq_file_name,
    const char* mpq_name,
    int32_t unused,
    bool32_t is_set_err_on_drive_query_fail,
    void* (*on_fail_callback)(void),
    int32_t priority
)
```
- `dll_file_name` in ecx
- `mpq_file_name` in edx
- Remaining parameters on the stack
  - Callee cleans the stack

The following 1.09D screenshot shows the calling convention, and the number of parameters. The return type is also shown to be a pointer type. Note the additional parameter `priority` that is passed in.
![D2Win_LoadMPQ_06 (1 09D)](https://user-images.githubusercontent.com/26683324/57587656-4eba8b80-74bd-11e9-9fa8-cd647a901977.PNG)

The following 1.09D screenshot shows how each of the parameters are used. It also shows that the `unused` parameter is indeed unused. The `priority` parameter replaces the hardcoded 1000 value.
![D2Win_LoadMPQ_07 (1 09D)](https://user-images.githubusercontent.com/26683324/57587664-642fb580-74bd-11e9-923c-dd2a3a4a10ab.PNG)

The following 1.10 screenshot shows that `priority` is a signed type.
![D2Win_LoadMPQ_14 (1 10)](https://user-images.githubusercontent.com/26683324/57588103-44e85680-74c4-11e9-8c68-e324183477d8.PNG)

1.12A:
```C
MPQArchiveHandle* D2Win_LoadMPQ(
    const char* dll_file_name,
    const char* mpq_file_name,
    const char* mpq_name,
    bool32_t is_set_err_on_drive_query_fail,
    void* (*on_fail_callback)(void),
    int32_t priority
)
```
- `priority` in eax
- Remaining parameters on the stack
  - Callee cleans the stack

The following 1.12A screenshot shows the calling convention, and the number of parameters. The return type is also shown to be a pointer type. The calling convention is changed so that all parameters except `priority` are passed in via the stack. The parameter `priority` is instead stored in eax. The parameter `unused` is no longer passed in.
![D2Win_LoadMPQ_08 (1 12A)](https://user-images.githubusercontent.com/26683324/57587679-9d682580-74bd-11e9-810f-9995bb5c0be3.PNG)

The following 1.12A screenshot shows how each of the parameters are used.
![D2Win_LoadMPQ_09 (1 12A)](https://user-images.githubusercontent.com/26683324/57587696-f041dd00-74bd-11e9-800b-4d0ecc25c278.PNG)

The following 1.12A screenshot shows how the `on_fail_callback` variable is indeed a function pointer with the specified type.
![D2Win_LoadMPQ_10 (1 12A)](https://user-images.githubusercontent.com/26683324/57588055-58df8880-74c3-11e9-9b08-cd02b93d8304.PNG)

LoD 1.14C:
```C
MPQArchiveHandle* D2Win_LoadMPQ(
    const char* mpq_file_name,
    bool32_t is_set_err_on_drive_query_fail,
    void* (*on_fail_callback)(void),
    int32_t priority
)
```
- `mpq_file_name` in ecx
- `is_set_err_on_drive_query_fail` in edx
- Remaining parameters on the stack
  - Callee cleans the stack

The following LoD 1.14C screenshot shows the calling convention, and the number of parameters. The return type is also shown to be a pointer type. Note that the parameters `dll_file_name`, `mpq_name`, and `is_set_err_on_drive_query_fail` are removed.
![D2Win_LoadMPQ_11 (1 14C)](https://user-images.githubusercontent.com/26683324/57588067-790f4780-74c3-11e9-9a82-e20a665b7e6f.PNG)

The following LoD 1.14C screenshot shows how each of the parameters are used.
![D2Win_LoadMPQ_12 (1 14C)](https://user-images.githubusercontent.com/26683324/57588087-f0dd7200-74c3-11e9-82d5-0bb95a673c66.PNG)

The following LoD 1.14C screenshot shows how the `on_fail_callback` variable is indeed a function pointer with the specified type.
![D2Win_LoadMPQ_13 (1 14C)](https://user-images.githubusercontent.com/26683324/57588091-11a5c780-74c4-11e9-8a23-2c78e0726c78.PNG)

As a note, in 1.10, there are functions with the exact same code found on other DLL files. However, this definition is the only one available on all versions of the game.
