### PR TITLE
Add D2Client GeneralPlayAreaCameraShiftX

### DIFF
--- a/1.00.txt
+++ b/1.00.txt
@@ -2,6 +2,7 @@ Library	Name	Locator Type	Locator Value	Comments
 D2Client.dll	DifficultyLevel	Offset	0x12EDDC	nDifficultyLevel	
 D2Client.dll	GeneralDisplayHeight	Offset	0x1681A4		
 D2Client.dll	GeneralDisplayWidth	Offset	0x1681A8		
+D2Client.dll	GeneralPlayAreaCameraShiftX	Offset	0x1348AC		
 D2Client.dll	IngameMousePositionX	Offset	0x11AFF8		
 D2Client.dll	IngameMousePositionY	Offset	0x11AFFC		
 D2Client.dll	InventoryArrangeMode	N/A	N/A		

--- a/1.03.txt
+++ b/1.03.txt
@@ -2,6 +2,7 @@ Library	Name	Locator Type	Locator Value	Comments
 D2Client.dll	DifficultyLevel	Offset	0x12EAC4	nDifficultyLevel	
 D2Client.dll	GeneralDisplayHeight	Offset	0x1680AC		
 D2Client.dll	GeneralDisplayWidth	Offset	0x1680B0		
+D2Client.dll	GeneralPlayAreaCameraShiftX	Offset	0x134594		
 D2Client.dll	IngameMousePositionX	Offset	0x11ACA0		
 D2Client.dll	IngameMousePositionY	Offset	0x11ACA4		
 D2Client.dll	InventoryArrangeMode	N/A	N/A		

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -2,6 +2,7 @@ Library	Name	Locator Type	Locator Value	Comments
 D2Client.dll	DifficultyLevel	Offset	0xE3024	nDifficultyLevel	
 D2Client.dll	GeneralDisplayHeight	Offset	0xFB594		
 D2Client.dll	GeneralDisplayWidth	Offset	0xFB598		
+D2Client.dll	GeneralPlayAreaCameraShiftX	Offset	0xE7B4C		
 D2Client.dll	IngameMousePositionX	Offset	0xD19A8		
 D2Client.dll	IngameMousePositionY	Offset	0xD19AC		
 D2Client.dll	InventoryArrangeMode	N/A	N/A		

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -2,6 +2,7 @@ Library	Name	Locator Type	Locator Value	Comments
 D2Client.dll	DifficultyLevel	Offset	0x110BBC	nDifficultyLevel	
 D2Client.dll	GeneralDisplayHeight	Offset	0xD40E0		
 D2Client.dll	GeneralDisplayWidth	Offset	0xD40DC		
+D2Client.dll	GeneralPlayAreaCameraShiftX	Offset	0x115C14		
 D2Client.dll	IngameMousePositionX	Offset	0x12B168		
 D2Client.dll	IngameMousePositionY	Offset	0x12B16C		
 D2Client.dll	InventoryArrangeMode	Offset	0x103978		

--- a/1.10.txt
+++ b/1.10.txt
@@ -2,6 +2,7 @@ Library	Name	Locator Type	Locator Value	Comments
 D2Client.dll	DifficultyLevel	Offset	0x10795C	nDifficultyLevel	
 D2Client.dll	GeneralDisplayHeight	Offset	0xD40F0		
 D2Client.dll	GeneralDisplayWidth	Offset	0xD40EC		
+D2Client.dll	GeneralPlayAreaCameraShiftX	Offset	0x10B9C8		
 D2Client.dll	IngameMousePositionX	Offset	0x121AE4		
 D2Client.dll	IngameMousePositionY	Offset	0x121AE8		
 D2Client.dll	InventoryArrangeMode	Offset	0xFA708		

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -2,6 +2,7 @@ Library	Name	Locator Type	Locator Value	Comments
 D2Client.dll	DifficultyLevel	Offset	0x11BFF4	nDifficultyLevel	
 D2Client.dll	GeneralDisplayHeight	Offset	0xDC6E4		
 D2Client.dll	GeneralDisplayWidth	Offset	0xDC6E0		
+D2Client.dll	GeneralPlayAreaCameraShiftX	Offset	0x11C1D4		
 D2Client.dll	IngameMousePositionX	Offset	0x101638		
 D2Client.dll	IngameMousePositionY	Offset	0x101634		
 D2Client.dll	InventoryArrangeMode	Offset	0x11B980		

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -2,6 +2,7 @@ Library	Name	Locator Type	Locator Value	Comments
 D2Client.dll	DifficultyLevel	Offset	0x11C390	nDifficultyLevel	
 D2Client.dll	GeneralDisplayHeight	Offset	0xDBC4C		
 D2Client.dll	GeneralDisplayWidth	Offset	0xDBC48		
+D2Client.dll	GeneralPlayAreaCameraShiftX	Offset	0x11C418		
 D2Client.dll	IngameMousePositionX	Offset	0x11B828		
 D2Client.dll	IngameMousePositionY	Offset	0x11B824		
 D2Client.dll	InventoryArrangeMode	Offset	0x11B99C		

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -2,6 +2,7 @@ Library	Name	Locator Type	Locator Value	Comments
 D2Client.dll	DifficultyLevel	Offset	0x11D1D8	nDifficultyLevel	
 D2Client.dll	GeneralDisplayHeight	Offset	0xF7038		
 D2Client.dll	GeneralDisplayWidth	Offset	0xF7034		
+D2Client.dll	GeneralPlayAreaCameraShiftX	Offset	0x11D074		
 D2Client.dll	IngameMousePositionX	Offset	0x11C950		
 D2Client.dll	IngameMousePositionY	Offset	0x11C94C		
 D2Client.dll	InventoryArrangeMode	Offset	0x11D2B4		

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -2,6 +2,7 @@ Library	Name	Locator Type	Locator Value	Comments
 D2Client.dll	DifficultyLevel	Offset	0x397694	nDifficultyLevel	
 D2Client.dll	GeneralDisplayHeight	Offset	0x30FF4C		
 D2Client.dll	GeneralDisplayWidth	Offset	0x30FF48		
+D2Client.dll	GeneralPlayAreaCameraShiftX	Offset	0x39C29C		
 D2Client.dll	IngameMousePositionX	Offset	0x39DB38		
 D2Client.dll	IngameMousePositionY	Offset	0x39DB34		
 D2Client.dll	InventoryArrangeMode	Offset	0x39C2A0		

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -2,6 +2,7 @@ Library	Name	Locator Type	Locator Value	Comments
 D2Client.dll	DifficultyLevel	Offset	0x3A060C	nDifficultyLevel	
 D2Client.dll	GeneralDisplayHeight	Offset	0x311470		
 D2Client.dll	GeneralDisplayWidth	Offset	0x31146C		
+D2Client.dll	GeneralPlayAreaCameraShiftX	Offset	0x3A5214		
 D2Client.dll	IngameMousePositionX	Offset	0x3A6AB0		
 D2Client.dll	IngameMousePositionY	Offset	0x3A6AAC		
 D2Client.dll	InventoryArrangeMode	Offset	0x3A5218		


### PR DESCRIPTION
The variable is involved in the shifting of the camera origin of the play area. Prior to 1.07, this variable also determined whether the floor tiles were also shifted with the correct values and essentially acted as [D2Client ScreenOpenMode](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/33) prior to that variable's existence. With the release of 1.07, the variable no longer determines if floor tiles are shifted, but still affects the placement of game Cel images and interactivity logic. This variable, due to its behavior, is an `int32_t`.

Prior to 1.07, setting the variable to a value of 1 indicated that the entire play area was covered by screens on both sides. With the release of 1.07 this behavior is no more.

The variable can be located in 640x480 resolution mode by scanning for the value 0 when no screens are open. By opening a screen on the left side, the value becomes 160. By opening a screen on the right side, the value becomes -160.

## Screenshots
The following 1.00 screenshot shows the value being manually set to 159. Notice that the floor tiles have not shifted.
![D2Client_GeneralPlayAreaCameraShiftX_01_(1 00)](https://user-images.githubusercontent.com/26683324/60410732-7dc8b180-9b7e-11e9-9d77-439a1aacbe20.jpg)

The following 1.00 screenshot shows the value being manually set to 160. Notice that the floor tiles have shifted.
![D2Client_GeneralPlayAreaCameraShiftX_02_(1 00)](https://user-images.githubusercontent.com/26683324/60410733-7dc8b180-9b7e-11e9-9bf4-05f593fc191e.jpg)

The following 1.00 screenshot shows the value being manually set to 1. This causes the screen to turn completely black.
![D2Client_GeneralPlayAreaCameraShiftX_03_(1 00)](https://user-images.githubusercontent.com/26683324/60410734-7e614800-9b7e-11e9-838d-cd8884df561b.jpg)

The following 1.09D screenshot shows the value being manually set to 160. Notice that the floor tiles have not shifted like in the 1.00 screenshot.
![D2Client_GeneralPlayAreaCameraShiftX_04_(1 10)](https://user-images.githubusercontent.com/26683324/60410735-7e614800-9b7e-11e9-9e15-094fed02870a.jpg)

The following 1.00 screenshot shows the variables being utilized. This indicates that the variable is a 32-bit integer.
![D2Client_GeneralPlayAreaCameraShiftX_05_(1 00)](https://user-images.githubusercontent.com/26683324/60410736-7e614800-9b7e-11e9-86a6-41e09fdeb225.PNG)
