### PR TITLE
Add D2Glide DisplayWidth and DisplayHeight

### DIFF
--- a/1.00.txt
+++ b/1.00.txt
@@ -17,6 +17,8 @@ D2GDI.dll	BitBlockWidth	Offset	0xB434
 D2GDI.dll	CelDisplayLeft	Offset	0xBF80		
 D2GDI.dll	CelDisplayRight	Offset	0xBF7C		
 D2GFX.dll	ResolutionMode	Offset	0x2A950	"0 = 640x480, 1 = Main Menu 800x600"	
+D2Glide.dll	DisplayHeight	Offset	0x1DE04		
+D2Glide.dll	DisplayWidth	Offset	0x1DD44		
 D2Lang.dll	GetLocaleText	Ordinal	10004		
 D2Lang.dll	ToUnicodeString	Offset	0x1118	?toUnicode@Unicode@@SIPAU1@PAU1@PBDH@Z	Unicode::toUnicode
 D2Lang.dll	ConvertUnicodeToWin				

--- a/1.03.txt
+++ b/1.03.txt
@@ -16,6 +16,8 @@ D2GDI.dll	BitBlockWidth	Offset	0xB434
 D2GDI.dll	CelDisplayLeft	Offset	0xBF80		
 D2GDI.dll	CelDisplayRight	Offset	0xBF7C		
 D2GFX.dll	ResolutionMode	Offset	0x2A990	"0 = 640x480, 1 = Main Menu 800x600"	
+D2Glide.dll	DisplayHeight	Offset	0x1DDC4		
+D2Glide.dll	DisplayWidth	Offset	0x1DD04		
 D2Lang.dll	GetStringByIndex	Ordinal	10004		
 D2Lang.dll	Unicode_strcat	Offset	0x10B4		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x1055	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -16,6 +16,8 @@ D2GDI.dll	BitBlockWidth	Offset	0xAFBC
 D2GDI.dll	CelDisplayLeft	Offset	0xB8EC		
 D2GDI.dll	CelDisplayRight	Offset	0xB8E8		
 D2GFX.dll	ResolutionMode	Offset	0x1D060	"0 = 640x480, 1 = Main Menu 800x600"	
+D2Glide.dll	DisplayHeight	Offset	0x153AC		
+D2Glide.dll	DisplayWidth	Offset	0x152EC		
 D2Lang.dll	GetStringByIndex	Ordinal	10004		
 D2Lang.dll	Unicode_strcat	Offset	0x13A0		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x1490	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -16,6 +16,8 @@ D2GDI.dll	BitBlockWidth	Offset	0xC03C
 D2GDI.dll	CelDisplayLeft	Offset	0xC96C		
 D2GDI.dll	CelDisplayRight	Offset	0xC968		
 D2GFX.dll	ResolutionMode	Offset	0x1D210	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
+D2Glide.dll	DisplayHeight	Offset	0x153CC		
+D2Glide.dll	DisplayWidth	Offset	0x1530C		
 D2Lang.dll	GetStringByIndex	Ordinal	10004		
 D2Lang.dll	Unicode_strcat	Offset	0x13A0		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x1490	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen

--- a/1.10.txt
+++ b/1.10.txt
@@ -16,6 +16,8 @@ D2GDI.dll	BitBlockWidth	Offset	0xC07C
 D2GDI.dll	CelDisplayLeft	Offset	0xC9B4		
 D2GDI.dll	CelDisplayRight	Offset	0xC9B0		
 D2GFX.dll	ResolutionMode	Offset	0x1D26C	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
+D2Glide.dll	DisplayHeight	Offset	0x15468		
+D2Glide.dll	DisplayWidth	Offset	0x153AC		
 D2Lang.dll	GetStringByIndex	Ordinal	10004		
 D2Lang.dll	Unicode_strcat	Offset	0x13F0		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x14C0	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -16,6 +16,8 @@ D2GDI.dll	BitBlockWidth	Offset	0xCA88
 D2GDI.dll	CelDisplayLeft	Offset	0xC040		
 D2GDI.dll	CelDisplayRight	Offset	0xC044		
 D2GFX.dll	ResolutionMode	Offset	0x1D454	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
+D2Glide.dll	DisplayHeight	Offset	0x16E8C		
+D2Glide.dll	DisplayWidth	Offset	0x16DF0		
 D2Lang.dll	GetStringByIndex	Ordinal	10005		
 D2Lang.dll	Unicode_strcat	Offset	0xA610		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0xA6E0	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -17,6 +17,8 @@ D2GDI.dll	BitBlockWidth	Offset	0xCA80
 D2GDI.dll	CelDisplayLeft	Offset	0xCA98		
 D2GDI.dll	CelDisplayRight	Offset	0xCA9C		
 D2GFX.dll	ResolutionMode	Offset	0x11260	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
+D2Glide.dll	DisplayHeight	Offset	0x15B04		
+D2Glide.dll	DisplayWidth	Offset	0x15A68		
 D2Lang.dll	CreateD2UnicodeChar	Ordinal	10000		
 D2Lang.dll	CreateD2UnicodeCharWithValue	Ordinal			
 D2Lang.dll	GetStringByIndex	Ordinal	10003		

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -16,6 +16,8 @@ D2GDI.dll	BitBlockWidth	Offset	0xC970
 D2GDI.dll	CelDisplayLeft	Offset	0xCA94		
 D2GDI.dll	CelDisplayRight	Offset	0xCA98		
 D2GFX.dll	ResolutionMode	Offset	0x14A40	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
+D2Glide.dll	DisplayHeight	Offset	0x15B14		
+D2Glide.dll	DisplayWidth	Offset	0x15A78		
 D2Lang.dll	GetStringByIndex	Ordinal	10004		
 D2Lang.dll	Unicode_strcat	Offset	0x8B90		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x8C60	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -16,6 +16,8 @@ D2GDI.dll	BitBlockWidth	Offset	0x3C01C0
 D2GDI.dll	CelDisplayLeft	Offset	0x5810F0		
 D2GDI.dll	CelDisplayRight	Offset	0x5810F4		
 D2GFX.dll	ResolutionMode	Offset	0x3BFD40	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
+D2Glide.dll	DisplayHeight	Offset	0x3C01C4		
+D2Glide.dll	DisplayWidth	Offset	0x3C01C0		
 D2Lang.dll	GetStringByIndex	Offset	0x121EE0		
 D2Lang.dll	Unicode_strcat	Offset	0x123C50		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x123D50	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -16,6 +16,8 @@ D2GDI.dll	BitBlockWidth	Offset	0x3C9138
 D2GDI.dll	CelDisplayLeft	Offset	0x58A168		
 D2GDI.dll	CelDisplayRight	Offset	0x58A16C		
 D2GFX.dll	ResolutionMode	Offset	0x3C8CB8	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
+D2Glide.dll	DisplayHeight	Offset	0x3C913C		
+D2Glide.dll	DisplayWidth	Offset	0x3C9138		
 D2Lang.dll	GetStringByIndex	Offset	0x124A30		
 D2Lang.dll	Unicode_strcat	Offset	0x126700		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x126800	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen


### PR DESCRIPTION
The variables are involved in Glide's display width and height. They are both of type `int32_t`.

The variables can be located by repeatedly entering and exiting the game, with the ingame resolution set to 640x480. Scan for the values 640 and 800, matching the display width.

The following 1.00 screenshot shows the variables being modified.
![D2Glide_DisplayWidth_And_DisplayHeight_00](https://user-images.githubusercontent.com/26683324/59887789-96181f80-9379-11e9-9213-100dd667b977.PNG)

The following 1.00 screenshot shows the variables being used in the context of two `int32_t`.
![D2Glide_DisplayWidth_And_DisplayHeight_01](https://user-images.githubusercontent.com/26683324/59887793-9a443d00-9379-11e9-89e0-295c4b5fe54e.PNG)
