### PR TITLE
Add D2Win DrawText

### DIFF
--- a/1.00.txt
+++ b/1.00.txt
@@ -50,6 +50,7 @@ D2Lang.dll	Unicode_tolower	Offset	0x1014	?toLower@Unicode@@QBE?AU1@XZ	Unicode::t
 D2Lang.dll	Unicode_toupper	Offset	0x1154		Unicode::toUpper
 D2Lang.dll	UnicodeString_NCompareIgnoreCase	Offset	0x1091	?strnicmp@Unicode@@SIHPBU1@0I@Z	Unicode::strnicmp
 D2Lang.dll	UnloadSysMap	Offset	0x104B	?unloadSysMap@Unicode@@SIXXZ	Unicode::unloadSysMap
+D2Win.dll	DrawText	Ordinal	10110		
 D2Win.dll	LoadCelFile	Ordinal	10035		
 D2Win.dll	LoadMPQ	Offset	0x1458A		
 D2Win.dll	MainMenuMousePositionX	Offset	0x72A90		

--- a/1.03.txt
+++ b/1.03.txt
@@ -33,6 +33,7 @@ D2Lang.dll	Unicode_strcat	Offset	0x10B4		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x1055	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x1014	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x1154		Unicode::toUpper
+D2Win.dll	DrawText	Ordinal	10110		
 D2Win.dll	LoadCelFile	Ordinal	10035		
 D2Win.dll	LoadMPQ	Offset	0x146FA		
 D2Win.dll	MainMenuMousePositionX	Offset	0x72A98		

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -33,6 +33,7 @@ D2Lang.dll	Unicode_strcat	Offset	0x13A0		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x1490	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10E0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10B0		Unicode::toUpper
+D2Win.dll	DrawText	Ordinal	10110		
 D2Win.dll	LoadCelFile	Ordinal	10035		
 D2Win.dll	LoadMPQ	Offset	0x10595		
 D2Win.dll	MainMenuMousePositionX	Offset	0x5BCB8		

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -33,6 +33,7 @@ D2Lang.dll	Unicode_strcat	Offset	0x13A0		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x1490	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10E0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10B0		Unicode::toUpper
+D2Win.dll	DrawText	Ordinal	10117		
 D2Win.dll	LoadCelFile	Ordinal	10039		
 D2Win.dll	LoadMPQ	Offset	0x142FB		
 D2Win.dll	MainMenuMousePositionX	Offset	0x618A0		

--- a/1.10.txt
+++ b/1.10.txt
@@ -33,6 +33,7 @@ D2Lang.dll	Unicode_strcat	Offset	0x13F0		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x14C0	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10E0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10B0		Unicode::toUpper
+D2Win.dll	DrawText	Ordinal	10117		
 D2Win.dll	LoadCelFile	Ordinal	10039		
 D2Win.dll	LoadMPQ	Offset	0x12399		
 D2Win.dll	MainMenuMousePositionX	Offset	0x5E234		

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -33,6 +33,7 @@ D2Lang.dll	Unicode_strcat	Offset	0xA610		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0xA6E0	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10C0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10A0		Unicode::toUpper
+D2Win.dll	DrawText	Ordinal	10001		
 D2Win.dll	LoadCelFile	Ordinal	10186		
 D2Win.dll	LoadMPQ	Offset	0x7E40		
 D2Win.dll	MainMenuMousePositionX	Offset	0x5C700		

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -36,6 +36,7 @@ D2Lang.dll	Unicode_strcat	Offset	0xAFE0		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0xB0B0	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10C0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10A0		Unicode::toUpper
+D2Win.dll	DrawText	Ordinal	10150		
 D2Win.dll	LoadCelFile	Ordinal	10111		
 D2Win.dll	LoadMPQ	Offset	0x7E60		
 D2Win.dll	MainMenuMousePositionX	Offset	0x21488		

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -33,6 +33,7 @@ D2Lang.dll	Unicode_strcat	Offset	0x8B90		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x8C60	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10C0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10A0		Unicode::toUpper
+D2Win.dll	DrawText	Ordinal	10076		
 D2Win.dll	LoadCelFile	Ordinal	10023		
 D2Win.dll	LoadMPQ	Offset	0x7E50		
 D2Win.dll	MainMenuMousePositionX	Offset	0x8DB1C		

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -33,6 +33,7 @@ D2Lang.dll	Unicode_strcat	Offset	0x123C50		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x123D50	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0xADD70	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x29E40		Unicode::toUpper
+D2Win.dll	DrawText	Offset	0xFFB70		
 D2Win.dll	LoadCelFile	Offset	0xF7F80		
 D2Win.dll	LoadMPQ	Offset	0x114FF7		
 D2Win.dll	MainMenuMousePositionX	Offset	0x3CC62C		

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -33,6 +33,7 @@ D2Lang.dll	Unicode_strcat	Offset	0x126700		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x126800	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0xB15F3	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x2E650		Unicode::toUpper
+D2Win.dll	DrawText	Offset	0x102320		
 D2Win.dll	LoadCelFile	Offset	0xFA9B0		
 D2Win.dll	LoadMPQ	Offset	0x117332		
 D2Win.dll	MainMenuMousePositionX	Offset	0x3D55A4		


### PR DESCRIPTION
The function displays the specified text at the specified position on the display. The text may also take on one of the multiple predefined colors.

The function may be located by creating a game with a character who has at least one skill point. Scan for the Unicode text `New Skill` and look for code that accesses the variable. A function featuring the following definition will be visible.

## Function Definition
### All Versions
```C
void D2Win_DrawText(
  const UnicodeChar* text,
  int32_t position_x,
  int32_t position_y,
  int32_t text_color_id,
  bool32_t is_indented
)
```
- `text` in ecx
- `position_x` in edx
- Remaining parameters on the stack
  - Callee cleans the stack

`src` is never modified, which qualifies it for the `const` modifier.

This function calls another function near the end that returns a `bool32_t`. Out of safety, this function has been made to return `void`.

The parameter `text_color_id` can take on the following values:
```
0 = White
1 = Red (Light Red)
2 = Green (Light Green)
3 = Blue
4 = Gold
5 = Dark Grey
6 = Black
7 = Tan
8 = Orange
9 = Yellow
10 = Darker Green
11 = Purple
12 = Dark Green
13 = White (same as 1)
14 = Black (same as 6)
15 = Metallic
16 = Light Grey
17 = Corrupt Colors (Not Pleasing to the eye)
18 = Bright White
19 = Dark Red
20 = Brown
```

## Screenshots
The following 1.00 screenshot shows the function's calling convention.
![D2Win_DrawText_01_(1 00)](https://user-images.githubusercontent.com/26683324/60774936-c9281600-a0d0-11e9-972b-e0d5c4434f69.PNG)

The following 1.00 screenshots show the effects of having `is_indented` set to 0, then 1. Other values are treated the same as 0. This makes the parameter a `bool32_t`.
![D2Win_DrawText_02_(1 00)](https://user-images.githubusercontent.com/26683324/60774937-c9281600-a0d0-11e9-8bb4-add3ce8979b2.jpg)
![D2Win_DrawText_03_(1 00)](https://user-images.githubusercontent.com/26683324/60774938-c9281600-a0d0-11e9-881e-4e43de84d113.jpg)

The following 1.00 screenshots depict the belt number colors changing depending on the value of `text_color_id`. The screenshots are ordered according to that value.
![TextColor_00_(1 00)](https://user-images.githubusercontent.com/26683324/60774970-5f5c3c00-a0d1-11e9-9188-2d463533abe4.jpg)
![TextColor_01_(1 00)](https://user-images.githubusercontent.com/26683324/60774971-5ff4d280-a0d1-11e9-89ae-d16148f4ef5f.jpg)
![TextColor_02_(1 00)](https://user-images.githubusercontent.com/26683324/60774972-5ff4d280-a0d1-11e9-9cc6-827a142e33ba.jpg)
![TextColor_03_(1 00)](https://user-images.githubusercontent.com/26683324/60774973-5ff4d280-a0d1-11e9-826e-df7cb986c8db.jpg)
![TextColor_04_(1 00)](https://user-images.githubusercontent.com/26683324/60774974-5ff4d280-a0d1-11e9-9d47-42a61124af6e.jpg)
![TextColor_05_(1 00)](https://user-images.githubusercontent.com/26683324/60774975-5ff4d280-a0d1-11e9-899e-a7df32cbe977.jpg)
![TextColor_06_(1 00)](https://user-images.githubusercontent.com/26683324/60774976-5ff4d280-a0d1-11e9-865c-4b90911eccc5.jpg)
![TextColor_07_(1 00)](https://user-images.githubusercontent.com/26683324/60774977-608d6900-a0d1-11e9-9135-a027db97d232.jpg)
![TextColor_08_(1 00)](https://user-images.githubusercontent.com/26683324/60774978-608d6900-a0d1-11e9-8d11-cbb6ddd0964d.jpg)
![TextColor_09_(1 00)](https://user-images.githubusercontent.com/26683324/60774979-608d6900-a0d1-11e9-9399-25fe6877afd3.jpg)
![TextColor_10_(1 00)](https://user-images.githubusercontent.com/26683324/60774980-608d6900-a0d1-11e9-8c35-3da8bcbbce34.jpg)
![TextColor_11_(1 00)](https://user-images.githubusercontent.com/26683324/60774981-608d6900-a0d1-11e9-87da-b8be15489159.jpg)
![TextColor_12_(1 00)](https://user-images.githubusercontent.com/26683324/60774982-608d6900-a0d1-11e9-8d21-c5aa4203415e.jpg)
![TextColor_13_(1 00)](https://user-images.githubusercontent.com/26683324/60774983-608d6900-a0d1-11e9-8205-abd78e273d16.jpg)
![TextColor_14_(1 00)](https://user-images.githubusercontent.com/26683324/60774984-6125ff80-a0d1-11e9-9f72-64200191d6ba.jpg)
![TextColor_15_(1 00)](https://user-images.githubusercontent.com/26683324/60774985-6125ff80-a0d1-11e9-86de-f78acff8abf6.jpg)
![TextColor_16_(1 00)](https://user-images.githubusercontent.com/26683324/60774986-6125ff80-a0d1-11e9-9a6e-d650061dcc21.jpg)
![TextColor_17_(1 00)](https://user-images.githubusercontent.com/26683324/60774987-6125ff80-a0d1-11e9-84ff-94c6039af656.jpg)
![TextColor_18_(1 00)](https://user-images.githubusercontent.com/26683324/60774988-6125ff80-a0d1-11e9-8312-3c8c962da526.jpg)
![TextColor_19_(1 00)](https://user-images.githubusercontent.com/26683324/60774989-6125ff80-a0d1-11e9-8316-a5654ba11b73.jpg)
![TextColor_20_(1 00)](https://user-images.githubusercontent.com/26683324/60774990-6125ff80-a0d1-11e9-80d6-a169d780ed68.jpg)
