### PR TITLE
Add D2Client ScreenShift

### DIFF
--- a/1.00.txt
+++ b/1.00.txt
@@ -7,7 +7,8 @@ D2Client.dll	IsGameMenuOpen	Offset	0x143660
 D2Client.dll	IsHelpScreenOpen	Offset	0x1436C0		
 D2Client.dll	IsNewSkillButtonPressed	Offset	0x13DDF8		
 D2Client.dll	IsNewStatsButtonPressed	Offset	0x13DDF4		
-D2Client.dll	ScreenXShift	Ordinal	0x1348AC		
+D2Client.dll	ScreenShiftX	N/A	N/A		
+D2Client.dll	ScreenShiftY	N/A	N/A		
 D2DDraw.dll	DisplayHeight	Offset	0x190D0		
 D2DDraw.dll	DisplayWidth	Offset	0x190D8		
 D2Direct3D.dll	DisplayHeight	Offset	0x26930		

--- a/1.03.txt
+++ b/1.03.txt
@@ -7,6 +7,8 @@ D2Client.dll	IsGameMenuOpen	Offset	0x143530
 D2Client.dll	IsHelpScreenOpen	Offset	0x143590		
 D2Client.dll	IsNewSkillButtonPressed	Offset	0x13DB30		
 D2Client.dll	IsNewStatsButtonPressed	Offset	0x13DB2C		
+D2Client.dll	ScreenShiftX	N/A	N/A		
+D2Client.dll	ScreenShiftY	N/A	N/A		
 D2DDraw.dll	DisplayHeight	Offset	0x190D0		
 D2DDraw.dll	DisplayWidth	Offset	0x190D8		
 D2Direct3D.dll	DisplayHeight	Offset	0x26930		

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -7,6 +7,8 @@ D2Client.dll	IsGameMenuOpen	Offset	0xF4D98
 D2Client.dll	IsHelpScreenOpen	Offset	0xF4DF8		
 D2Client.dll	IsNewSkillButtonPressed	Offset	0xF01F8		
 D2Client.dll	IsNewStatsButtonPressed	Offset	0xF01F4		
+D2Client.dll	ScreenShiftX	N/A	N/A		
+D2Client.dll	ScreenShiftY	N/A	N/A		
 D2DDraw.dll	DisplayHeight	Offset	0x116F8		
 D2DDraw.dll	DisplayWidth	Offset	0x11700		
 D2Direct3D.dll	DisplayHeight	Offset	0x1A708		

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -7,6 +7,8 @@ D2Client.dll	IsGameMenuOpen	Offset	0x1248D8
 D2Client.dll	IsHelpScreenOpen	Offset	0x124938		
 D2Client.dll	IsNewSkillButtonPressed	Offset	0x11FE88		
 D2Client.dll	IsNewStatsButtonPressed	Offset	0x11FE84		
+D2Client.dll	ScreenShiftX	Offset	0x124954		
+D2Client.dll	ScreenShiftY	Offset	0x124958		
 D2DDraw.dll	DisplayHeight	Offset	0x11768		
 D2DDraw.dll	DisplayWidth	Offset	0x11770		
 D2Direct3D.dll	DisplayHeight	Offset	0x1B708		

--- a/1.10.txt
+++ b/1.10.txt
@@ -7,6 +7,8 @@ D2Client.dll	IsGameMenuOpen	Offset	0x11A6CC
 D2Client.dll	IsHelpScreenOpen	Offset	0x11A72C		
 D2Client.dll	IsNewSkillButtonPressed	Offset	0x115BC0		
 D2Client.dll	IsNewStatsButtonPressed	Offset	0x115BBC		
+D2Client.dll	ScreenShiftX	Offset	0x11A748		
+D2Client.dll	ScreenShiftY	Offset	0x11A74C		
 D2DDraw.dll	DisplayHeight	Offset	0x117A8		
 D2DDraw.dll	DisplayWidth	Offset	0x117B0		
 D2Direct3D.dll	DisplayHeight	Offset	0x1A7AC		

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -7,6 +7,8 @@ D2Client.dll	IsGameMenuOpen	Offset	0x102B7C
 D2Client.dll	IsHelpScreenOpen	Offset	0x102BDC		
 D2Client.dll	IsNewSkillButtonPressed	Offset	0x11C348		
 D2Client.dll	IsNewStatsButtonPressed	Offset	0x11C344		
+D2Client.dll	ScreenShiftX	Offset	0x11BD28		
+D2Client.dll	ScreenShiftY	Offset	0x11BD2C		
 D2DDraw.dll	DisplayHeight	Offset	0xFDCC		
 D2DDraw.dll	DisplayWidth	Offset	0xFDD4		
 D2Direct3D.dll	DisplayHeight	Offset	0x196F4		

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -8,6 +8,8 @@ D2Client.dll	IsHelpScreenOpen	Offset	0xFAE04
 D2Client.dll	ScreenXShift	Offset	0x11C418		
 D2Client.dll	IsNewSkillButtonPressed	Offset	0x11C30C		
 D2Client.dll	IsNewStatsButtonPressed	Offset	0x11C308		
+D2Client.dll	ScreenShiftX	Offset	0x11B9A0		
+D2Client.dll	ScreenShiftY	Offset	0x11B9A4		
 D2DDraw.dll	DisplayHeight	Offset	0x101CC		
 D2DDraw.dll	DisplayWidth	Offset	0x101D4		
 D2Direct3D.dll	DisplayHeight	Offset	0x1AFD4		

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -7,6 +7,8 @@ D2Client.dll	IsGameMenuOpen	Offset	0x11C8B4
 D2Client.dll	IsHelpScreenOpen	Offset	0x11C914		
 D2Client.dll	IsNewSkillButtonPressed	Offset	0x11D31C		
 D2Client.dll	IsNewStatsButtonPressed	Offset	0x11D318		
+D2Client.dll	ScreenShiftX	Offset	0x11D354		
+D2Client.dll	ScreenShiftY	Offset	0x11D358		
 D2DDraw.dll	DisplayHeight	Offset	0x100DC		
 D2DDraw.dll	DisplayWidth	Offset	0x100E4		
 D2Direct3D.dll	DisplayHeight	Offset	0x32DFC		

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -7,6 +7,8 @@ D2Client.dll	IsGameMenuOpen	Offset	0x39986C
 D2Client.dll	IsHelpScreenOpen	Offset	0x3998CC		
 D2Client.dll	IsNewSkillButtonPressed	Offset	0x3B7370		
 D2Client.dll	IsNewStatsButtonPressed	Offset	0x3B736C		
+D2Client.dll	ScreenShiftX	Offset	0x3998E0		
+D2Client.dll	ScreenShiftY	Offset	0x3998E4		
 D2DDraw.dll	DisplayHeight	Offset	0x4782DC		
 D2DDraw.dll	DisplayWidth	Offset	0x4782E0		
 D2Direct3D.dll	DisplayHeight	Offset	0x3C01C4		

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -7,6 +7,8 @@ D2Client.dll	IsGameMenuOpen	Offset	0x3A27E4
 D2Client.dll	IsHelpScreenOpen	Offset	0x3A2844		
 D2Client.dll	IsNewSkillButtonPressed	Offset	0x3C02E8		
 D2Client.dll	IsNewStatsButtonPressed	Offset	0x3C02E4		
+D2Client.dll	ScreenShiftX	Offset	0x3A2858		
+D2Client.dll	ScreenShiftY	Offset	0x3A285C		
 D2DDraw.dll	DisplayHeight	Offset	0x481254		
 D2DDraw.dll	DisplayWidth	Offset	0x481258		
 D2Direct3D.dll	DisplayHeight	Offset	0x3C913C		


### PR DESCRIPTION
The variables are involved in the shifting of the Inventory Screen, Vendor Screen, Skill Tree Screen, and other screens that open on the left or right side and cover half of the screen. They are both of type `int32_t`.

The variables can be located by repeatedly changing the ingame resolution from 640x480 to 800x600. In 640x480, the screen shift is (0, 0). In 800x600, the screen shift is (80, -60). These variables are not available prior to 1.07.

The following 1.09D screenshot shows the variables being modified.
![D2Client_ScreenShift_01_(1 09D)](https://user-images.githubusercontent.com/26683324/59970670-3f4d4a00-9521-11e9-80b1-83bc379e44e0.png)

The following 1.09D screenshots show the effects of the variables in 640x480, then 800x600 mode.
![D2Client_ScreenShift_02_(1 09D)](https://user-images.githubusercontent.com/26683324/59970681-6efc5200-9521-11e9-938b-4a8a2f7f8cbe.jpg)

![D2Client_ScreenShift_03_(1 09D)](https://user-images.githubusercontent.com/26683324/59970682-74f23300-9521-11e9-8b12-abd90e6527c6.jpg)

The following 1.00 screenshot explains the reason for the chosen name for this variable. Look close to where the mouse cursor is positioned.
![D2Client_ScreenShift_04_(1 00)](https://user-images.githubusercontent.com/26683324/59970683-7c194100-9521-11e9-87ed-1bfe62e66880.jpg)

