### PR TITLE
Add D2Client InventoryArrangeMode

### DIFF
--- a/1.00.txt
+++ b/1.00.txt
@@ -4,6 +4,7 @@ D2Client.dll	GeneralDisplayHeight	Offset	0x1681A4
 D2Client.dll	GeneralDisplayWidth	Offset	0x1681A8		
 D2Client.dll	IngameMousePositionX	Offset	0x11AFF8		
 D2Client.dll	IngameMousePositionY	Offset	0x11AFFC		
+D2Client.dll	InventoryArrangeMode	N/A	N/A		
 D2Client.dll	IsAutomapOpen	Offset	0x143664		
 D2Client.dll	IsGameMenuOpen	Offset	0x143660		
 D2Client.dll	IsHelpScreenOpen	Offset	0x1436C0		

--- a/1.03.txt
+++ b/1.03.txt
@@ -4,6 +4,7 @@ D2Client.dll	GeneralDisplayHeight	Offset	0x1680AC
 D2Client.dll	GeneralDisplayWidth	Offset	0x1680B0		
 D2Client.dll	IngameMousePositionX	Offset	0x11ACA0		
 D2Client.dll	IngameMousePositionY	Offset	0x11ACA4		
+D2Client.dll	InventoryArrangeMode	N/A	N/A		
 D2Client.dll	IsAutomapOpen	Offset	0x143534		
 D2Client.dll	IsGameMenuOpen	Offset	0x143530		
 D2Client.dll	IsHelpScreenOpen	Offset	0x143590		

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -4,6 +4,7 @@ D2Client.dll	GeneralDisplayHeight	Offset	0xFB594
 D2Client.dll	GeneralDisplayWidth	Offset	0xFB598		
 D2Client.dll	IngameMousePositionX	Offset	0xD19A8		
 D2Client.dll	IngameMousePositionY	Offset	0xD19AC		
+D2Client.dll	InventoryArrangeMode	N/A	N/A		
 D2Client.dll	IsAutomapOpen	Offset	0xF4D9C		
 D2Client.dll	IsGameMenuOpen	Offset	0xF4D98		
 D2Client.dll	IsHelpScreenOpen	Offset	0xF4DF8		

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -4,6 +4,7 @@ D2Client.dll	GeneralDisplayHeight	Offset	0xD40E0
 D2Client.dll	GeneralDisplayWidth	Offset	0xD40DC		
 D2Client.dll	IngameMousePositionX	Offset	0x12B168		
 D2Client.dll	IngameMousePositionY	Offset	0x12B16C		
+D2Client.dll	InventoryArrangeMode	Offset	0x103978		
 D2Client.dll	IsAutomapOpen	Offset	0x1248DC		
 D2Client.dll	IsGameMenuOpen	Offset	0x1248D8		
 D2Client.dll	IsHelpScreenOpen	Offset	0x124938		

--- a/1.10.txt
+++ b/1.10.txt
@@ -4,6 +4,7 @@ D2Client.dll	GeneralDisplayHeight	Offset	0xD40F0
 D2Client.dll	GeneralDisplayWidth	Offset	0xD40EC		
 D2Client.dll	IngameMousePositionX	Offset	0x121AE4		
 D2Client.dll	IngameMousePositionY	Offset	0x121AE8		
+D2Client.dll	InventoryArrangeMode	Offset	0xFA708		
 D2Client.dll	IsAutomapOpen	Offset	0x11A6D0		
 D2Client.dll	IsGameMenuOpen	Offset	0x11A6CC		
 D2Client.dll	IsHelpScreenOpen	Offset	0x11A72C		

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -4,6 +4,7 @@ D2Client.dll	GeneralDisplayHeight	Offset	0xDC6E4
 D2Client.dll	GeneralDisplayWidth	Offset	0xDC6E0		
 D2Client.dll	IngameMousePositionX	Offset	0x101638		
 D2Client.dll	IngameMousePositionY	Offset	0x101634		
+D2Client.dll	InventoryArrangeMode	Offset	0x11B980		
 D2Client.dll	IsAutomapOpen	Offset	0x102B80		
 D2Client.dll	IsGameMenuOpen	Offset	0x102B7C		
 D2Client.dll	IsHelpScreenOpen	Offset	0x102BDC		

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -4,6 +4,7 @@ D2Client.dll	GeneralDisplayHeight	Offset	0xDBC4C
 D2Client.dll	GeneralDisplayWidth	Offset	0xDBC48		
 D2Client.dll	IngameMousePositionX	Offset	0x11B828		
 D2Client.dll	IngameMousePositionY	Offset	0x11B824		
+D2Client.dll	InventoryArrangeMode	Offset	0x11B99C		
 D2Client.dll	IsAutomapOpen	Offset	0xFADA8		
 D2Client.dll	IsGameMenuOpen	Offset	0xFADA4		
 D2Client.dll	IsHelpScreenOpen	Offset	0xFAE04		

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -4,6 +4,7 @@ D2Client.dll	GeneralDisplayHeight	Offset	0xF7038
 D2Client.dll	GeneralDisplayWidth	Offset	0xF7034		
 D2Client.dll	IngameMousePositionX	Offset	0x11C950		
 D2Client.dll	IngameMousePositionY	Offset	0x11C94C		
+D2Client.dll	InventoryArrangeMode	Offset	0x11D2B4		
 D2Client.dll	IsAutomapOpen	Offset	0x11C8B8		
 D2Client.dll	IsGameMenuOpen	Offset	0x11C8B4		
 D2Client.dll	IsHelpScreenOpen	Offset	0x11C914		

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -4,6 +4,7 @@ D2Client.dll	GeneralDisplayHeight	Offset	0x30FF4C
 D2Client.dll	GeneralDisplayWidth	Offset	0x30FF48		
 D2Client.dll	IngameMousePositionX	Offset	0x39DB38		
 D2Client.dll	IngameMousePositionY	Offset	0x39DB34		
+D2Client.dll	InventoryArrangeMode	Offset	0x39C2A0		
 D2Client.dll	IsAutomapOpen	Offset	0x399870		
 D2Client.dll	IsGameMenuOpen	Offset	0x39986C		
 D2Client.dll	IsHelpScreenOpen	Offset	0x3998CC		

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -4,6 +4,7 @@ D2Client.dll	GeneralDisplayHeight	Offset	0x311470
 D2Client.dll	GeneralDisplayWidth	Offset	0x31146C		
 D2Client.dll	IngameMousePositionX	Offset	0x3A6AB0		
 D2Client.dll	IngameMousePositionY	Offset	0x3A6AAC		
+D2Client.dll	InventoryArrangeMode	Offset	0x3A5218		
 D2Client.dll	IsAutomapOpen	Offset	0x3A27E8		
 D2Client.dll	IsGameMenuOpen	Offset	0x3A27E4		
 D2Client.dll	IsHelpScreenOpen	Offset	0x3A2844		


### PR DESCRIPTION
The variable is responsible for determining which inventory grid layout or arrangement to use. If 0, then the grids are laid out in their 640x480 positions. If 1, then the grids are laid out in their 800x600 positions. This variable only exists in 1.07 and above.

This variable can be located by repeatedly changing the resolution, and scanning for the aforementioned respective values.

## Definition
### 1.09D and Above
```C
uint32_t D2Client_InventoryArrangeMode;
```

## Screenshots
The following 1.09D screenshot shows the effects of having the variable changed to 0 when the resolution is 800x600.
![D2Client_InventoryArrangeMode_04_(1 09D)](https://user-images.githubusercontent.com/26683324/60391813-1c381280-9aac-11e9-9fed-c5cd2c0dfe28.jpg)

The following 1.09D screenshot shows the parts of the code where the variable is modified.
![D2Client_InventoryArrangeMode_01_(1 09D)](https://user-images.githubusercontent.com/26683324/60391810-1b9f7c00-9aac-11e9-9607-2845a84865db.PNG)

The following 1.09D screenshots shows how the variable is used. 
![D2Client_InventoryArrangeMode_02_(1 10)](https://user-images.githubusercontent.com/26683324/60391811-1b9f7c00-9aac-11e9-8ebf-6a784d686a0d.PNG)
![D2Client_InventoryArrangeMode_03_(1 10)](https://user-images.githubusercontent.com/26683324/60391812-1b9f7c00-9aac-11e9-9f36-d14e44f4d41a.PNG)

The following 1.09D screenshot shows that the variable, when passed in as a parameter, is treated as a `uint32_t`.
![D2Client_InventoryArrangeMode_05_(1 09D)](https://user-images.githubusercontent.com/26683324/70680972-a76a2680-1c4e-11ea-9897-536941d100e5.jpg)

