### PR TITLE
Add Fog FreeClientMemory

### DIFF
--- a/1.00.txt
+++ b/1.00.txt
@@ -40,3 +40,4 @@ D2Win.dll	MainMenuMousePositionX	Offset	0x72A90
 D2Win.dll	MainMenuMousePositionY	Offset	0x72A94		
 D2Win.dll	UnloadMPQ	Offset	0x14729		
 Fog.dll	AllocClientMemory	Ordinal	10033		
+Fog.dll	FreeClientMemory	Ordinal	10034		

--- a/1.03.txt
+++ b/1.03.txt
@@ -22,3 +22,4 @@ D2Win.dll	MainMenuMousePositionX	Offset	0x72A98
 D2Win.dll	MainMenuMousePositionY	Offset	0x72A9C		
 D2Win.dll	UnloadMPQ	Offset	0x148A7		
 Fog.dll	AllocClientMemory	Ordinal	10033		
+Fog.dll	FreeClientMemory	Ordinal	10034		

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -22,3 +22,4 @@ D2Win.dll	MainMenuMousePositionX	Offset	0x5BCB8
 D2Win.dll	MainMenuMousePositionY	Offset	0x5BCBC		
 D2Win.dll	UnloadMPQ	Offset	0x10742		
 Fog.dll	AllocClientMemory	Ordinal	10033		
+Fog.dll	FreeClientMemory	Ordinal	10034		

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -22,3 +22,4 @@ D2Win.dll	MainMenuMousePositionX	Offset	0x618A0
 D2Win.dll	MainMenuMousePositionY	Offset	0x618A4		
 D2Win.dll	UnloadMPQ	Offset	0x144A6		
 Fog.dll	AllocClientMemory	Ordinal	10042		
+Fog.dll	FreeClientMemory	Ordinal	10043		

--- a/1.10.txt
+++ b/1.10.txt
@@ -22,3 +22,4 @@ D2Win.dll	MainMenuMousePositionX	Offset	0x5E234
 D2Win.dll	MainMenuMousePositionY	Offset	0x5E238		
 D2Win.dll	UnloadMPQ	Offset	0x12548		
 Fog.dll	AllocClientMemory	Ordinal	10042		
+Fog.dll	FreeClientMemory	Ordinal	10043		

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -22,3 +22,4 @@ D2Win.dll	MainMenuMousePositionX	Offset	0x5C700
 D2Win.dll	MainMenuMousePositionY	Offset	0x5C704		
 D2Win.dll	UnloadMPQ	N/A	N/A		
 Fog.dll	AllocClientMemory	Ordinal	10042		
+Fog.dll	FreeClientMemory	Ordinal	10043		

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -25,3 +25,4 @@ D2Win.dll	MainMenuMousePositionX	Offset	0x21488
 D2Win.dll	MainMenuMousePositionY	Offset	0x2148C		
 D2Win.dll	UnloadMPQ	N/A	N/A		
 Fog.dll	AllocClientMemory	Ordinal	10042		
+Fog.dll	FreeClientMemory	Ordinal	10043		

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -22,3 +22,4 @@ D2Win.dll	MainMenuMousePositionX	Offset	0x8DB1C
 D2Win.dll	MainMenuMousePositionY	Offset	0x8DB20		
 D2Win.dll	UnloadMPQ	N/A	N/A		
 Fog.dll	AllocClientMemory	Ordinal	10042		
+Fog.dll	FreeClientMemory	Ordinal	10043		

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -22,3 +22,4 @@ D2Win.dll	MainMenuMousePositionX	Offset	0x3CC62C
 D2Win.dll	MainMenuMousePositionY	Offset	0x3CC630		
 D2Win.dll	UnloadMPQ	Offset	0x115071		
 Fog.dll	AllocClientMemory	Offset	0x6B90		
+Fog.dll	FreeClientMemory	Offset	0x6BD0		

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -22,3 +22,4 @@ D2Win.dll	MainMenuMousePositionX	Offset	0x3D55A4
 D2Win.dll	MainMenuMousePositionY	Offset	0x3D55A8		
 D2Win.dll	UnloadMPQ	Offset	0x1173AC		
 Fog.dll	AllocClientMemory	Offset	0xB380		
+Fog.dll	FreeClientMemory	Offset	0xB3C0		


### PR DESCRIPTION
The function frees memory on the heap that was allocated using [Fog AllocClientMemory](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/18).

The function can be located in the [D2Win LoadMPQ](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/16) function, where one of the functions called is `Fog FreeClientMemory`, only when the `MPQArchive` opening function fails.

Credits to [PhrozenKeep](https://d2mods.info/forum/viewtopic.php?t=61294), for making this information available.

## Function Definitions
### All Versions
```C
bool32_t Fog_FreeClientMemory(
  void* ptr,
  const char* source_file,
  int32_t line,
  int32_t unused
)
```
- `size` in ecx
- `source_file` in edx
- Remaining parameters on the stack
  - Callee cleans the stack

The following 1.00 screenshot shows the calling convention and the parameters passed into the function.
![Fog_FreeClientMemory_01 (1 00)](https://user-images.githubusercontent.com/26683324/57957326-c3703a00-78b0-11e9-85e2-da40be99d1fc.PNG)

The following 1.00 screenshot shows how the parameters are used. Note that `unused` is not used.
![Fog_FreeClientMemory_02 (1 00)](https://user-images.githubusercontent.com/26683324/57957394-fa465000-78b0-11e9-8700-3409fcb13027.PNG)

Although `source_file` and `line` are passed in, they are not used at all.