### PR TITLE
Add D2CMP CloseCelFile

### DIFF
--- a/1.00.txt
+++ b/1.00.txt
@@ -9,6 +9,7 @@ D2Client.dll	IsNewSkillButtonPressed	Offset	0x13DDF8
 D2Client.dll	IsNewStatsButtonPressed	Offset	0x13DDF4		
 D2Client.dll	ScreenShiftX	N/A	N/A		
 D2Client.dll	ScreenShiftY	N/A	N/A		
+D2CMP.dll	CloseCelFile	Ordinal	10032		
 D2DDraw.dll	DisplayHeight	Offset	0x190D0		
 D2DDraw.dll	DisplayWidth	Offset	0x190D8		
 D2Direct3D.dll	DisplayHeight	Offset	0x26930		

--- a/1.03.txt
+++ b/1.03.txt
@@ -9,6 +9,7 @@ D2Client.dll	IsNewSkillButtonPressed	Offset	0x13DB30
 D2Client.dll	IsNewStatsButtonPressed	Offset	0x13DB2C		
 D2Client.dll	ScreenShiftX	N/A	N/A		
 D2Client.dll	ScreenShiftY	N/A	N/A		
+D2CMP.dll	CloseCelFile	Ordinal	10032		
 D2DDraw.dll	DisplayHeight	Offset	0x190D0		
 D2DDraw.dll	DisplayWidth	Offset	0x190D8		
 D2Direct3D.dll	DisplayHeight	Offset	0x26930		

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -9,6 +9,7 @@ D2Client.dll	IsNewSkillButtonPressed	Offset	0xF01F8
 D2Client.dll	IsNewStatsButtonPressed	Offset	0xF01F4		
 D2Client.dll	ScreenShiftX	N/A	N/A		
 D2Client.dll	ScreenShiftY	N/A	N/A		
+D2CMP.dll	CloseCelFile	Ordinal	10032		
 D2DDraw.dll	DisplayHeight	Offset	0x116F8		
 D2DDraw.dll	DisplayWidth	Offset	0x11700		
 D2Direct3D.dll	DisplayHeight	Offset	0x1A708		

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -9,6 +9,7 @@ D2Client.dll	IsNewSkillButtonPressed	Offset	0x11FE88
 D2Client.dll	IsNewStatsButtonPressed	Offset	0x11FE84		
 D2Client.dll	ScreenShiftX	Offset	0x124954		
 D2Client.dll	ScreenShiftY	Offset	0x124958		
+D2CMP.dll	CloseCelFile	Ordinal	10032		
 D2DDraw.dll	DisplayHeight	Offset	0x11768		
 D2DDraw.dll	DisplayWidth	Offset	0x11770		
 D2Direct3D.dll	DisplayHeight	Offset	0x1B708		

--- a/1.10.txt
+++ b/1.10.txt
@@ -9,6 +9,7 @@ D2Client.dll	IsNewSkillButtonPressed	Offset	0x115BC0
 D2Client.dll	IsNewStatsButtonPressed	Offset	0x115BBC		
 D2Client.dll	ScreenShiftX	Offset	0x11A748		
 D2Client.dll	ScreenShiftY	Offset	0x11A74C		
+D2CMP.dll	CloseCelFile	Ordinal	10032		
 D2DDraw.dll	DisplayHeight	Offset	0x117A8		
 D2DDraw.dll	DisplayWidth	Offset	0x117B0		
 D2Direct3D.dll	DisplayHeight	Offset	0x1A7AC		

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -9,6 +9,7 @@ D2Client.dll	IsNewSkillButtonPressed	Offset	0x11C348
 D2Client.dll	IsNewStatsButtonPressed	Offset	0x11C344		
 D2Client.dll	ScreenShiftX	Offset	0x11BD28		
 D2Client.dll	ScreenShiftY	Offset	0x11BD2C		
+D2CMP.dll	CloseCelFile	Ordinal	10106		
 D2DDraw.dll	DisplayHeight	Offset	0xFDCC		
 D2DDraw.dll	DisplayWidth	Offset	0xFDD4		
 D2Direct3D.dll	DisplayHeight	Offset	0x196F4		

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -10,6 +10,7 @@ D2Client.dll	IsNewSkillButtonPressed	Offset	0x11C30C
 D2Client.dll	IsNewStatsButtonPressed	Offset	0x11C308		
 D2Client.dll	ScreenShiftX	Offset	0x11B9A0		
 D2Client.dll	ScreenShiftY	Offset	0x11B9A4		
+D2CMP.dll	CloseCelFile	Ordinal	10065		
 D2DDraw.dll	DisplayHeight	Offset	0x101CC		
 D2DDraw.dll	DisplayWidth	Offset	0x101D4		
 D2Direct3D.dll	DisplayHeight	Offset	0x1AFD4		

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -9,6 +9,7 @@ D2Client.dll	IsNewSkillButtonPressed	Offset	0x11D31C
 D2Client.dll	IsNewStatsButtonPressed	Offset	0x11D318		
 D2Client.dll	ScreenShiftX	Offset	0x11D354		
 D2Client.dll	ScreenShiftY	Offset	0x11D358		
+D2CMP.dll	CloseCelFile	Ordinal	10020		
 D2DDraw.dll	DisplayHeight	Offset	0x100DC		
 D2DDraw.dll	DisplayWidth	Offset	0x100E4		
 D2Direct3D.dll	DisplayHeight	Offset	0x32DFC		

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -9,6 +9,7 @@ D2Client.dll	IsNewSkillButtonPressed	Offset	0x3B7370
 D2Client.dll	IsNewStatsButtonPressed	Offset	0x3B736C		
 D2Client.dll	ScreenShiftX	Offset	0x3998E0		
 D2Client.dll	ScreenShiftY	Offset	0x3998E4		
+D2CMP.dll	CloseCelFile	Offset	0x200820		
 D2DDraw.dll	DisplayHeight	Offset	0x4782DC		
 D2DDraw.dll	DisplayWidth	Offset	0x4782E0		
 D2Direct3D.dll	DisplayHeight	Offset	0x3C01C4		

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -9,6 +9,7 @@ D2Client.dll	IsNewSkillButtonPressed	Offset	0x3C02E8
 D2Client.dll	IsNewStatsButtonPressed	Offset	0x3C02E4		
 D2Client.dll	ScreenShiftX	Offset	0x3A2858		
 D2Client.dll	ScreenShiftY	Offset	0x3A285C		
+D2CMP.dll	CloseCelFile	Offset	0x201A50		
 D2DDraw.dll	DisplayHeight	Offset	0x481254		
 D2DDraw.dll	DisplayWidth	Offset	0x481258		
 D2Direct3D.dll	DisplayHeight	Offset	0x3C913C		


### PR DESCRIPTION
The function closes a specified `CelFile`. The return value is a `bool32_t` to indicate success.

The function can be located inside of the function [D2Win UnloadCelFile](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/29), or in the case of version 1.11 - 1.13D, the `CelFile` unloading routines. The function is called right before a call to [Fog FreeClientMemory](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/19).

## Function Definitions
### All Versions
```C
bool32_t D2CMP_CloseCelFile(CelFile* cel_file)
```
- All parameters on the stack
  - Callee cleans the stack

The following 1.00 screenshots show the single parameter of the function.
![D2CMP_UnloadCelFile_01_(1 00)](https://user-images.githubusercontent.com/26683324/59990054-89ecc600-95f6-11e9-9af9-35244e80d1d8.PNG)
![D2CMP_CloseCelFile_01_(1 00)](https://user-images.githubusercontent.com/26683324/59990036-7ccfd700-95f6-11e9-92fe-3397d6889f73.PNG)
![D2CMP_CloseCelFile_02_(1 00)](https://user-images.githubusercontent.com/26683324/59990085-b274c000-95f6-11e9-8063-04c5f214672b.PNG)

The two following 1.00 screenshots show that the return type is `bool32_t`. The screenshots also show the cleanup convention of the function.
![D2CMP_CloseCelFile_03_(1 00)](https://user-images.githubusercontent.com/26683324/59990066-9c66ff80-95f6-11e9-995c-d4b29b1cbfef.PNG)
![D2CMP_CloseCelFile_04_(1 00)](https://user-images.githubusercontent.com/26683324/59990067-9cff9600-95f6-11e9-966f-96ad9bcf03be.PNG)
