### PR TITLE
Add D2GFX DrawCelContext

### DIFF
--- a/1.00.txt
+++ b/1.00.txt
@@ -23,6 +23,7 @@ D2GDI.dll	BitBlockHeight	Offset	0xB840
 D2GDI.dll	BitBlockWidth	Offset	0xB434		
 D2GDI.dll	CelDisplayLeft	Offset	0xBF80		
 D2GDI.dll	CelDisplayRight	Offset	0xBF7C		
+D2GFX.dll	DrawCelContext	Ordinal	10076		
 D2GFX.dll	ResolutionMode	Offset	0x2A950	"0 = 640x480, 1 = Main Menu 800x600"	
 D2GFX.dll	VideoMode	Offset	0x2A948	"1 = GDI, 2 = Software, 3 = DirectDraw, 4 = Glide, 5 = OpenGL, 6 = Direct3D, 7 = Rave"	
 D2Glide.dll	DisplayHeight	Offset	0x1DE04		

--- a/1.03.txt
+++ b/1.03.txt
@@ -23,6 +23,7 @@ D2GDI.dll	BitBlockHeight	Offset	0xB840
 D2GDI.dll	BitBlockWidth	Offset	0xB434		
 D2GDI.dll	CelDisplayLeft	Offset	0xBF80		
 D2GDI.dll	CelDisplayRight	Offset	0xBF7C		
+D2GFX.dll	DrawCelContext	Ordinal	10076		
 D2GFX.dll	ResolutionMode	Offset	0x2A990	"0 = 640x480, 1 = Main Menu 800x600"	
 D2GFX.dll	VideoMode	Offset	0x2A988	"1 = GDI, 2 = Software, 3 = DirectDraw, 4 = Glide, 5 = OpenGL, 6 = Direct3D, 7 = Rave"	
 D2Glide.dll	DisplayHeight	Offset	0x1DDC4		

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -23,6 +23,7 @@ D2GDI.dll	BitBlockHeight	Offset	0xB3C8
 D2GDI.dll	BitBlockWidth	Offset	0xAFBC		
 D2GDI.dll	CelDisplayLeft	Offset	0xB8EC		
 D2GDI.dll	CelDisplayRight	Offset	0xB8E8		
+D2GFX.dll	DrawCelContext	Ordinal	10076		
 D2GFX.dll	ResolutionMode	Offset	0x1D060	"0 = 640x480, 1 = Main Menu 800x600"	
 D2GFX.dll	VideoMode	Offset	0x1D058	"1 = GDI, 2 = Software, 3 = DirectDraw, 4 = Glide, 5 = OpenGL, 6 = Direct3D, 7 = Rave"	
 D2Glide.dll	DisplayHeight	Offset	0x153AC		

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -23,6 +23,7 @@ D2GDI.dll	BitBlockHeight	Offset	0xC448
 D2GDI.dll	BitBlockWidth	Offset	0xC03C		
 D2GDI.dll	CelDisplayLeft	Offset	0xC96C		
 D2GDI.dll	CelDisplayRight	Offset	0xC968		
+D2GFX.dll	DrawCelContext	Ordinal	10072		
 D2GFX.dll	ResolutionMode	Offset	0x1D210	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
 D2GFX.dll	VideoMode	Offset	0x1D208	"1 = GDI, 2 = Software, 3 = DirectDraw, 4 = Glide, 5 = OpenGL, 6 = Direct3D, 7 = Rave"	
 D2Glide.dll	DisplayHeight	Offset	0x153CC		

--- a/1.10.txt
+++ b/1.10.txt
@@ -23,6 +23,7 @@ D2GDI.dll	BitBlockHeight	Offset	0xC48C
 D2GDI.dll	BitBlockWidth	Offset	0xC07C		
 D2GDI.dll	CelDisplayLeft	Offset	0xC9B4		
 D2GDI.dll	CelDisplayRight	Offset	0xC9B0		
+D2GFX.dll	DrawCelContext	Ordinal	10072		
 D2GFX.dll	ResolutionMode	Offset	0x1D26C	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
 D2GFX.dll	VideoMode	Offset	0x1D264	"1 = GDI, 2 = Software, 3 = DirectDraw, 4 = Glide, 5 = OpenGL, 6 = Direct3D, 7 = Rave"	
 D2Glide.dll	DisplayHeight	Offset	0x15468		

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -23,6 +23,7 @@ D2GDI.dll	BitBlockHeight	Offset	0xCA98
 D2GDI.dll	BitBlockWidth	Offset	0xCA88		
 D2GDI.dll	CelDisplayLeft	Offset	0xC040		
 D2GDI.dll	CelDisplayRight	Offset	0xC044		
+D2GFX.dll	DrawCelContext	Ordinal	10024		
 D2GFX.dll	ResolutionMode	Offset	0x1D454	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
 D2GFX.dll	VideoMode	Offset	0x1D44C	"1 = GDI, 2 = Software, 3 = DirectDraw, 4 = Glide, 5 = OpenGL, 6 = Direct3D, 7 = Rave"	
 D2Glide.dll	DisplayHeight	Offset	0x16E8C		

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -24,6 +24,7 @@ D2GDI.dll	BitBlockHeight	Offset	0xCA90
 D2GDI.dll	BitBlockWidth	Offset	0xCA80		
 D2GDI.dll	CelDisplayLeft	Offset	0xCA98		
 D2GDI.dll	CelDisplayRight	Offset	0xCA9C		
+D2GFX.dll	DrawCelContext	Ordinal	10041		
 D2GFX.dll	ResolutionMode	Offset	0x11260	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
 D2GFX.dll	VideoMode	Offset	0x11258	"1 = GDI, 2 = Software, 3 = DirectDraw, 4 = Glide, 5 = OpenGL, 6 = Direct3D, 7 = Rave"	
 D2Glide.dll	DisplayHeight	Offset	0x15B04		

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -23,6 +23,7 @@ D2GDI.dll	BitBlockHeight	Offset	0xC980
 D2GDI.dll	BitBlockWidth	Offset	0xC970		
 D2GDI.dll	CelDisplayLeft	Offset	0xCA94		
 D2GDI.dll	CelDisplayRight	Offset	0xCA98		
+D2GFX.dll	DrawCelContext	Ordinal	10042		
 D2GFX.dll	ResolutionMode	Offset	0x14A40	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
 D2GFX.dll	VideoMode	Offset	0x14A38	"1 = GDI, 2 = Software, 3 = DirectDraw, 4 = Glide, 5 = OpenGL, 6 = Direct3D, 7 = Rave"	
 D2Glide.dll	DisplayHeight	Offset	0x15B14		

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -23,6 +23,7 @@ D2GDI.dll	BitBlockHeight	Offset	0x3C01C4
 D2GDI.dll	BitBlockWidth	Offset	0x3C01C0		
 D2GDI.dll	CelDisplayLeft	Offset	0x5810F0		
 D2GDI.dll	CelDisplayRight	Offset	0x5810F4		
+D2GFX.dll	DrawCelContext	Offset	0xF3AA0		
 D2GFX.dll	ResolutionMode	Offset	0x3BFD40	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
 D2GFX.dll	VideoMode	Offset	0x3BFD38	"1 = GDI, 2 = Software, 3 = DirectDraw, 4 = Glide, 5 = OpenGL, 6 = Direct3D, 7 = Rave"	
 D2Glide.dll	DisplayHeight	Offset	0x3C01C4		

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -23,6 +23,7 @@ D2GDI.dll	BitBlockHeight	Offset	0x3C913C
 D2GDI.dll	BitBlockWidth	Offset	0x3C9138		
 D2GDI.dll	CelDisplayLeft	Offset	0x58A168		
 D2GDI.dll	CelDisplayRight	Offset	0x58A16C		
+D2GFX.dll	DrawCelContext	Offset	0xF6480		
 D2GFX.dll	ResolutionMode	Offset	0x3C8CB8	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
 D2GFX.dll	VideoMode	Offset	0x3C8CB0	"1 = GDI, 2 = Software, 3 = DirectDraw, 4 = Glide, 5 = OpenGL, 6 = Direct3D, 7 = Rave"	
 D2Glide.dll	DisplayHeight	Offset	0x3C913C		


### PR DESCRIPTION
The function is a wrapper that calls the correct function for the current video mode and draws a `CelContext` to the display. The color format is specified to be **B**lue, **G**reen, **R**ed, and **T**int. However, only the tint portion of the color is used if not running in Glide mode.

This function can be located by scanning for the string `%s\UI\CURSOR\Pentspin` in non-writable regions and getting the address of the string. Afterwards, use the address of the string in another scan in non-writable regions to get an executable code that references that address and uses it to call [D2Win LoadCelFile](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/28). The return of that function is placed into a global variable. Scan for executable regions that reference that global variable.

## Function Definition
### All Versions
```C
bool32_t D2GFX_DrawCelContext(
  CelContext* cel_context,
  int32_t position_x,
  int32_t position_y,
  uint32_t bgrt_color,
  int32_t draw_cel_context_effect,
  undefined* unknown_06
)
```
- All parameters on the stack
  - Callee cleans the stack

The `position_y` parameter determines the bottom position of the image, as the image is drawn above the value specified for `position_y`.

The `unknown_06` parameter has not been document for the sake of time and practicality. However, it is known that the parameter is a pointer. Most, if not all use cases pass in a value of `nullptr`.

`draw_cel_context_effect` is a 32-bit integer with the following values. Not all values are known, due to time and difficulty of understanding.

```
0 = QUARTER_OPACITY = ONE_FOURTH_OPACITY,
1 = HALF_OPAQUE,
2 = THREE_QUARTERS_OPAQUE = THREE_FOURTHS_OPAQUE,
3 = UNKNOWN
4 = UNKNOWN
5 = NO_EFFECT,
6 = UNKNOWN
7 = UNKNOWN
```

## Screenshots
The following 1.00 screenshots depict the different values of `draw_cel_context_effect` and their effects. The left pentagram is unmodified, while the right pentagram has the listed effect. 
![D2GFX_DrawCelContext_01_(1 00)](https://user-images.githubusercontent.com/26683324/60699160-9cdd8100-9ea7-11e9-88e5-a7ab29facc5b.jpg)
![D2GFX_DrawCelContext_02_(1 00)](https://user-images.githubusercontent.com/26683324/60699162-9cdd8100-9ea7-11e9-8b24-aafdc9de7704.jpg)
![D2GFX_DrawCelContext_03_(1 00)](https://user-images.githubusercontent.com/26683324/60699163-9cdd8100-9ea7-11e9-81d6-388fe4e0f610.jpg)
![D2GFX_DrawCelContext_04_(1 00)](https://user-images.githubusercontent.com/26683324/60699164-9d761780-9ea7-11e9-8a1a-0ac947d28e2c.jpg)
![D2GFX_DrawCelContext_05_(1 00)](https://user-images.githubusercontent.com/26683324/60699165-9d761780-9ea7-11e9-958b-d20c4b734758.jpg)

A better position of the right pentagram is provided for the value 4.
![D2GFX_DrawCelContext_06_(1 00)](https://user-images.githubusercontent.com/26683324/60699166-9d761780-9ea7-11e9-9e47-47917639074d.jpg)
![D2GFX_DrawCelContext_07_(1 00)](https://user-images.githubusercontent.com/26683324/60699167-9e0eae00-9ea7-11e9-9a5f-01d888eec43a.jpg)
![D2GFX_DrawCelContext_08_(1 00)](https://user-images.githubusercontent.com/26683324/60699169-9e0eae00-9ea7-11e9-8f9e-1ce36d0e2ab7.jpg)
![D2GFX_DrawCelContext_09_(1 00)](https://user-images.githubusercontent.com/26683324/60699171-9e0eae00-9ea7-11e9-8d56-48f9c9fbd1f9.jpg)

The following 1.00 screenshot shows the calling convention of the function and its parameters.
![D2GFX_DrawCelContext_10_(1 00)](https://user-images.githubusercontent.com/26683324/60699172-9ea74480-9ea7-11e9-8c5c-40a102c4a348.PNG)

The following 1.00 screenshot shows the function in its entirety. It is a wrapper for the actual function, which is determined by the video mode. The screenshot also shows the function's cleanup convention.
![D2GFX_DrawCelContext_11_(1 00)](https://user-images.githubusercontent.com/26683324/60699173-9ea74480-9ea7-11e9-95a0-9bbc80110571.PNG)

The following 1.10 screenshot shows the different values of `draw_cel_context_effect`. Some of the values were easy to discern their respective effects.
![D2GFX_DrawCelContext_12_(1 10)](https://user-images.githubusercontent.com/26683324/60699174-9ea74480-9ea7-11e9-88ae-f3b00a292c2b.PNG)

The following 1.10 screenshot shows that `position_x` and `position_y` are both `int32_t`.
![D2GFX_DrawCelContext_13_(1 10)](https://user-images.githubusercontent.com/26683324/60699175-9f3fdb00-9ea7-11e9-9b81-6ce44ee01fda.PNG)

The following 1.10 screenshot shows that `bgrt_color` is a `uint32_t` and that the color format is BGRT.
![D2GFX_DrawCelContext_14_(1 10)](https://user-images.githubusercontent.com/26683324/60699176-9f3fdb00-9ea7-11e9-88a8-914cc59e6397.PNG)

The following 1.10 screenshot shows the return type is a `bool32_t`.
![D2GFX_DrawCelContext_15_(1 10)](https://user-images.githubusercontent.com/26683324/60699178-9f3fdb00-9ea7-11e9-8f7d-b5b733322b3a.PNG)

The following 1.00 screenshot confirms that the parameter `cel_context` does not qualify for the `const` qualifier, because a member of the struct is modified in this function.
![D2GFX_DrawCelContext_16_(1 00)](https://user-images.githubusercontent.com/26683324/62407786-e1297300-b572-11e9-9c9c-68863c6481ba.PNG)

