### PR TITLE
Add Storm SFileCloseArchive

### DIFF
--- a/1.00.txt
+++ b/1.00.txt
@@ -41,3 +41,4 @@ D2Win.dll	MainMenuMousePositionY	Offset	0x72A94
 D2Win.dll	UnloadMPQ	Offset	0x14729		
 Fog.dll	AllocClientMemory	Ordinal	10033		
 Fog.dll	FreeClientMemory	Ordinal	10034		
+Storm.dll	SFileCloseArchive	Ordinal	252		

--- a/1.03.txt
+++ b/1.03.txt
@@ -23,3 +23,4 @@ D2Win.dll	MainMenuMousePositionY	Offset	0x72A9C
 D2Win.dll	UnloadMPQ	Offset	0x148A7		
 Fog.dll	AllocClientMemory	Ordinal	10033		
 Fog.dll	FreeClientMemory	Ordinal	10034		
+Storm.dll	SFileCloseArchive	Ordinal	252		

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -23,3 +23,4 @@ D2Win.dll	MainMenuMousePositionY	Offset	0x5BCBC
 D2Win.dll	UnloadMPQ	Offset	0x10742		
 Fog.dll	AllocClientMemory	Ordinal	10033		
 Fog.dll	FreeClientMemory	Ordinal	10034		
+Storm.dll	SFileCloseArchive	Ordinal	252		

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -23,3 +23,4 @@ D2Win.dll	MainMenuMousePositionY	Offset	0x618A4
 D2Win.dll	UnloadMPQ	Offset	0x144A6		
 Fog.dll	AllocClientMemory	Ordinal	10042		
 Fog.dll	FreeClientMemory	Ordinal	10043		
+Storm.dll	SFileCloseArchive	Ordinal	252		

--- a/1.10.txt
+++ b/1.10.txt
@@ -23,3 +23,4 @@ D2Win.dll	MainMenuMousePositionY	Offset	0x5E238
 D2Win.dll	UnloadMPQ	Offset	0x12548		
 Fog.dll	AllocClientMemory	Ordinal	10042		
 Fog.dll	FreeClientMemory	Ordinal	10043		
+Storm.dll	SFileCloseArchive	Ordinal	252		

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -23,3 +23,4 @@ D2Win.dll	MainMenuMousePositionY	Offset	0x5C704
 D2Win.dll	UnloadMPQ	N/A	N/A		
 Fog.dll	AllocClientMemory	Ordinal	10042		
 Fog.dll	FreeClientMemory	Ordinal	10043		
+Storm.dll	SFileCloseArchive	Ordinal	252		

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -26,3 +26,4 @@ D2Win.dll	MainMenuMousePositionY	Offset	0x2148C
 D2Win.dll	UnloadMPQ	N/A	N/A		
 Fog.dll	AllocClientMemory	Ordinal	10042		
 Fog.dll	FreeClientMemory	Ordinal	10043		
+Storm.dll	SFileCloseArchive	Ordinal	252		

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -23,3 +23,4 @@ D2Win.dll	MainMenuMousePositionY	Offset	0x8DB20
 D2Win.dll	UnloadMPQ	N/A	N/A		
 Fog.dll	AllocClientMemory	Ordinal	10042		
 Fog.dll	FreeClientMemory	Ordinal	10043		
+Storm.dll	SFileCloseArchive	Ordinal	252		

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -23,3 +23,4 @@ D2Win.dll	MainMenuMousePositionY	Offset	0x3CC630
 D2Win.dll	UnloadMPQ	Offset	0x115071		
 Fog.dll	AllocClientMemory	Offset	0x6B90		
 Fog.dll	FreeClientMemory	Offset	0x6BD0		
+Storm.dll	SFileCloseArchive	Offset	0x15210		

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -23,3 +23,4 @@ D2Win.dll	MainMenuMousePositionY	Offset	0x3D55A8
 D2Win.dll	UnloadMPQ	Offset	0x1173AC		
 Fog.dll	AllocClientMemory	Offset	0xB380		
 Fog.dll	FreeClientMemory	Offset	0xB3C0		
+Storm.dll	SFileCloseArchive	Offset	0x19A80		


### PR DESCRIPTION
The function closes a specified `MPQArchive` that was opened using [Storm SFileOpenArchive](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/21).

The function can be located inside of the function [D2Win UnloadMPQ](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/17), or in the case of version 1.11 - 1.13D, the MPQ unloading routines. The function is called right before a call to [Fog FreeClientMemory](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/19).

Credits to [vgce](https://web.archive.org/web/20160404085855/https://code.google.com/p/vgce/wiki/stormDLL) for documenting the common Storm.dll ordinals.

## Function Definitions
### All Versions
```C
bool32_t Storm_SFileCloseArchive(MPQArchive* mpq_archive)
```
- All parameters on the stack
  - Callee cleans the stack

The following 1.00 screenshot shows the calling convention and the single parameter of the function.
![Storm_SFileCloseArchive_01 (1 00)](https://user-images.githubusercontent.com/26683324/57959111-1cdb6780-78b7-11e9-8a19-c8dc305fb804.PNG)

The two following 1.00 screenshots show that the return type is `bool32_t`. The screenshots also show the cleanup convention of the function.
![Storm_SFileCloseArchive_03 (1 00)](https://user-images.githubusercontent.com/26683324/57959142-38df0900-78b7-11e9-818c-e9de68cb8352.PNG)
![Storm_SFileCloseArchive_02 (1 00)](https://user-images.githubusercontent.com/26683324/57959164-4c8a6f80-78b7-11e9-8b3b-af0f1a438c13.PNG)

