### PR TITLE
Add D2Win UnloadCelFile

### DIFF
--- a/1.00.txt
+++ b/1.00.txt
@@ -44,10 +44,11 @@ D2Lang.dll	Unicode_tolower	Offset	0x1014	?toLower@Unicode@@QBE?AU1@XZ	Unicode::t
 D2Lang.dll	Unicode_toupper	Offset	0x1154		Unicode::toUpper
 D2Lang.dll	UnicodeString_NCompareIgnoreCase	Offset	0x1091	?strnicmp@Unicode@@SIHPBU1@0I@Z	Unicode::strnicmp
 D2Lang.dll	UnloadSysMap	Offset	0x104B	?unloadSysMap@Unicode@@SIXXZ	Unicode::unloadSysMap
-D2Win.dll	LoadCelFile	Ordinal	10035
+D2Win.dll	LoadCelFile	Ordinal	10035		
 D2Win.dll	LoadMPQ	Offset	0x1458A		
 D2Win.dll	MainMenuMousePositionX	Offset	0x72A90		
 D2Win.dll	MainMenuMousePositionY	Offset	0x72A94		
+D2Win.dll	UnloadCelFile	Ordinal	10037		
 D2Win.dll	UnloadMPQ	Offset	0x14729		
 Fog.dll	AllocClientMemory	Ordinal	10033		
 Fog.dll	FreeClientMemory	Ordinal	10034		

--- a/1.03.txt
+++ b/1.03.txt
@@ -27,10 +27,11 @@ D2Lang.dll	Unicode_strcat	Offset	0x10B4		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x1055	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x1014	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x1154		Unicode::toUpper
-D2Win.dll	LoadCelFile	Ordinal	10035
+D2Win.dll	LoadCelFile	Ordinal	10035		
 D2Win.dll	LoadMPQ	Offset	0x146FA		
 D2Win.dll	MainMenuMousePositionX	Offset	0x72A98		
 D2Win.dll	MainMenuMousePositionY	Offset	0x72A9C		
+D2Win.dll	UnloadCelFile	Ordinal	10037		
 D2Win.dll	UnloadMPQ	Offset	0x148A7		
 Fog.dll	AllocClientMemory	Ordinal	10033		
 Fog.dll	FreeClientMemory	Ordinal	10034		

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -27,10 +27,11 @@ D2Lang.dll	Unicode_strcat	Offset	0x13A0		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x1490	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10E0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10B0		Unicode::toUpper
-D2Win.dll	LoadCelFile	Ordinal	10035
+D2Win.dll	LoadCelFile	Ordinal	10035		
 D2Win.dll	LoadMPQ	Offset	0x10595		
 D2Win.dll	MainMenuMousePositionX	Offset	0x5BCB8		
 D2Win.dll	MainMenuMousePositionY	Offset	0x5BCBC		
+D2Win.dll	UnloadCelFile	Ordinal	10037		
 D2Win.dll	UnloadMPQ	Offset	0x10742		
 Fog.dll	AllocClientMemory	Ordinal	10033		
 Fog.dll	FreeClientMemory	Ordinal	10034		

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -27,10 +27,11 @@ D2Lang.dll	Unicode_strcat	Offset	0x13A0		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x1490	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10E0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10B0		Unicode::toUpper
-D2Win.dll	LoadCelFile	Ordinal	10039
+D2Win.dll	LoadCelFile	Ordinal	10039		
 D2Win.dll	LoadMPQ	Offset	0x142FB		
 D2Win.dll	MainMenuMousePositionX	Offset	0x618A0		
 D2Win.dll	MainMenuMousePositionY	Offset	0x618A4		
+D2Win.dll	UnloadCelFile	Ordinal	10041		
 D2Win.dll	UnloadMPQ	Offset	0x144A6		
 Fog.dll	AllocClientMemory	Ordinal	10042		
 Fog.dll	FreeClientMemory	Ordinal	10043		

--- a/1.10.txt
+++ b/1.10.txt
@@ -27,10 +27,11 @@ D2Lang.dll	Unicode_strcat	Offset	0x13F0		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x14C0	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10E0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10B0		Unicode::toUpper
-D2Win.dll	LoadCelFile	Ordinal	10039
+D2Win.dll	LoadCelFile	Ordinal	10039		
 D2Win.dll	LoadMPQ	Offset	0x12399		
 D2Win.dll	MainMenuMousePositionX	Offset	0x5E234		
 D2Win.dll	MainMenuMousePositionY	Offset	0x5E238		
+D2Win.dll	UnloadCelFile	Ordinal	10041		
 D2Win.dll	UnloadMPQ	Offset	0x12548		
 Fog.dll	AllocClientMemory	Ordinal	10042		
 Fog.dll	FreeClientMemory	Ordinal	10043		

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -27,10 +27,11 @@ D2Lang.dll	Unicode_strcat	Offset	0xA610		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0xA6E0	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10C0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10A0		Unicode::toUpper
-D2Win.dll	LoadCelFile	Ordinal	10186
+D2Win.dll	LoadCelFile	Ordinal	10186		
 D2Win.dll	LoadMPQ	Offset	0x7E40		
 D2Win.dll	MainMenuMousePositionX	Offset	0x5C700		
 D2Win.dll	MainMenuMousePositionY	Offset	0x5C704		
+D2Win.dll	UnloadCelFile	N/A	N/A		
 D2Win.dll	UnloadMPQ	N/A	N/A		
 Fog.dll	AllocClientMemory	Ordinal	10042		
 Fog.dll	FreeClientMemory	Ordinal	10043		

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -30,10 +30,11 @@ D2Lang.dll	Unicode_strcat	Offset	0xAFE0		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0xB0B0	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10C0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10A0		Unicode::toUpper
-D2Win.dll	LoadCelFile	Ordinal	10111
+D2Win.dll	LoadCelFile	Ordinal	10111		
 D2Win.dll	LoadMPQ	Offset	0x7E60		
 D2Win.dll	MainMenuMousePositionX	Offset	0x21488		
 D2Win.dll	MainMenuMousePositionY	Offset	0x2148C		
+D2Win.dll	UnloadCelFile	N/A	N/A		
 D2Win.dll	UnloadMPQ	N/A	N/A		
 Fog.dll	AllocClientMemory	Ordinal	10042		
 Fog.dll	FreeClientMemory	Ordinal	10043		

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -27,10 +27,11 @@ D2Lang.dll	Unicode_strcat	Offset	0x8B90		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x8C60	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10C0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10A0		Unicode::toUpper
-D2Win.dll	LoadCelFile	Ordinal	10023
+D2Win.dll	LoadCelFile	Ordinal	10023		
 D2Win.dll	LoadMPQ	Offset	0x7E50		
 D2Win.dll	MainMenuMousePositionX	Offset	0x8DB1C		
 D2Win.dll	MainMenuMousePositionY	Offset	0x8DB20		
+D2Win.dll	UnloadCelFile	N/A	N/A		
 D2Win.dll	UnloadMPQ	N/A	N/A		
 Fog.dll	AllocClientMemory	Ordinal	10042		
 Fog.dll	FreeClientMemory	Ordinal	10043		

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -27,10 +27,11 @@ D2Lang.dll	Unicode_strcat	Offset	0x123C50		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x123D50	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0xADD70	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x29E40		Unicode::toUpper
-D2Win.dll	LoadCelFile	Offset	0xF7F80
+D2Win.dll	LoadCelFile	Offset	0xF7F80		
 D2Win.dll	LoadMPQ	Offset	0x114FF7		
 D2Win.dll	MainMenuMousePositionX	Offset	0x3CC62C		
 D2Win.dll	MainMenuMousePositionY	Offset	0x3CC630		
+D2Win.dll	UnloadCelFile	Offset	0xF80B0		
 D2Win.dll	UnloadMPQ	Offset	0x115071		
 Fog.dll	AllocClientMemory	Offset	0x6B90		
 Fog.dll	FreeClientMemory	Offset	0x6BD0		

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -27,10 +27,11 @@ D2Lang.dll	Unicode_strcat	Offset	0x126700		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x126800	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0xB15F3	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x2E650		Unicode::toUpper
-D2Win.dll	LoadCelFile	Offset	0xFA9B0
+D2Win.dll	LoadCelFile	Offset	0xFA9B0		
 D2Win.dll	LoadMPQ	Offset	0x117332		
 D2Win.dll	MainMenuMousePositionX	Offset	0x3D55A4		
 D2Win.dll	MainMenuMousePositionY	Offset	0x3D55A8		
+D2Win.dll	UnloadCelFile	Offset	0xFAAE0		
 D2Win.dll	UnloadMPQ	Offset	0x1173AC		
 Fog.dll	AllocClientMemory	Offset	0xB380		
 Fog.dll	FreeClientMemory	Offset	0xB3C0		


### PR DESCRIPTION
The function unloads the specified `CelFile`. It may return a value of 1, as a consequence of calling [Fog FreeClientMemory](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/19). The return value is therefore left defined as void.

The function is located similar in vein to [D2Win LoadCelFile](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/28). Scan for regions of memory that modify the `CelFile` storing the pentagram data. The function prior to the line of code that sets the pointer to the `CelFile` to `nullptr` is the desired function.

In versions 1.11 - 1.13D (inclusive), the function had become inline optimized and cannot be called. Therefore, the function must be reconstructed for those versions.

## Function Definitions
### All Versions (except 1.11 - 1.13D (inclusive))
```C
void D2Win_UnloadCelFile(CelFile* cel_file)
```
- `cel_file` in ecx

## Screenshots
The following 1.00 screenshot shows the function's parameter and calling convention.
![D2Win_UnloadCelFile_01_(1 00)](https://user-images.githubusercontent.com/26683324/60388851-2e925c00-9a6c-11e9-87dc-a6cb43ba2b83.PNG)

The following 1.00 screenshot shows the function in its entirety, the calling convention, the parameter types, and the cleanup convention.
![D2Win_UnloadCelFile_02_(1 00)](https://user-images.githubusercontent.com/26683324/60388857-49fd6700-9a6c-11e9-96c1-84a6ef1c5674.PNG)

The following 1.12A screenshot shows that the function has been optimized away.
![D2Win_UnloadCelFile_03_(1 12A)](https://user-images.githubusercontent.com/26683324/60389364-f04d6a80-9a74-11e9-8a18-bed0ece88193.PNG)
