### PR TITLE
Fix D2Win UnloadMPQ

### DIFF
--- a/1.12A.txt
+++ b/1.12A.txt
@@ -38,7 +38,7 @@ D2Win.dll	LoadMPQ	Offset	0x7E40
 D2Win.dll	MainMenuMousePositionX	Offset	0x5C700		
 D2Win.dll	MainMenuMousePositionY	Offset	0x5C704		
 D2Win.dll	UnloadCelFile	Ordinal	10130		
-D2Win.dll	UnloadMPQ	N/A	N/A		
+D2Win.dll	UnloadMPQ	Offset	0x78D0		
 Fog.dll	AllocClientMemory	Ordinal	10042		
 Fog.dll	FreeClientMemory	Ordinal	10043		
 Storm.dll	SFileCloseArchive	Ordinal	252		

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -41,7 +41,7 @@ D2Win.dll	LoadMPQ	Offset	0x7E60
 D2Win.dll	MainMenuMousePositionX	Offset	0x21488		
 D2Win.dll	MainMenuMousePositionY	Offset	0x2148C		
 D2Win.dll	UnloadCelFile	Ordinal	10126		
-D2Win.dll	UnloadMPQ	N/A	N/A		
+D2Win.dll	UnloadMPQ	Offset	0x78F0		
 Fog.dll	AllocClientMemory	Ordinal	10042		
 Fog.dll	FreeClientMemory	Ordinal	10043		
 Storm.dll	SFileCloseArchive	Ordinal	252		

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -38,7 +38,7 @@ D2Win.dll	LoadMPQ	Offset	0x7E50
 D2Win.dll	MainMenuMousePositionX	Offset	0x8DB1C		
 D2Win.dll	MainMenuMousePositionY	Offset	0x8DB20		
 D2Win.dll	UnloadCelFile	Ordinal	10189		
-D2Win.dll	UnloadMPQ	N/A	N/A		
+D2Win.dll	UnloadMPQ	Offset	0x78E0		
 Fog.dll	AllocClientMemory	Ordinal	10042		
 Fog.dll	FreeClientMemory	Ordinal	10043		
 Storm.dll	SFileCloseArchive	Ordinal	252		


### PR DESCRIPTION
This change revises the definition of [D2Win UnloadMPQ](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/17), pull request #17, for versions 1.11 - 1.13D. The previous definition claimed that in those versions, the function was inline optimized.

The function may be located by scanning for the string `Archive.cpp` and selecting the address that belongs to `D2Win.dll`. Afterwards, adjust the base address back so that it contains the entire string. Afterwards, scan for every usage of the string and perform brute force lookup on each use case. The usage must match what is shown in the screenshot below.

## Function Definition
### 1.11 - 1.13D (inclusive)
```C
void D2Win_UnloadMPQ(MPQArchiveHandle* mpq_archive_handle)
```
- `mpq_archive_handle` in esi

## Screenshots
The following 1.12A screenshot proves that the function exists.
![D2Win_UnloadMPQ_05_(1 12A)](https://user-images.githubusercontent.com/26683324/60752152-b7caf680-9f76-11e9-9cd6-28c5b35c3a9d.PNG)
