### PR TITLE
Add Fog AllocClientMemory

### DIFF
--- a/1.00.txt
+++ b/1.00.txt
@@ -39,3 +39,4 @@ D2Win.dll	LoadMPQ	Offset	0x1458A
 D2Win.dll	MainMenuMousePositionX	Offset	0x72A90		
 D2Win.dll	MainMenuMousePositionY	Offset	0x72A94		
 D2Win.dll	UnloadMPQ	Offset	0x14729		
+Fog.dll	AllocClientMemory	Ordinal	10033		

--- a/1.03.txt
+++ b/1.03.txt
@@ -21,3 +21,4 @@ D2Win.dll	LoadMPQ	Offset	0x146FA
 D2Win.dll	MainMenuMousePositionX	Offset	0x72A98		
 D2Win.dll	MainMenuMousePositionY	Offset	0x72A9C		
 D2Win.dll	UnloadMPQ	Offset	0x148A7		
+Fog.dll	AllocClientMemory	Ordinal	10033		

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -21,3 +21,4 @@ D2Win.dll	LoadMPQ	Offset	0x10595
 D2Win.dll	MainMenuMousePositionX	Offset	0x5BCB8		
 D2Win.dll	MainMenuMousePositionY	Offset	0x5BCBC		
 D2Win.dll	UnloadMPQ	Offset	0x10742		
+Fog.dll	AllocClientMemory	Ordinal	10033		

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -21,3 +21,4 @@ D2Win.dll	LoadMPQ	Offset	0x142FB
 D2Win.dll	MainMenuMousePositionX	Offset	0x618A0		
 D2Win.dll	MainMenuMousePositionY	Offset	0x618A4		
 D2Win.dll	UnloadMPQ	Offset	0x144A6		
+Fog.dll	AllocClientMemory	Ordinal	10042		

--- a/1.10.txt
+++ b/1.10.txt
@@ -21,3 +21,4 @@ D2Win.dll	LoadMPQ	Offset	0x12399
 D2Win.dll	MainMenuMousePositionX	Offset	0x5E234		
 D2Win.dll	MainMenuMousePositionY	Offset	0x5E238		
 D2Win.dll	UnloadMPQ	Offset	0x12548		
+Fog.dll	AllocClientMemory	Ordinal	10042		

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -21,3 +21,4 @@ D2Win.dll	LoadMPQ	Offset	0x7E40
 D2Win.dll	MainMenuMousePositionX	Offset	0x5C700		
 D2Win.dll	MainMenuMousePositionY	Offset	0x5C704		
 D2Win.dll	UnloadMPQ	N/A	N/A		
+Fog.dll	AllocClientMemory	Ordinal	10042		

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -24,3 +24,4 @@ D2Win.dll	LoadMPQ	Offset	0x7E60
 D2Win.dll	MainMenuMousePositionX	Offset	0x21488		
 D2Win.dll	MainMenuMousePositionY	Offset	0x2148C		
 D2Win.dll	UnloadMPQ	N/A	N/A		
+Fog.dll	AllocClientMemory	Ordinal	10042		

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -21,3 +21,4 @@ D2Win.dll	LoadMPQ	Offset	0x7E50
 D2Win.dll	MainMenuMousePositionX	Offset	0x8DB1C		
 D2Win.dll	MainMenuMousePositionY	Offset	0x8DB20		
 D2Win.dll	UnloadMPQ	N/A	N/A		
+Fog.dll	AllocClientMemory	Ordinal	10042		

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -21,3 +21,4 @@ D2Win.dll	LoadMPQ	Offset	0x114FF7
 D2Win.dll	MainMenuMousePositionX	Offset	0x3CC62C		
 D2Win.dll	MainMenuMousePositionY	Offset	0x3CC630		
 D2Win.dll	UnloadMPQ	Offset	0x115071		
+Fog.dll	AllocClientMemory	Offset	0x6B90		

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -21,3 +21,4 @@ D2Win.dll	LoadMPQ	Offset	0x117332
 D2Win.dll	MainMenuMousePositionX	Offset	0x3D55A4		
 D2Win.dll	MainMenuMousePositionY	Offset	0x3D55A8		
 D2Win.dll	UnloadMPQ	Offset	0x1173AC		
+Fog.dll	AllocClientMemory	Offset	0xB380		


### PR DESCRIPTION
The function allocates memory on the heap with the specified size in bytes. Memory allocated with this function must be freed using [Fog FreeClientMemory](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/19).

The function can be located in the [D2Win LoadMPQ](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/16) function, where the very first function called is `Fog AllocClientMemory`.

Credits to [PhrozenKeep](https://d2mods.info/forum/viewtopic.php?t=61294), for making this information available.

## Function Definitions
### All Versions
```C
void* Fog_AllocClientMemory(
  int32_t size,
  const char* source_file,
  int32_t line,
  int32_t unused
)
```
- `size` in ecx
- `source_file` in edx
- Remaining parameters on the stack
  - Callee cleans the stack

The following 1.00 screenshot shows the calling convention and the parameters being passed in.
![Fog_AllocClientMemory_01 (1 00)](https://user-images.githubusercontent.com/26683324/57954363-8b182e00-78a7-11e9-866b-2764554b5f16.PNG)

The following 1.00 screenshot shows how these parameters are used. The `unused` parameter is not used.
![Fog_AllocClientMemory_02 (1 00)](https://user-images.githubusercontent.com/26683324/57954405-aaaf5680-78a7-11e9-96cf-e3caada38c62.PNG)

The following 1.10 screenshot shows how the `size` parameter is an `int32_t`.
![Fog_AllocClientMemory_03 (1 10)](https://user-images.githubusercontent.com/26683324/57954844-fd3d4280-78a8-11e9-8d68-fe16389fd074.PNG)

The following 1.10 screenshot shows how the `size` parameter is also used as a `size_t`. Given the context of how this parameter is used in this function, it is highly likely that `size` is a signed type. The signed type is also the better option, as it is extremely unlikely one would ever need to allocate more than 2 GB of memory at one time.
![Fog_AllocClientMemory_05 (1 10)](https://user-images.githubusercontent.com/26683324/57955968-31663280-78ac-11e9-8d6e-020dd0c81dbd.PNG)

The following 1.10 screenshot shows how the `line` parameter is a signed value.
![Fog_AllocClientMemory_04 (1 10)](https://user-images.githubusercontent.com/26683324/57954952-4a211900-78a9-11e9-80be-d5e16d4e9629.PNG)

