### PR TITLE
Fix D2Win UnloadCelFile

### DIFF
--- a/1.12A.txt
+++ b/1.12A.txt
@@ -37,7 +37,7 @@ D2Win.dll	LoadCelFile	Ordinal	10186
 D2Win.dll	LoadMPQ	Offset	0x7E40		
 D2Win.dll	MainMenuMousePositionX	Offset	0x5C700		
 D2Win.dll	MainMenuMousePositionY	Offset	0x5C704		
-D2Win.dll	UnloadCelFile	N/A	N/A		
+D2Win.dll	UnloadCelFile	Ordinal	10130		
 D2Win.dll	UnloadMPQ	N/A	N/A		
 Fog.dll	AllocClientMemory	Ordinal	10042		
 Fog.dll	FreeClientMemory	Ordinal	10043		

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -40,7 +40,7 @@ D2Win.dll	LoadCelFile	Ordinal	10111
 D2Win.dll	LoadMPQ	Offset	0x7E60		
 D2Win.dll	MainMenuMousePositionX	Offset	0x21488		
 D2Win.dll	MainMenuMousePositionY	Offset	0x2148C		
-D2Win.dll	UnloadCelFile	N/A	N/A		
+D2Win.dll	UnloadCelFile	Ordinal	10126		
 D2Win.dll	UnloadMPQ	N/A	N/A		
 Fog.dll	AllocClientMemory	Ordinal	10042		
 Fog.dll	FreeClientMemory	Ordinal	10043		

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -37,7 +37,7 @@ D2Win.dll	LoadCelFile	Ordinal	10023
 D2Win.dll	LoadMPQ	Offset	0x7E50		
 D2Win.dll	MainMenuMousePositionX	Offset	0x8DB1C		
 D2Win.dll	MainMenuMousePositionY	Offset	0x8DB20		
-D2Win.dll	UnloadCelFile	N/A	N/A		
+D2Win.dll	UnloadCelFile	Ordinal	10189		
 D2Win.dll	UnloadMPQ	N/A	N/A		
 Fog.dll	AllocClientMemory	Ordinal	10042		
 Fog.dll	FreeClientMemory	Ordinal	10043		


### PR DESCRIPTION
The change revises the definition of [D2Win UnloadCelFile](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/29), pull request #29, for versions 1.11 - 1.13D. The previous definition claimed that in those versions, the function was inline optimized.

The function can be found in those versions using similar methods to [D2Win UnloadCelFile](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/29), except using the string `%s\UI\FrontEnd\blizno`. The code is in `D2Launch.dll`.

Credits to Necrolis for correcting my assumption that the function was inlined away.

## Function Definition
### 1.11 - 1.13D (inclusive)
Uses the same definition as every other version.

## Screenshot
The following 1.12A screenshot proves that the function exists.
![D2Win_UnloadCelFile_04_(1 12A)](https://user-images.githubusercontent.com/26683324/60751837-7c79f900-9f71-11e9-843b-ddb3ec588943.PNG)
