### PR TITLE
Add D2GFX VideoMode

### DIFF
--- a/1.00.txt
+++ b/1.00.txt
@@ -17,6 +17,7 @@ D2GDI.dll	BitBlockWidth	Offset	0xB434
 D2GDI.dll	CelDisplayLeft	Offset	0xBF80		
 D2GDI.dll	CelDisplayRight	Offset	0xBF7C		
 D2GFX.dll	ResolutionMode	Offset	0x2A950	"0 = 640x480, 1 = Main Menu 800x600"	
+D2GFX.dll	VideoMode	Offset	0x2A948	"1 = GDI, 2 = Software, 3 = DirectDraw, 4 = Glide, 5 = OpenGL, 6 = Direct3D, 7 = Rave"	
 D2Glide.dll	DisplayHeight	Offset	0x1DE04		
 D2Glide.dll	DisplayWidth	Offset	0x1DD44		
 D2Lang.dll	GetLocaleText	Ordinal	10004		

--- a/1.03.txt
+++ b/1.03.txt
@@ -16,6 +16,7 @@ D2GDI.dll	BitBlockWidth	Offset	0xB434
 D2GDI.dll	CelDisplayLeft	Offset	0xBF80		
 D2GDI.dll	CelDisplayRight	Offset	0xBF7C		
 D2GFX.dll	ResolutionMode	Offset	0x2A990	"0 = 640x480, 1 = Main Menu 800x600"	
+D2GFX.dll	VideoMode	Offset	0x2A988	"1 = GDI, 2 = Software, 3 = DirectDraw, 4 = Glide, 5 = OpenGL, 6 = Direct3D, 7 = Rave"	
 D2Glide.dll	DisplayHeight	Offset	0x1DDC4		
 D2Glide.dll	DisplayWidth	Offset	0x1DD04		
 D2Lang.dll	GetStringByIndex	Ordinal	10004		

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -16,6 +16,7 @@ D2GDI.dll	BitBlockWidth	Offset	0xAFBC
 D2GDI.dll	CelDisplayLeft	Offset	0xB8EC		
 D2GDI.dll	CelDisplayRight	Offset	0xB8E8		
 D2GFX.dll	ResolutionMode	Offset	0x1D060	"0 = 640x480, 1 = Main Menu 800x600"	
+D2GFX.dll	VideoMode	Offset	0x1D058	"1 = GDI, 2 = Software, 3 = DirectDraw, 4 = Glide, 5 = OpenGL, 6 = Direct3D, 7 = Rave"	
 D2Glide.dll	DisplayHeight	Offset	0x153AC		
 D2Glide.dll	DisplayWidth	Offset	0x152EC		
 D2Lang.dll	GetStringByIndex	Ordinal	10004		

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -16,6 +16,7 @@ D2GDI.dll	BitBlockWidth	Offset	0xC03C
 D2GDI.dll	CelDisplayLeft	Offset	0xC96C		
 D2GDI.dll	CelDisplayRight	Offset	0xC968		
 D2GFX.dll	ResolutionMode	Offset	0x1D210	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
+D2GFX.dll	VideoMode	Offset	0x1D208	"1 = GDI, 2 = Software, 3 = DirectDraw, 4 = Glide, 5 = OpenGL, 6 = Direct3D, 7 = Rave"	
 D2Glide.dll	DisplayHeight	Offset	0x153CC		
 D2Glide.dll	DisplayWidth	Offset	0x1530C		
 D2Lang.dll	GetStringByIndex	Ordinal	10004		

--- a/1.10.txt
+++ b/1.10.txt
@@ -16,6 +16,7 @@ D2GDI.dll	BitBlockWidth	Offset	0xC07C
 D2GDI.dll	CelDisplayLeft	Offset	0xC9B4		
 D2GDI.dll	CelDisplayRight	Offset	0xC9B0		
 D2GFX.dll	ResolutionMode	Offset	0x1D26C	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
+D2GFX.dll	VideoMode	Offset	0x1D264	"1 = GDI, 2 = Software, 3 = DirectDraw, 4 = Glide, 5 = OpenGL, 6 = Direct3D, 7 = Rave"	
 D2Glide.dll	DisplayHeight	Offset	0x15468		
 D2Glide.dll	DisplayWidth	Offset	0x153AC		
 D2Lang.dll	GetStringByIndex	Ordinal	10004		

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -16,6 +16,7 @@ D2GDI.dll	BitBlockWidth	Offset	0xCA88
 D2GDI.dll	CelDisplayLeft	Offset	0xC040		
 D2GDI.dll	CelDisplayRight	Offset	0xC044		
 D2GFX.dll	ResolutionMode	Offset	0x1D454	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
+D2GFX.dll	VideoMode	Offset	0x1D44C	"1 = GDI, 2 = Software, 3 = DirectDraw, 4 = Glide, 5 = OpenGL, 6 = Direct3D, 7 = Rave"	
 D2Glide.dll	DisplayHeight	Offset	0x16E8C		
 D2Glide.dll	DisplayWidth	Offset	0x16DF0		
 D2Lang.dll	GetStringByIndex	Ordinal	10005		

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -17,6 +17,7 @@ D2GDI.dll	BitBlockWidth	Offset	0xCA80
 D2GDI.dll	CelDisplayLeft	Offset	0xCA98		
 D2GDI.dll	CelDisplayRight	Offset	0xCA9C		
 D2GFX.dll	ResolutionMode	Offset	0x11260	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
+D2GFX.dll	VideoMode	Offset	0x11258	"1 = GDI, 2 = Software, 3 = DirectDraw, 4 = Glide, 5 = OpenGL, 6 = Direct3D, 7 = Rave"	
 D2Glide.dll	DisplayHeight	Offset	0x15B04		
 D2Glide.dll	DisplayWidth	Offset	0x15A68		
 D2Lang.dll	CreateD2UnicodeChar	Ordinal	10000		

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -16,6 +16,7 @@ D2GDI.dll	BitBlockWidth	Offset	0xC970
 D2GDI.dll	CelDisplayLeft	Offset	0xCA94		
 D2GDI.dll	CelDisplayRight	Offset	0xCA98		
 D2GFX.dll	ResolutionMode	Offset	0x14A40	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
+D2GFX.dll	VideoMode	Offset	0x14A38	"1 = GDI, 2 = Software, 3 = DirectDraw, 4 = Glide, 5 = OpenGL, 6 = Direct3D, 7 = Rave"	
 D2Glide.dll	DisplayHeight	Offset	0x15B14		
 D2Glide.dll	DisplayWidth	Offset	0x15A78		
 D2Lang.dll	GetStringByIndex	Ordinal	10004		

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -16,6 +16,7 @@ D2GDI.dll	BitBlockWidth	Offset	0x3C01C0
 D2GDI.dll	CelDisplayLeft	Offset	0x5810F0		
 D2GDI.dll	CelDisplayRight	Offset	0x5810F4		
 D2GFX.dll	ResolutionMode	Offset	0x3BFD40	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
+D2GFX.dll	VideoMode	Offset	0x3BFD38	"1 = GDI, 2 = Software, 3 = DirectDraw, 4 = Glide, 5 = OpenGL, 6 = Direct3D, 7 = Rave"	
 D2Glide.dll	DisplayHeight	Offset	0x3C01C4		
 D2Glide.dll	DisplayWidth	Offset	0x3C01C0		
 D2Lang.dll	GetStringByIndex	Offset	0x121EE0		

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -16,6 +16,7 @@ D2GDI.dll	BitBlockWidth	Offset	0x3C9138
 D2GDI.dll	CelDisplayLeft	Offset	0x58A168		
 D2GDI.dll	CelDisplayRight	Offset	0x58A16C		
 D2GFX.dll	ResolutionMode	Offset	0x3C8CB8	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
+D2GFX.dll	VideoMode	Offset	0x3C8CB0	"1 = GDI, 2 = Software, 3 = DirectDraw, 4 = Glide, 5 = OpenGL, 6 = Direct3D, 7 = Rave"	
 D2Glide.dll	DisplayHeight	Offset	0x3C913C		
 D2Glide.dll	DisplayWidth	Offset	0x3C9138		
 D2Lang.dll	GetStringByIndex	Offset	0x124A30		


### PR DESCRIPTION
The variable is involved in the video mode of Diablo II. It is of type `int32_t`. The following value is used for this variable:
```
1 = Windowed Mode (GDI)
2 = Software
3 = DirectDraw
4 = Glide
5 = OpenGL
6 = Direct3D
7 = Rave
```

The variable can be located by scanning for the string `Error 21: A critical error has occurred while initializing windowed mode.` where the variable is used to determine which error string to display.

The following 1.10 screenshot shows the variable being used and all associated values. Note the first value is referred to as software, but it is used for GDI.
![D2GFX_VideoMode_00_(1 10)](https://user-images.githubusercontent.com/26683324/59897190-616b8e80-93a0-11e9-9a64-ae52e6d61e42.PNG)

The following 1.00 screenshot shows the variable being used in the context of an `int32_t`.
![D2GFX_VideoMode_01_(1 00)](https://user-images.githubusercontent.com/26683324/59897212-7e07c680-93a0-11e9-81d2-0455747fc9e7.PNG)

