### PR TITLE
Add D2GDI CelDisplayLeft and CelDisplayRight

### DIFF
--- a/1.00.txt
+++ b/1.00.txt
@@ -14,6 +14,8 @@ D2Direct3D.dll	DisplayHeight	Offset	0x26930
 D2Direct3D.dll	DisplayWidth	Offset	0x26674		
 D2GDI.dll	BitBlockHeight	Offset	0xB840		
 D2GDI.dll	BitBlockWidth	Offset	0xB434		
+D2GDI.dll	CelDisplayLeft	Offset	0xBF80		
+D2GDI.dll	CelDisplayRight	Offset	0xBF7C		
 D2GFX.dll	ResolutionMode	Offset	0x2A950	"0 = 640x480, 1 = Main Menu 800x600"	
 D2Lang.dll	GetLocaleText	Ordinal	10004		
 D2Lang.dll	ToUnicodeString	Offset	0x1118	?toUnicode@Unicode@@SIPAU1@PAU1@PBDH@Z	Unicode::toUnicode

--- a/1.03.txt
+++ b/1.03.txt
@@ -13,6 +13,8 @@ D2Direct3D.dll	DisplayHeight	Offset	0x26930
 D2Direct3D.dll	DisplayWidth	Offset	0x26674		
 D2GDI.dll	BitBlockHeight	Offset	0xB840		
 D2GDI.dll	BitBlockWidth	Offset	0xB434		
+D2GDI.dll	CelDisplayLeft	Offset	0xBF80		
+D2GDI.dll	CelDisplayRight	Offset	0xBF7C		
 D2GFX.dll	ResolutionMode	Offset	0x2A990	"0 = 640x480, 1 = Main Menu 800x600"	
 D2Lang.dll	GetStringByIndex	Ordinal	10004		
 D2Lang.dll	Unicode_strcat	Offset	0x10B4		Unicode::strcat

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -13,6 +13,8 @@ D2Direct3D.dll	DisplayHeight	Offset	0x1A708
 D2Direct3D.dll	DisplayWidth	Offset	0x1A44C		
 D2GDI.dll	BitBlockHeight	Offset	0xB3C8		
 D2GDI.dll	BitBlockWidth	Offset	0xAFBC		
+D2GDI.dll	CelDisplayLeft	Offset	0xB8EC		
+D2GDI.dll	CelDisplayRight	Offset	0xB8E8		
 D2GFX.dll	ResolutionMode	Offset	0x1D060	"0 = 640x480, 1 = Main Menu 800x600"	
 D2Lang.dll	GetStringByIndex	Ordinal	10004		
 D2Lang.dll	Unicode_strcat	Offset	0x13A0		Unicode::strcat

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -13,6 +13,8 @@ D2Direct3D.dll	DisplayHeight	Offset	0x1B708
 D2Direct3D.dll	DisplayWidth	Offset	0x1B44C		
 D2GDI.dll	BitBlockHeight	Offset	0xC448		
 D2GDI.dll	BitBlockWidth	Offset	0xC03C		
+D2GDI.dll	CelDisplayLeft	Offset	0xC96C		
+D2GDI.dll	CelDisplayRight	Offset	0xC968		
 D2GFX.dll	ResolutionMode	Offset	0x1D210	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
 D2Lang.dll	GetStringByIndex	Ordinal	10004		
 D2Lang.dll	Unicode_strcat	Offset	0x13A0		Unicode::strcat

--- a/1.10.txt
+++ b/1.10.txt
@@ -13,6 +13,8 @@ D2Direct3D.dll	DisplayHeight	Offset	0x1A7AC
 D2Direct3D.dll	DisplayWidth	Offset	0x1A4F0		
 D2GDI.dll	BitBlockHeight	Offset	0xC48C		
 D2GDI.dll	BitBlockWidth	Offset	0xC07C		
+D2GDI.dll	CelDisplayLeft	Offset	0xC9B4		
+D2GDI.dll	CelDisplayRight	Offset	0xC9B0		
 D2GFX.dll	ResolutionMode	Offset	0x1D26C	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
 D2Lang.dll	GetStringByIndex	Ordinal	10004		
 D2Lang.dll	Unicode_strcat	Offset	0x13F0		Unicode::strcat

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -13,6 +13,8 @@ D2Direct3D.dll	DisplayHeight	Offset	0x196F4
 D2Direct3D.dll	DisplayWidth	Offset	0x19264		
 D2GDI.dll	BitBlockHeight	Offset	0xCA98		
 D2GDI.dll	BitBlockWidth	Offset	0xCA88		
+D2GDI.dll	CelDisplayLeft	Offset	0xC040		
+D2GDI.dll	CelDisplayRight	Offset	0xC044		
 D2GFX.dll	ResolutionMode	Offset	0x1D454	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
 D2Lang.dll	GetStringByIndex	Ordinal	10005		
 D2Lang.dll	Unicode_strcat	Offset	0xA610		Unicode::strcat

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -14,6 +14,8 @@ D2Direct3D.dll	DisplayHeight	Offset	0x1AFD4
 D2Direct3D.dll	DisplayWidth	Offset	0x1AB44		
 D2GDI.dll	BitBlockHeight	Offset	0xCA90		
 D2GDI.dll	BitBlockWidth	Offset	0xCA80		
+D2GDI.dll	CelDisplayLeft	Offset	0xCA98		
+D2GDI.dll	CelDisplayRight	Offset	0xCA9C		
 D2GFX.dll	ResolutionMode	Offset	0x11260	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
 D2Lang.dll	CreateD2UnicodeChar	Ordinal	10000		
 D2Lang.dll	CreateD2UnicodeCharWithValue	Ordinal			

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -13,6 +13,8 @@ D2Direct3D.dll	DisplayHeight	Offset	0x32DFC
 D2Direct3D.dll	DisplayWidth	Offset	0x3296C		
 D2GDI.dll	BitBlockHeight	Offset	0xC980		
 D2GDI.dll	BitBlockWidth	Offset	0xC970		
+D2GDI.dll	CelDisplayLeft	Offset	0xCA94		
+D2GDI.dll	CelDisplayRight	Offset	0xCA98		
 D2GFX.dll	ResolutionMode	Offset	0x14A40	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
 D2Lang.dll	GetStringByIndex	Ordinal	10004		
 D2Lang.dll	Unicode_strcat	Offset	0x8B90		Unicode::strcat

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -13,6 +13,8 @@ D2Direct3D.dll	DisplayHeight	Offset	0x3C01C4
 D2Direct3D.dll	DisplayWidth	Offset	0x3C01C0		
 D2GDI.dll	BitBlockHeight	Offset	0x3C01C4		
 D2GDI.dll	BitBlockWidth	Offset	0x3C01C0		
+D2GDI.dll	CelDisplayLeft	Offset	0x5810F0		
+D2GDI.dll	CelDisplayRight	Offset	0x5810F4		
 D2GFX.dll	ResolutionMode	Offset	0x3BFD40	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
 D2Lang.dll	GetStringByIndex	Offset	0x121EE0		
 D2Lang.dll	Unicode_strcat	Offset	0x123C50		Unicode::strcat

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -13,6 +13,8 @@ D2Direct3D.dll	DisplayHeight	Offset	0x3C913C
 D2Direct3D.dll	DisplayWidth	Offset	0x3C9138		
 D2GDI.dll	BitBlockHeight	Offset	0x3C913C		
 D2GDI.dll	BitBlockWidth	Offset	0x3C9138		
+D2GDI.dll	CelDisplayLeft	Offset	0x58A168		
+D2GDI.dll	CelDisplayRight	Offset	0x58A16C		
 D2GFX.dll	ResolutionMode	Offset	0x3C8CB8	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
 D2Lang.dll	GetStringByIndex	Offset	0x124A30		
 D2Lang.dll	Unicode_strcat	Offset	0x126700		Unicode::strcat


### PR DESCRIPTION
The variables are involved in the display of `CelContext` images, by limiting their appearance on the left and right side of the screen. They are both of type `int32_t`.

The variables can be located by repeatedly entering and exiting the game, with the ingame resolution set to 640x480. Scan for the values 640 and 800, matching the display width.

The following 1.00 screenshot shows what happens when `D2GDI CelDisplayLeft` is set to 240, while `D2GDI CelDisplayRight` is set to 400.
![D2GDI_CelDisplayLeft_And_CelDisplayRight_02_(1 00)](https://user-images.githubusercontent.com/26683324/58008942-43a9c180-7aa2-11e9-98e2-1c016401cfef.jpg)

The following 1.00 screenshot shows the variables being modifed.
![D2GDI_CelDisplayLeft_And_CelDisplayRight_04_(1 00)](https://user-images.githubusercontent.com/26683324/58009061-79e74100-7aa2-11e9-846e-701047f3e12a.PNG)

The following 1.10 screenshot shows the variables being used in the context of two `int32_t`.
![D2GDI_CelDisplayLeft_And_CelDisplayRight_05_(1 10)](https://user-images.githubusercontent.com/26683324/58009719-e9a9fb80-7aa3-11e9-9c8b-e8ff0504ac57.PNG)

The following 1.00 screenshot supports the name and [spelling](https://www.dictionary.com/browse/cel) chosen for this variable. 
![D2GDI_CelDisplayLeft_And_CelDisplayRight_06_(1 00)](https://user-images.githubusercontent.com/26683324/58009778-080ff700-7aa4-11e9-8fc8-db6a4758e263.PNG)
