### PR TITLE
Add D2Win UnloadMPQ

### DIFF
--- a/1.00.txt
+++ b/1.00.txt
@@ -38,3 +38,4 @@ D2Lang.dll	UnloadSysMap	Offset	0x104B	?unloadSysMap@Unicode@@SIXXZ	Unicode::unlo
 D2Win.dll	LoadMPQ	Offset	0x1458A		
 D2Win.dll	MainMenuMousePositionX	Offset	0x72A90		
 D2Win.dll	MainMenuMousePositionY	Offset	0x72A94		
+D2Win.dll	UnloadMPQ	Offset	0x14729		

--- a/1.03.txt
+++ b/1.03.txt
@@ -20,3 +20,4 @@ D2Lang.dll	Unicode_toupper	Offset	0x1154		Unicode::toUpper
 D2Win.dll	LoadMPQ	Offset	0x146FA		
 D2Win.dll	MainMenuMousePositionX	Offset	0x72A98		
 D2Win.dll	MainMenuMousePositionY	Offset	0x72A9C		
+D2Win.dll	UnloadMPQ	Offset	0x148A7		

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -20,3 +20,4 @@ D2Lang.dll	Unicode_toupper	Offset	0x10B0		Unicode::toUpper
 D2Win.dll	LoadMPQ	Offset	0x10595		
 D2Win.dll	MainMenuMousePositionX	Offset	0x5BCB8		
 D2Win.dll	MainMenuMousePositionY	Offset	0x5BCBC		
+D2Win.dll	UnloadMPQ	Offset	0x10742		

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -20,3 +20,4 @@ D2Lang.dll	Unicode_toupper	Offset	0x10B0		Unicode::toUpper
 D2Win.dll	LoadMPQ	Offset	0x142FB		
 D2Win.dll	MainMenuMousePositionX	Offset	0x618A0		
 D2Win.dll	MainMenuMousePositionY	Offset	0x618A4		
+D2Win.dll	UnloadMPQ	Offset	0x144A6		

--- a/1.10.txt
+++ b/1.10.txt
@@ -20,3 +20,4 @@ D2Lang.dll	Unicode_toupper	Offset	0x10B0		Unicode::toUpper
 D2Win.dll	LoadMPQ	Offset	0x12399		
 D2Win.dll	MainMenuMousePositionX	Offset	0x5E234		
 D2Win.dll	MainMenuMousePositionY	Offset	0x5E238		
+D2Win.dll	UnloadMPQ	Offset	0x12548		

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -20,4 +20,4 @@ D2Lang.dll	Unicode_toupper	Offset	0x10A0		Unicode::toUpper
 D2Win.dll	LoadMPQ	Offset	0x7E40		
 D2Win.dll	MainMenuMousePositionX	Offset	0x5C700		
 D2Win.dll	MainMenuMousePositionY	Offset	0x5C704		
-D2Win.dll	UnloadMPQ	Offset	0x879B		
+D2Win.dll	UnloadMPQ	N/A	N/A		

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -20,3 +20,4 @@ D2Lang.dll	Unicode_toupper	Offset	0x10A0		Unicode::toUpper
 D2Win.dll	LoadMPQ	Offset	0x7E40		
 D2Win.dll	MainMenuMousePositionX	Offset	0x5C700		
 D2Win.dll	MainMenuMousePositionY	Offset	0x5C704		
+D2Win.dll	UnloadMPQ	Offset	0x879B		

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -23,4 +23,4 @@ D2Lang.dll	Unicode_toupper	Offset	0x10A0		Unicode::toUpper
 D2Win.dll	LoadMPQ	Offset	0x7E60		
 D2Win.dll	MainMenuMousePositionX	Offset	0x21488		
 D2Win.dll	MainMenuMousePositionY	Offset	0x2148C		
-D2Win.dll	UnloadMPQ	Offset	0xA43B		
+D2Win.dll	UnloadMPQ	N/A	N/A		

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -23,3 +23,4 @@ D2Lang.dll	Unicode_toupper	Offset	0x10A0		Unicode::toUpper
 D2Win.dll	LoadMPQ	Offset	0x7E60		
 D2Win.dll	MainMenuMousePositionX	Offset	0x21488		
 D2Win.dll	MainMenuMousePositionY	Offset	0x2148C		
+D2Win.dll	UnloadMPQ	Offset	0xA43B		

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -20,3 +20,4 @@ D2Lang.dll	Unicode_toupper	Offset	0x10A0		Unicode::toUpper
 D2Win.dll	LoadMPQ	Offset	0x7E50		
 D2Win.dll	MainMenuMousePositionX	Offset	0x8DB1C		
 D2Win.dll	MainMenuMousePositionY	Offset	0x8DB20		
+D2Win.dll	UnloadMPQ	Offset	0xCC5B		

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -20,4 +20,4 @@ D2Lang.dll	Unicode_toupper	Offset	0x10A0		Unicode::toUpper
 D2Win.dll	LoadMPQ	Offset	0x7E50		
 D2Win.dll	MainMenuMousePositionX	Offset	0x8DB1C		
 D2Win.dll	MainMenuMousePositionY	Offset	0x8DB20		
-D2Win.dll	UnloadMPQ	Offset	0xCC5B		
+D2Win.dll	UnloadMPQ	N/A	N/A		

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -20,3 +20,4 @@ D2Lang.dll	Unicode_toupper	Offset	0x29E40		Unicode::toUpper
 D2Win.dll	LoadMPQ	Offset	0x114FF7		
 D2Win.dll	MainMenuMousePositionX	Offset	0x3CC62C		
 D2Win.dll	MainMenuMousePositionY	Offset	0x3CC630		
+D2Win.dll	UnloadMPQ	Offset	0x115071		

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -20,3 +20,4 @@ D2Lang.dll	Unicode_toupper	Offset	0x2E650		Unicode::toUpper
 D2Win.dll	LoadMPQ	Offset	0x117332		
 D2Win.dll	MainMenuMousePositionX	Offset	0x3D55A4		
 D2Win.dll	MainMenuMousePositionY	Offset	0x3D55A8		
+D2Win.dll	UnloadMPQ	Offset	0x1173AC		


### PR DESCRIPTION
The function unloads the specified MPQ archive. It may return a value of 1, as a consequence of calling [Fog FreeClientMemory](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/19). The return value is therefore left defined as `void`.

The function is located by searching for the address of the string `d2char.mpq`. The address is used in a call to [D2Win LoadMPQ](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/16). One of the variables involved in the call to [D2Win LoadMPQ](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/16) is the address for the `MPQArchiveHandle` that will store the return value. Scan for code entries that reference that `MPQArchiveHandle` to locate a call to `D2Win UnloadMPQ`.

In versions 1.11 - 1.13D (inclusive), the function had become inline optimized and cannot be called. Therefore, the function must be reconstructed for those versions.

## Function Definitions
### All Versions (except 1.11 - 1.13D (inclusive)):
```C
void D2Win_UnloadMPQ(MPQArchiveHandle* mpq_archive_handle)
```
- `mpq_archive_handle` in ecx

## Screenshots
The following 1.00 screenshot shows the function's calling convention and the type of the parameter.
![D2Win_UnloadMPQ_01 (1 00)](https://user-images.githubusercontent.com/26683324/57910659-a6991f80-783a-11e9-8739-d44ac00d3524.PNG)

The following 1.12A screenshot shows how the function has been inline optimized and no longer exists.
![D2Win_UnloadMPQ_02 (1 12A)](https://user-images.githubusercontent.com/26683324/57910729-d6482780-783a-11e9-93df-c32342735e49.PNG)

The following 1.14C screenshot shows that the function has returned.
![D2Win_UnloadMPQ_04 (1 14C)](https://user-images.githubusercontent.com/26683324/57910796-f546b980-783a-11e9-9c5d-a02b13266375.PNG)
