### PR TITLE
Add D2Client GeneralDisplayWidth and GeneralDisplayHeight

### DIFF
--- a/1.00.txt
+++ b/1.00.txt
@@ -1,5 +1,7 @@
 Library	Name	Locator Type	Locator Value	Comments	
 D2Client.dll	DifficultyLevel	Offset	0x12EDDC	nDifficultyLevel	
+D2Client.dll	GeneralDisplayHeight	Offset	0x1681A4		
+D2Client.dll	GeneralDisplayWidth	Offset	0x1681A8		
 D2Client.dll	IngameMousePositionX	Offset	0x11AFF8		
 D2Client.dll	IngameMousePositionY	Offset	0x11AFFC		
 D2Client.dll	IsAutomapOpen	Offset	0x143664		

--- a/1.03.txt
+++ b/1.03.txt
@@ -1,5 +1,7 @@
 Library	Name	Locator Type	Locator Value	Comments	
 D2Client.dll	DifficultyLevel	Offset	0x12EAC4	nDifficultyLevel	
+D2Client.dll	GeneralDisplayHeight	Offset	0x1680AC		
+D2Client.dll	GeneralDisplayWidth	Offset	0x1680B0		
 D2Client.dll	IngameMousePositionX	Offset	0x11ACA0		
 D2Client.dll	IngameMousePositionY	Offset	0x11ACA4		
 D2Client.dll	IsAutomapOpen	Offset	0x143534		

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -1,5 +1,7 @@
 Library	Name	Locator Type	Locator Value	Comments	
 D2Client.dll	DifficultyLevel	Offset	0xE3024	nDifficultyLevel	
+D2Client.dll	GeneralDisplayHeight	Offset	0xFB594		
+D2Client.dll	GeneralDisplayWidth	Offset	0xFB598		
 D2Client.dll	IngameMousePositionX	Offset	0xD19A8		
 D2Client.dll	IngameMousePositionY	Offset	0xD19AC		
 D2Client.dll	IsAutomapOpen	Offset	0xF4D9C		

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -1,5 +1,7 @@
 Library	Name	Locator Type	Locator Value	Comments	
 D2Client.dll	DifficultyLevel	Offset	0x110BBC	nDifficultyLevel	
+D2Client.dll	GeneralDisplayHeight	Offset	0xD40E0		
+D2Client.dll	GeneralDisplayWidth	Offset	0xD40DC		
 D2Client.dll	IngameMousePositionX	Offset	0x12B168		
 D2Client.dll	IngameMousePositionY	Offset	0x12B16C		
 D2Client.dll	IsAutomapOpen	Offset	0x1248DC		

--- a/1.10.txt
+++ b/1.10.txt
@@ -1,5 +1,7 @@
 Library	Name	Locator Type	Locator Value	Comments	
 D2Client.dll	DifficultyLevel	Offset	0x10795C	nDifficultyLevel	
+D2Client.dll	GeneralDisplayHeight	Offset	0xD40F0		
+D2Client.dll	GeneralDisplayWidth	Offset	0xD40EC		
 D2Client.dll	IngameMousePositionX	Offset	0x121AE4		
 D2Client.dll	IngameMousePositionY	Offset	0x121AE8		
 D2Client.dll	IsAutomapOpen	Offset	0x11A6D0		

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -1,5 +1,7 @@
 Library	Name	Locator Type	Locator Value	Comments	
 D2Client.dll	DifficultyLevel	Offset	0x11BFF4	nDifficultyLevel	
+D2Client.dll	GeneralDisplayHeight	Offset	0xDC6E4		
+D2Client.dll	GeneralDisplayWidth	Offset	0xDC6E0		
 D2Client.dll	IngameMousePositionX	Offset	0x101638		
 D2Client.dll	IngameMousePositionY	Offset	0x101634		
 D2Client.dll	IsAutomapOpen	Offset	0x102B80		

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -1,5 +1,7 @@
 Library	Name	Locator Type	Locator Value	Comments	
 D2Client.dll	DifficultyLevel	Offset	0x11C390	nDifficultyLevel	
+D2Client.dll	GeneralDisplayHeight	Offset	0xDBC4C		
+D2Client.dll	GeneralDisplayWidth	Offset	0xDBC48		
 D2Client.dll	IngameMousePositionX	Offset	0x11B828		
 D2Client.dll	IngameMousePositionY	Offset	0x11B824		
 D2Client.dll	IsAutomapOpen	Offset	0xFADA8		

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -1,5 +1,7 @@
 Library	Name	Locator Type	Locator Value	Comments	
 D2Client.dll	DifficultyLevel	Offset	0x11D1D8	nDifficultyLevel	
+D2Client.dll	GeneralDisplayHeight	Offset	0xF7038		
+D2Client.dll	GeneralDisplayWidth	Offset	0xF7034		
 D2Client.dll	IngameMousePositionX	Offset	0x11C950		
 D2Client.dll	IngameMousePositionY	Offset	0x11C94C		
 D2Client.dll	IsAutomapOpen	Offset	0x11C8B8		

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -1,5 +1,7 @@
 Library	Name	Locator Type	Locator Value	Comments	
 D2Client.dll	DifficultyLevel	Offset	0x397694	nDifficultyLevel	
+D2Client.dll	GeneralDisplayHeight	Offset	0x30FF4C		
+D2Client.dll	GeneralDisplayWidth	Offset	0x30FF48		
 D2Client.dll	IngameMousePositionX	Offset	0x39DB38		
 D2Client.dll	IngameMousePositionY	Offset	0x39DB34		
 D2Client.dll	IsAutomapOpen	Offset	0x399870		

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -1,5 +1,7 @@
 Library	Name	Locator Type	Locator Value	Comments	
 D2Client.dll	DifficultyLevel	Offset	0x3A060C	nDifficultyLevel	
+D2Client.dll	GeneralDisplayHeight	Offset	0x311470		
+D2Client.dll	GeneralDisplayWidth	Offset	0x31146C		
 D2Client.dll	IngameMousePositionX	Offset	0x3A6AB0		
 D2Client.dll	IngameMousePositionY	Offset	0x3A6AAC		
 D2Client.dll	IsAutomapOpen	Offset	0x3A27E8		


### PR DESCRIPTION
The variables are involved in the ingame interpretation of width and height, but differ depending on whether the game version is 1.07 or higher. Prior to 1.07, these variables only affect the maximum values of the [D2Client IngameMousePosition](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/3). Starting with version 1.07, the variables affect the placement of the HUD (except inventory grids) and sprite placement, including character sprites and the ingame mouse. They are both of type `int32_t`.

The variables can be found prior to 1.07 by scanning for the value 640 and looking for the D2Client variable associated with the maximum values of the [D2Client IngameMousePosition](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/3). With the release of 1.07, the variables can be much more easily located by switching the ingame resolution from 640x480 to 800x600 and back, then scanning for the appropriate values. The intended values are the ones with the aforementioned behavior when altered manually.

## Screenshots
The following 1.00 screenshot shows the variable having been manually changed to a lower value than intended, resulting in the cursor not hovering over the waypoint tile, even though the true mouse position is hovering over the waypoint tile.
![D2Client_GeneralDisplayWidth_And_GeneralDisplayHeight_01_(1 00)](https://user-images.githubusercontent.com/26683324/60390406-cc951f00-9a8a-11e9-94dc-b2689b1d9c8b.jpg)

The following 1.00 screenshot demonstrates that the variables are of type `int32_t`.
![D2Client_GeneralDisplayWidth_And_GeneralDisplayHeight_03_(1 00)](https://user-images.githubusercontent.com/26683324/60390496-d455c300-9a8c-11e9-8a01-43428a1d2c0e.PNG)

The following 1.09D screenshot demonstrates the behavior of the variables starting from versions 1.07.
![D2Client_GeneralDisplayWidth_And_GeneralDisplayHeight_04_(1 09D)](https://user-images.githubusercontent.com/26683324/60390542-cbb1bc80-9a8d-11e9-8913-6cb09b4cceee.jpg)
