### PR TITLE
Add Storm SFileOpenArchive

### DIFF
--- a/1.00.txt
+++ b/1.00.txt
@@ -42,3 +42,4 @@ D2Win.dll	UnloadMPQ	Offset	0x14729
 Fog.dll	AllocClientMemory	Ordinal	10033		
 Fog.dll	FreeClientMemory	Ordinal	10034		
 Storm.dll	SFileCloseArchive	Ordinal	252		
+Storm.dll	SFileOpenArchive	Ordinal	266		

--- a/1.03.txt
+++ b/1.03.txt
@@ -24,3 +24,4 @@ D2Win.dll	UnloadMPQ	Offset	0x148A7
 Fog.dll	AllocClientMemory	Ordinal	10033		
 Fog.dll	FreeClientMemory	Ordinal	10034		
 Storm.dll	SFileCloseArchive	Ordinal	252		
+Storm.dll	SFileOpenArchive	Ordinal	266		

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -24,3 +24,4 @@ D2Win.dll	UnloadMPQ	Offset	0x10742
 Fog.dll	AllocClientMemory	Ordinal	10033		
 Fog.dll	FreeClientMemory	Ordinal	10034		
 Storm.dll	SFileCloseArchive	Ordinal	252		
+Storm.dll	SFileOpenArchive	Ordinal	266		

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -24,3 +24,4 @@ D2Win.dll	UnloadMPQ	Offset	0x144A6
 Fog.dll	AllocClientMemory	Ordinal	10042		
 Fog.dll	FreeClientMemory	Ordinal	10043		
 Storm.dll	SFileCloseArchive	Ordinal	252		
+Storm.dll	SFileOpenArchive	Ordinal	266		

--- a/1.10.txt
+++ b/1.10.txt
@@ -24,3 +24,4 @@ D2Win.dll	UnloadMPQ	Offset	0x12548
 Fog.dll	AllocClientMemory	Ordinal	10042		
 Fog.dll	FreeClientMemory	Ordinal	10043		
 Storm.dll	SFileCloseArchive	Ordinal	252		
+Storm.dll	SFileOpenArchive	Ordinal	266		

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -24,3 +24,4 @@ D2Win.dll	UnloadMPQ	N/A	N/A
 Fog.dll	AllocClientMemory	Ordinal	10042		
 Fog.dll	FreeClientMemory	Ordinal	10043		
 Storm.dll	SFileCloseArchive	Ordinal	252		
+Storm.dll	SFileOpenArchive	Ordinal	266		

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -27,3 +27,4 @@ D2Win.dll	UnloadMPQ	N/A	N/A
 Fog.dll	AllocClientMemory	Ordinal	10042		
 Fog.dll	FreeClientMemory	Ordinal	10043		
 Storm.dll	SFileCloseArchive	Ordinal	252		
+Storm.dll	SFileOpenArchive	Ordinal	266		

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -24,3 +24,4 @@ D2Win.dll	UnloadMPQ	N/A	N/A
 Fog.dll	AllocClientMemory	Ordinal	10042		
 Fog.dll	FreeClientMemory	Ordinal	10043		
 Storm.dll	SFileCloseArchive	Ordinal	252		
+Storm.dll	SFileOpenArchive	Ordinal	266		

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -24,3 +24,4 @@ D2Win.dll	UnloadMPQ	Offset	0x115071
 Fog.dll	AllocClientMemory	Offset	0x6B90		
 Fog.dll	FreeClientMemory	Offset	0x6BD0		
 Storm.dll	SFileCloseArchive	Offset	0x15210		
+Storm.dll	SFileOpenArchive	Offset	0x17200		

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -24,3 +24,4 @@ D2Win.dll	UnloadMPQ	Offset	0x1173AC
 Fog.dll	AllocClientMemory	Offset	0xB380		
 Fog.dll	FreeClientMemory	Offset	0xB3C0		
 Storm.dll	SFileCloseArchive	Offset	0x19A80		
+Storm.dll	SFileOpenArchive	Offset	0x1BA60		


### PR DESCRIPTION
The function opens an MPQ file, stores the pointer to the `MPQArchive*` in one of the parameters, and returns whether the operation was a success. The pointer to the `MPQArchive*` must be closed with [Storm SFileCloseArchive](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/20).

The function can be located in the function [D2Win LoadMPQ](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/16). In the archive loading routine, there is a call to `Storm SFileOpenArchive`.

The following 1.00 screenshots show the steps used to get to the function, along with how the parameters get passed starting from [D2Win LoadMPQ](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/16).
![Storm_SFileOpenArchive_01 (1 00)](https://user-images.githubusercontent.com/26683324/57962343-78fbb700-78ca-11e9-88e1-b51b38e1bdc5.PNG)
![Storm_SFileOpenArchive_02 (1 00)](https://user-images.githubusercontent.com/26683324/57962336-671a1400-78ca-11e9-9f73-bd8cc9f344f4.PNG)

Credits to [vgce](https://web.archive.org/web/20160404085855/https://code.google.com/p/vgce/wiki/stormDLL) for documenting the common Storm.dll ordinals.

## Function Definition
### All Versions
```C
bool32_t Storm_SFileOpenArchive(
  const char* mpq_archive_path,
  int32_t priority,
  uint32_t flags,
  MPQArchive** mpq_archive_ptr_out
)
```
- All parameters on the stack
  - Callee cleans the stack

The following 1.10 screenshot shows the reverse engineered parameters to the function.
![Storm_SFileOpenArchive_06 (1 10)](https://user-images.githubusercontent.com/26683324/57962316-2de1a400-78ca-11e9-8ac9-b03991596b1f.PNG)

The following 1.10 screenshots show how `mpq_archive_path` is a `char*`. As it is never modified, it qualifies for the `const` qualifier.
![Storm_SFileOpenArchive_08 (1 10)](https://user-images.githubusercontent.com/26683324/57961985-c0cd0f00-78c7-11e9-9741-1ed8742fe570.PNG)
![Storm_SFileOpenArchive_09 (1 10)](https://user-images.githubusercontent.com/26683324/57961986-c0cd0f00-78c7-11e9-881b-9ceb69176944.PNG)

The following 1.10 screenshot shows how `priority` is an `int32_t`.
![Storm_SFileOpenArchive_07 (1 10)](https://user-images.githubusercontent.com/26683324/57962029-fb36ac00-78c7-11e9-890a-5c2746d6926d.PNG)

The following 1.10 screenshot shows how `flags` is a 32-bit integer. The function does not make a distinction as to whether the parameter is signed or unsigned.
![Storm_SFileOpenArchive_05 (1 10)](https://user-images.githubusercontent.com/26683324/57962049-26b99680-78c8-11e9-94f2-df17534e6b4c.PNG)

The following 1.10 screenshots show how `mpq_archive_ptr_out` is a `MPQArchive**`.
![Storm_SFileOpenArchive_03 (1 10)](https://user-images.githubusercontent.com/26683324/57962262-b3188900-78c9-11e9-9b10-f22af284f713.PNG)
![Storm_SFileOpenArchive_04 (1 10)](https://user-images.githubusercontent.com/26683324/57962263-b3188900-78c9-11e9-8a66-a680d2bbe8bf.PNG)

The following 1.10 screenshots show how the return value is a `bool32_t`.
![Storm_SFileOpenArchive_10 (1 10)](https://user-images.githubusercontent.com/26683324/57962357-a8122880-78ca-11e9-9f38-fa25461d5adf.PNG)
![Storm_SFileOpenArchive_11 (1 10)](https://user-images.githubusercontent.com/26683324/57962361-aa748280-78ca-11e9-9244-ce63be962362.PNG)
