### PR TITLE
Add D2Win LoadCelFile

### DIFF
--- a/1.00.txt
+++ b/1.00.txt
@@ -44,6 +44,7 @@ D2Lang.dll	Unicode_tolower	Offset	0x1014	?toLower@Unicode@@QBE?AU1@XZ	Unicode::t
 D2Lang.dll	Unicode_toupper	Offset	0x1154		Unicode::toUpper
 D2Lang.dll	UnicodeString_NCompareIgnoreCase	Offset	0x1091	?strnicmp@Unicode@@SIHPBU1@0I@Z	Unicode::strnicmp
 D2Lang.dll	UnloadSysMap	Offset	0x104B	?unloadSysMap@Unicode@@SIXXZ	Unicode::unloadSysMap
+D2Win.dll	LoadCelFile	Ordinal	10035
 D2Win.dll	LoadMPQ	Offset	0x1458A		
 D2Win.dll	MainMenuMousePositionX	Offset	0x72A90		
 D2Win.dll	MainMenuMousePositionY	Offset	0x72A94		

--- a/1.03.txt
+++ b/1.03.txt
@@ -27,6 +27,7 @@ D2Lang.dll	Unicode_strcat	Offset	0x10B4		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x1055	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x1014	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x1154		Unicode::toUpper
+D2Win.dll	LoadCelFile	Ordinal	10035
 D2Win.dll	LoadMPQ	Offset	0x146FA		
 D2Win.dll	MainMenuMousePositionX	Offset	0x72A98		
 D2Win.dll	MainMenuMousePositionY	Offset	0x72A9C		

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -27,6 +27,7 @@ D2Lang.dll	Unicode_strcat	Offset	0x13A0		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x1490	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10E0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10B0		Unicode::toUpper
+D2Win.dll	LoadCelFile	Ordinal	10035
 D2Win.dll	LoadMPQ	Offset	0x10595		
 D2Win.dll	MainMenuMousePositionX	Offset	0x5BCB8		
 D2Win.dll	MainMenuMousePositionY	Offset	0x5BCBC		

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -27,6 +27,7 @@ D2Lang.dll	Unicode_strcat	Offset	0x13A0		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x1490	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10E0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10B0		Unicode::toUpper
+D2Win.dll	LoadCelFile	Ordinal	10039
 D2Win.dll	LoadMPQ	Offset	0x142FB		
 D2Win.dll	MainMenuMousePositionX	Offset	0x618A0		
 D2Win.dll	MainMenuMousePositionY	Offset	0x618A4		

--- a/1.10.txt
+++ b/1.10.txt
@@ -27,6 +27,7 @@ D2Lang.dll	Unicode_strcat	Offset	0x13F0		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x14C0	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10E0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10B0		Unicode::toUpper
+D2Win.dll	LoadCelFile	Ordinal	10039
 D2Win.dll	LoadMPQ	Offset	0x12399		
 D2Win.dll	MainMenuMousePositionX	Offset	0x5E234		
 D2Win.dll	MainMenuMousePositionY	Offset	0x5E238		

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -27,6 +27,7 @@ D2Lang.dll	Unicode_strcat	Offset	0xA610		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0xA6E0	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10C0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10A0		Unicode::toUpper
+D2Win.dll	LoadCelFile	Ordinal	10186
 D2Win.dll	LoadMPQ	Offset	0x7E40		
 D2Win.dll	MainMenuMousePositionX	Offset	0x5C700		
 D2Win.dll	MainMenuMousePositionY	Offset	0x5C704		

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -30,6 +30,7 @@ D2Lang.dll	Unicode_strcat	Offset	0xAFE0		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0xB0B0	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10C0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10A0		Unicode::toUpper
+D2Win.dll	LoadCelFile	Ordinal	10111
 D2Win.dll	LoadMPQ	Offset	0x7E60		
 D2Win.dll	MainMenuMousePositionX	Offset	0x21488		
 D2Win.dll	MainMenuMousePositionY	Offset	0x2148C		

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -27,6 +27,7 @@ D2Lang.dll	Unicode_strcat	Offset	0x8B90		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x8C60	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10C0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10A0		Unicode::toUpper
+D2Win.dll	LoadCelFile	Ordinal	10023
 D2Win.dll	LoadMPQ	Offset	0x7E50		
 D2Win.dll	MainMenuMousePositionX	Offset	0x8DB1C		
 D2Win.dll	MainMenuMousePositionY	Offset	0x8DB20		

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -27,6 +27,7 @@ D2Lang.dll	Unicode_strcat	Offset	0x123C50		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x123D50	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0xADD70	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x29E40		Unicode::toUpper
+D2Win.dll	LoadCelFile	Offset	0xF7F80
 D2Win.dll	LoadMPQ	Offset	0x114FF7		
 D2Win.dll	MainMenuMousePositionX	Offset	0x3CC62C		
 D2Win.dll	MainMenuMousePositionY	Offset	0x3CC630		

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -27,6 +27,7 @@ D2Lang.dll	Unicode_strcat	Offset	0x126700		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x126800	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0xB15F3	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x2E650		Unicode::toUpper
+D2Win.dll	LoadCelFile	Offset	0xFA9B0
 D2Win.dll	LoadMPQ	Offset	0x117332		
 D2Win.dll	MainMenuMousePositionX	Offset	0x3D55A4		
 D2Win.dll	MainMenuMousePositionY	Offset	0x3D55A8		


### PR DESCRIPTION
The function loads a specified `CelFile` into the game so that it may be used. This `CelFile` may be specified to be a `DCC` file or a `DC6` file. It returns a pointer to the `CelFile`. The `CelFile` must be deconstructed and deallocated using [D2Win UnloadCelFile](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/29).

The function can be located by scanning for the string `%s\UI\CURSOR\Pentspin` in non-writable regions and getting the address of the string. Afterwards, use the address of the string in another scan in non-writable regions to get all executable code that references that address.

## Function Definitions
### All Versions
```C
CelFile* D2Win_LoadCelFile(
  const char* cel_file_path,
  bool32_t is_dcc_else_dc6
);
```
- `cel_file_path` in ecx
- `cel_file_type` in edx

The following 1.00 screenshot shows the calling convention of the function, the number of parameters, and the return type.
![D2Win_LoadCelFile_01_(1 00)](https://user-images.githubusercontent.com/26683324/60149896-42e40980-978b-11e9-8318-2da7d9ca6183.PNG)

The following 1.10 screenshot shows that `is_dcc_else_dc6` is a `bool32_t`.
![D2CMP_GetFileExtensionByType_01_(1 10)](https://user-images.githubusercontent.com/26683324/60149910-52635280-978b-11e9-877d-919f8ad2cfd8.PNG)
