### PR TITLE
Add D2GDI BitBlockWidth and BitBlockHeight

### DIFF
--- a/1.00.txt
+++ b/1.00.txt
@@ -12,6 +12,8 @@ D2DDraw.dll	DisplayHeight	Offset	0x190D0
 D2DDraw.dll	DisplayWidth	Offset	0x190D8		
 D2Direct3D.dll	DisplayHeight	Offset	0x26930		
 D2Direct3D.dll	DisplayWidth	Offset	0x26674		
+D2GDI.dll	BitBlockHeight	Offset	0xB840		
+D2GDI.dll	BitBlockWidth	Offset	0xB434		
 D2GFX.dll	ResolutionMode	Offset	0x2A950	"0 = 640x480, 1 = Main Menu 800x600"	
 D2Lang.dll	GetLocaleText	Ordinal	10004		
 D2Lang.dll	ToUnicodeString	Offset	0x1118	?toUnicode@Unicode@@SIPAU1@PAU1@PBDH@Z	Unicode::toUnicode

--- a/1.03.txt
+++ b/1.03.txt
@@ -11,6 +11,8 @@ D2DDraw.dll	DisplayHeight	Offset	0x190D0
 D2DDraw.dll	DisplayWidth	Offset	0x190D8		
 D2Direct3D.dll	DisplayHeight	Offset	0x26930		
 D2Direct3D.dll	DisplayWidth	Offset	0x26674		
+D2GDI.dll	BitBlockHeight	Offset	0xB840		
+D2GDI.dll	BitBlockWidth	Offset	0xB434		
 D2GFX.dll	ResolutionMode	Offset	0x2A990	"0 = 640x480, 1 = Main Menu 800x600"	
 D2Lang.dll	GetStringByIndex	Ordinal	10004		
 D2Lang.dll	Unicode_strcat	Offset	0x10B4		Unicode::strcat

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -11,6 +11,8 @@ D2DDraw.dll	DisplayHeight	Offset	0x116F8
 D2DDraw.dll	DisplayWidth	Offset	0x11700		
 D2Direct3D.dll	DisplayHeight	Offset	0x1A708		
 D2Direct3D.dll	DisplayWidth	Offset	0x1A44C		
+D2GDI.dll	BitBlockHeight	Offset	0xB3C8		
+D2GDI.dll	BitBlockWidth	Offset	0xAFBC		
 D2GFX.dll	ResolutionMode	Offset	0x1D060	"0 = 640x480, 1 = Main Menu 800x600"	
 D2Lang.dll	GetStringByIndex	Ordinal	10004		
 D2Lang.dll	Unicode_strcat	Offset	0x13A0		Unicode::strcat

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -11,6 +11,8 @@ D2DDraw.dll	DisplayHeight	Offset	0x11768
 D2DDraw.dll	DisplayWidth	Offset	0x11770		
 D2Direct3D.dll	DisplayHeight	Offset	0x1B708		
 D2Direct3D.dll	DisplayWidth	Offset	0x1B44C		
+D2GDI.dll	BitBlockHeight	Offset	0xC448		
+D2GDI.dll	BitBlockWidth	Offset	0xC03C		
 D2GFX.dll	ResolutionMode	Offset	0x1D210	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
 D2Lang.dll	GetStringByIndex	Ordinal	10004		
 D2Lang.dll	Unicode_strcat	Offset	0x13A0		Unicode::strcat

--- a/1.10.txt
+++ b/1.10.txt
@@ -11,6 +11,8 @@ D2DDraw.dll	DisplayHeight	Offset	0x117A8
 D2DDraw.dll	DisplayWidth	Offset	0x117B0		
 D2Direct3D.dll	DisplayHeight	Offset	0x1A7AC		
 D2Direct3D.dll	DisplayWidth	Offset	0x1A4F0		
+D2GDI.dll	BitBlockHeight	Offset	0xC48C		
+D2GDI.dll	BitBlockWidth	Offset	0xC07C		
 D2GFX.dll	ResolutionMode	Offset	0x1D26C	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
 D2Lang.dll	GetStringByIndex	Ordinal	10004		
 D2Lang.dll	Unicode_strcat	Offset	0x13F0		Unicode::strcat

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -11,6 +11,8 @@ D2DDraw.dll	DisplayHeight	Offset	0xFDCC
 D2DDraw.dll	DisplayWidth	Offset	0xFDD4		
 D2Direct3D.dll	DisplayHeight	Offset	0x196F4		
 D2Direct3D.dll	DisplayWidth	Offset	0x19264		
+D2GDI.dll	BitBlockHeight	Offset	0xCA98		
+D2GDI.dll	BitBlockWidth	Offset	0xCA88		
 D2GFX.dll	ResolutionMode	Offset	0x1D454	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
 D2Lang.dll	GetStringByIndex	Ordinal	10005		
 D2Lang.dll	Unicode_strcat	Offset	0xA610		Unicode::strcat

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -12,6 +12,8 @@ D2DDraw.dll	DisplayHeight	Offset	0x101CC
 D2DDraw.dll	DisplayWidth	Offset	0x101D4		
 D2Direct3D.dll	DisplayHeight	Offset	0x1AFD4		
 D2Direct3D.dll	DisplayWidth	Offset	0x1AB44		
+D2GDI.dll	BitBlockHeight	Offset	0xCA90		
+D2GDI.dll	BitBlockWidth	Offset	0xCA80		
 D2GFX.dll	ResolutionMode	Offset	0x11260	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
 D2Lang.dll	CreateD2UnicodeChar	Ordinal	10000		
 D2Lang.dll	CreateD2UnicodeCharWithValue	Ordinal			

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -11,6 +11,8 @@ D2DDraw.dll	DisplayHeight	Offset	0x100DC
 D2DDraw.dll	DisplayWidth	Offset	0x100E4		
 D2Direct3D.dll	DisplayHeight	Offset	0x32DFC		
 D2Direct3D.dll	DisplayWidth	Offset	0x3296C		
+D2GDI.dll	BitBlockHeight	Offset	0xC980		
+D2GDI.dll	BitBlockWidth	Offset	0xC970		
 D2GFX.dll	ResolutionMode	Offset	0x14A40	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
 D2Lang.dll	GetStringByIndex	Ordinal	10004		
 D2Lang.dll	Unicode_strcat	Offset	0x8B90		Unicode::strcat

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -11,6 +11,8 @@ D2DDraw.dll	DisplayHeight	Offset	0x4782DC
 D2DDraw.dll	DisplayWidth	Offset	0x4782E0		
 D2Direct3D.dll	DisplayHeight	Offset	0x3C01C4		
 D2Direct3D.dll	DisplayWidth	Offset	0x3C01C0		
+D2GDI.dll	BitBlockHeight	Offset	0x3C01C4		
+D2GDI.dll	BitBlockWidth	Offset	0x3C01C0		
 D2GFX.dll	ResolutionMode	Offset	0x3BFD40	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
 D2Lang.dll	GetStringByIndex	Offset	0x121EE0		
 D2Lang.dll	Unicode_strcat	Offset	0x123C50		Unicode::strcat

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -11,6 +11,8 @@ D2DDraw.dll	DisplayHeight	Offset	0x481254
 D2DDraw.dll	DisplayWidth	Offset	0x481258		
 D2Direct3D.dll	DisplayHeight	Offset	0x3C913C		
 D2Direct3D.dll	DisplayWidth	Offset	0x3C9138		
+D2GDI.dll	BitBlockHeight	Offset	0x3C913C		
+D2GDI.dll	BitBlockWidth	Offset	0x3C9138		
 D2GFX.dll	ResolutionMode	Offset	0x3C8CB8	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
 D2Lang.dll	GetStringByIndex	Offset	0x124A30		
 D2Lang.dll	Unicode_strcat	Offset	0x126700		Unicode::strcat


### PR DESCRIPTION
The variables correspond to the width and height used in a call to the [BitBlt](https://docs.microsoft.com/en-us/windows/desktop/api/wingdi/nf-wingdi-bitblt) function. The variables are both of type `int32_t`.

The variables can be located by entering, then saving and exiting the game. When the resolution changes, scan for the values matching its current width and height. It is recommended to keep the ingame resolution to 640x480.

The following 1.00 screenshot shows how the variables are set and the context.
![D2GDI_BitBlockWidth_And_BitBlockHeight_01_(1 00)](https://user-images.githubusercontent.com/26683324/57967959-678dcb80-7919-11e9-92f4-6d6d49f45c62.PNG)

The following 1.00 screenshot shows how the variables are both `int32_t`.
![D2GDI_BitBlockWidth_And_BitBlockHeight_03_(1 00)](https://user-images.githubusercontent.com/26683324/57968023-04e8ff80-791a-11e9-9996-3981a2a943f1.PNG)

The following 1.10 screenshot shows the variable being used in a call to [BitBlt](https://docs.microsoft.com/en-us/windows/desktop/api/wingdi/nf-wingdi-bitblt), which supports the belief that the chosen name is appropriate. This also adds to evidence that the variables are `int32_t`.
![D2GDI_BitBlockWidth_And_BitBlockHeight_02_(1 10)](https://user-images.githubusercontent.com/26683324/57968028-1b8f5680-791a-11e9-86a3-8c3f8c803d13.PNG)
