### PR TITLE
Add D2Client ScreenOpenMode

### DIFF
--- a/1.00.txt
+++ b/1.00.txt
@@ -1,5 +1,6 @@
 Library	Name	Locator Type	Locator Value	Comments	
 D2Client.dll	DifficultyLevel	Offset	0x12EDDC	nDifficultyLevel	
+D2Client.dll	ScreenOpenMode	N/A	N/A		
 D2Client.dll	GeneralDisplayHeight	Offset	0x1681A4		
 D2Client.dll	GeneralDisplayWidth	Offset	0x1681A8		
 D2Client.dll	GeneralPlayAreaCameraShiftX	Offset	0x1348AC		

--- a/1.03.txt
+++ b/1.03.txt
@@ -1,5 +1,6 @@
 Library	Name	Locator Type	Locator Value	Comments	
 D2Client.dll	DifficultyLevel	Offset	0x12EAC4	nDifficultyLevel	
+D2Client.dll	ScreenOpenMode	N/A	N/A		
 D2Client.dll	GeneralDisplayHeight	Offset	0x1680AC		
 D2Client.dll	GeneralDisplayWidth	Offset	0x1680B0		
 D2Client.dll	GeneralPlayAreaCameraShiftX	Offset	0x134594		

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -1,5 +1,6 @@
 Library	Name	Locator Type	Locator Value	Comments	
 D2Client.dll	DifficultyLevel	Offset	0xE3024	nDifficultyLevel	
+D2Client.dll	ScreenOpenMode	N/A	N/A		
 D2Client.dll	GeneralDisplayHeight	Offset	0xFB594		
 D2Client.dll	GeneralDisplayWidth	Offset	0xFB598		
 D2Client.dll	GeneralPlayAreaCameraShiftX	Offset	0xE7B4C		

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -1,5 +1,6 @@
 Library	Name	Locator Type	Locator Value	Comments	
 D2Client.dll	DifficultyLevel	Offset	0x110BBC	nDifficultyLevel	
+D2Client.dll	ScreenOpenMode	Offset	0x115C10		
 D2Client.dll	GeneralDisplayHeight	Offset	0xD40E0		
 D2Client.dll	GeneralDisplayWidth	Offset	0xD40DC		
 D2Client.dll	GeneralPlayAreaCameraShiftX	Offset	0x115C14		

--- a/1.10.txt
+++ b/1.10.txt
@@ -1,5 +1,6 @@
 Library	Name	Locator Type	Locator Value	Comments	
 D2Client.dll	DifficultyLevel	Offset	0x10795C	nDifficultyLevel	
+D2Client.dll	ScreenOpenMode	Offset	0x10B9C4		
 D2Client.dll	GeneralDisplayHeight	Offset	0xD40F0		
 D2Client.dll	GeneralDisplayWidth	Offset	0xD40EC		
 D2Client.dll	GeneralPlayAreaCameraShiftX	Offset	0x10B9C8		

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -1,5 +1,6 @@
 Library	Name	Locator Type	Locator Value	Comments	
 D2Client.dll	DifficultyLevel	Offset	0x11BFF4	nDifficultyLevel	
+D2Client.dll	ScreenOpenMode	Offset	0x11C1D0		
 D2Client.dll	GeneralDisplayHeight	Offset	0xDC6E4		
 D2Client.dll	GeneralDisplayWidth	Offset	0xDC6E0		
 D2Client.dll	GeneralPlayAreaCameraShiftX	Offset	0x11C1D4		

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -1,5 +1,6 @@
 Library	Name	Locator Type	Locator Value	Comments	
 D2Client.dll	DifficultyLevel	Offset	0x11C390	nDifficultyLevel	
+D2Client.dll	ScreenOpenMode	Offset	0x11C414		
 D2Client.dll	GeneralDisplayHeight	Offset	0xDBC4C		
 D2Client.dll	GeneralDisplayWidth	Offset	0xDBC48		
 D2Client.dll	GeneralPlayAreaCameraShiftX	Offset	0x11C418		

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -1,5 +1,6 @@
 Library	Name	Locator Type	Locator Value	Comments	
 D2Client.dll	DifficultyLevel	Offset	0x11D1D8	nDifficultyLevel	
+D2Client.dll	ScreenOpenMode	Offset	0x11D070		
 D2Client.dll	GeneralDisplayHeight	Offset	0xF7038		
 D2Client.dll	GeneralDisplayWidth	Offset	0xF7034		
 D2Client.dll	GeneralPlayAreaCameraShiftX	Offset	0x11D074		

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -1,5 +1,6 @@
 Library	Name	Locator Type	Locator Value	Comments	
 D2Client.dll	DifficultyLevel	Offset	0x397694	nDifficultyLevel	
+D2Client.dll	ScreenOpenMode	Offset	0x39C298		
 D2Client.dll	GeneralDisplayHeight	Offset	0x30FF4C		
 D2Client.dll	GeneralDisplayWidth	Offset	0x30FF48		
 D2Client.dll	GeneralPlayAreaCameraShiftX	Offset	0x39C29C		

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -1,5 +1,6 @@
 Library	Name	Locator Type	Locator Value	Comments	
 D2Client.dll	DifficultyLevel	Offset	0x3A060C	nDifficultyLevel	
+D2Client.dll	ScreenOpenMode	Offset	0x3A5210		
 D2Client.dll	GeneralDisplayHeight	Offset	0x311470		
 D2Client.dll	GeneralDisplayWidth	Offset	0x31146C		
 D2Client.dll	GeneralPlayAreaCameraShiftX	Offset	0x3A5214		


### PR DESCRIPTION
This variable does not exist prior to version 1.07. In 1.07 and above, the variable is associated with the shifting of floor tiles and the display of screen borders. The variable may take on the following values:

```
0 = No screens are open
1 = Right side screen is open
2 = Left side screen is open
3 = Both left and right side screens are open; cover the play area in black
```

This variable is a `uint32_t`.

The variable may be located by opening the screens and scanning for the aforementioned respective values.

## Screenshots
The following 1.09D screenshot shows the variable with the value 1.
![D2Client_ScreenOpenMode_02_(1 09D)](https://user-images.githubusercontent.com/26683324/60411362-54f5eb80-9b81-11e9-8fcf-593bf5c526fd.jpg)

The following 1.09D screenshot shows the variable with the value 2.
![D2Client_ScreenOpenMode_01_(1 09D)](https://user-images.githubusercontent.com/26683324/60411361-54f5eb80-9b81-11e9-84b2-8604c78915c1.jpg)

The following 1.09D screenshot shows the variable with the value 3. Notice that the play area is covered in black.
![D2Client_ScreenOpenMode_03_(1 09D)](https://user-images.githubusercontent.com/26683324/60411363-54f5eb80-9b81-11e9-81e4-2e5b8fde8b32.jpg)

The following 1.09D screenshot shows the variable being used, which proves that the variable is 32-bits.
![D2Client_ScreenOpenMode_04_(1 09D)](https://user-images.githubusercontent.com/26683324/60411365-558e8200-9b81-11e9-8d0e-554cff5065b0.PNG)

The following 1.10 screenshot shows that the variable is an unsigned type, making it a `uint32_t`.
![D2Client_ScreenOpenMode_05_(1 10)](https://user-images.githubusercontent.com/26683324/60411505-ee250200-9b81-11e9-88a1-031dbfd285a9.PNG)
