### PR TITLE
Add D2Client DrawCenteredText

### DIFF
--- a/1.00.txt
+++ b/1.00.txt
@@ -1,5 +1,6 @@
 Library	Name	Locator Type	Locator Value	Comments	
 D2Client.dll	DifficultyLevel	Offset	0x12EDDC	nDifficultyLevel	
+D2Client.dll	DrawCenteredText	Offset	0x10EB		
 D2Client.dll	ScreenOpenMode	N/A	N/A		
 D2Client.dll	GeneralDisplayHeight	Offset	0x1681A4		
 D2Client.dll	GeneralDisplayWidth	Offset	0x1681A8		

--- a/1.03.txt
+++ b/1.03.txt
@@ -1,5 +1,6 @@
 Library	Name	Locator Type	Locator Value	Comments	
 D2Client.dll	DifficultyLevel	Offset	0x12EAC4	nDifficultyLevel	
+D2Client.dll	DrawCenteredText	Offset	0x10E6		
 D2Client.dll	ScreenOpenMode	N/A	N/A		
 D2Client.dll	GeneralDisplayHeight	Offset	0x1680AC		
 D2Client.dll	GeneralDisplayWidth	Offset	0x1680B0		

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -1,5 +1,6 @@
 Library	Name	Locator Type	Locator Value	Comments	
 D2Client.dll	DifficultyLevel	Offset	0xE3024	nDifficultyLevel	
+D2Client.dll	DrawCenteredText	Offset	0x21ED0		
 D2Client.dll	ScreenOpenMode	N/A	N/A		
 D2Client.dll	GeneralDisplayHeight	Offset	0xFB594		
 D2Client.dll	GeneralDisplayWidth	Offset	0xFB598		

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -1,5 +1,6 @@
 Library	Name	Locator Type	Locator Value	Comments	
 D2Client.dll	DifficultyLevel	Offset	0x110BBC	nDifficultyLevel	
+D2Client.dll	DrawCenteredText	Offset	0x29760		
 D2Client.dll	ScreenOpenMode	Offset	0x115C10		
 D2Client.dll	GeneralDisplayHeight	Offset	0xD40E0		
 D2Client.dll	GeneralDisplayWidth	Offset	0xD40DC		

--- a/1.10.txt
+++ b/1.10.txt
@@ -1,5 +1,6 @@
 Library	Name	Locator Type	Locator Value	Comments	
 D2Client.dll	DifficultyLevel	Offset	0x10795C	nDifficultyLevel	
+D2Client.dll	DrawCenteredText	Offset	0x2FCD0		
 D2Client.dll	ScreenOpenMode	Offset	0x10B9C4		
 D2Client.dll	GeneralDisplayHeight	Offset	0xD40F0		
 D2Client.dll	GeneralDisplayWidth	Offset	0xD40EC		

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -1,5 +1,6 @@
 Library	Name	Locator Type	Locator Value	Comments	
 D2Client.dll	DifficultyLevel	Offset	0x11BFF4	nDifficultyLevel	
+D2Client.dll	DrawCenteredText	Offset	0x6A8C0		
 D2Client.dll	ScreenOpenMode	Offset	0x11C1D0		
 D2Client.dll	GeneralDisplayHeight	Offset	0xDC6E4		
 D2Client.dll	GeneralDisplayWidth	Offset	0xDC6E0		

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -1,5 +1,6 @@
 Library	Name	Locator Type	Locator Value	Comments	
 D2Client.dll	DifficultyLevel	Offset	0x11C390	nDifficultyLevel	
+D2Client.dll	DrawCenteredText	Offset	0xBC4E0		
 D2Client.dll	ScreenOpenMode	Offset	0x11C414		
 D2Client.dll	GeneralDisplayHeight	Offset	0xDBC4C		
 D2Client.dll	GeneralDisplayWidth	Offset	0xDBC48		

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -1,5 +1,6 @@
 Library	Name	Locator Type	Locator Value	Comments	
 D2Client.dll	DifficultyLevel	Offset	0x11D1D8	nDifficultyLevel	
+D2Client.dll	DrawCenteredText	Offset	0xBEC80		
 D2Client.dll	ScreenOpenMode	Offset	0x11D070		
 D2Client.dll	GeneralDisplayHeight	Offset	0xF7038		
 D2Client.dll	GeneralDisplayWidth	Offset	0xF7034		

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -1,5 +1,6 @@
 Library	Name	Locator Type	Locator Value	Comments	
 D2Client.dll	DifficultyLevel	Offset	0x397694	nDifficultyLevel	
+D2Client.dll	DrawCenteredText	Offset	0xA3750		
 D2Client.dll	ScreenOpenMode	Offset	0x39C298		
 D2Client.dll	GeneralDisplayHeight	Offset	0x30FF4C		
 D2Client.dll	GeneralDisplayWidth	Offset	0x30FF48		

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -1,5 +1,6 @@
 Library	Name	Locator Type	Locator Value	Comments	
 D2Client.dll	DifficultyLevel	Offset	0x3A060C	nDifficultyLevel	
+D2Client.dll	DrawCenteredText	Offset	0xA7080		
 D2Client.dll	ScreenOpenMode	Offset	0x3A5210		
 D2Client.dll	GeneralDisplayHeight	Offset	0x311470		
 D2Client.dll	GeneralDisplayWidth	Offset	0x31146C		


### PR DESCRIPTION
The function draws `UnicodeChar` text onto the display, with the specified text, color, and position on the screen. The x-axis position is specified using values to represent the left and right boundaries of the text for center calculations.

The function can be located through the following way. Create a game with a character with the `Normal Attack` set on the left and right action icons. Next, open the character screen. Next, search for a function call to [D2Lang GetStringByIndex](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/13) with the parameter `id` set to 4061. The `UnicodeChar` pointer that is returned is used in a call to the target function.

Alternatively, one could also search for the bytes `B9 DD 0F 00 00` in executable regions of memory, which will yield the correct results in all the cases that have been tested.

## Function Definition
The function makes a call to [D2Win DrawText](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/37), therefore `position_y`, `text`, and `color_id` parameters are the same type.

### All Versions except 1.11 - 1.13D (inclusive)
```C
void D2Client DrawCenteredText(
  int32_t left,
  int32_t position_y,
  const UnicodeChar* text,
  int32_t right,
  int32_t color_id
)
```
- `left` in ecx
- `position_y` in edx
- Remaining parameters on the stack
  - Callee cleans the stack

### 1.11 - 1.13D (inclusive)
```C
void D2Client DrawCenteredText(
  int32_t left,
  int32_t position_y,
  const UnicodeChar* text,
  int32_t right,
  int32_t color_id
)
```
- `left` in ecx
- `text` in ebx
- `right` in eax
- Remaining parameters on the stack
  - Callee cleans the stack

## Screenshots
The following 1.00 screenshot shows the function being called, and shows the parameters and calling convention.
![D2Client_DrawCenteredText_02_(1 00)](https://user-images.githubusercontent.com/26683324/60941098-afcec780-a292-11e9-8b62-a68175a99dde.PNG)

The following 1.00 screenshot shows the function. It is very simple, calling two other functions, one of which is [D2Win DrawText](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/37). This screenshot also shows the parameters and the cleaning convention.
![D2Client_DrawCenteredText_01_(1 00)](https://user-images.githubusercontent.com/26683324/60941097-afcec780-a292-11e9-8014-9b6ba449f0ef.PNG)

The following 1.00 screenshot shows the effects of manually setting `left` to 0, `right` to 640, and `color_id` to the red value.
![D2Client_DrawCenteredText_03_(1 00)](https://user-images.githubusercontent.com/26683324/60941099-afcec780-a292-11e9-91a1-355368edf9fd.jpg)

The following 1.12A screenshot shows the function's calling convention for 1.11 - 1.13D (inclusive).
![D2Client_DrawCenteredText_05_(1 12A)](https://user-images.githubusercontent.com/26683324/60941101-afcec780-a292-11e9-9f63-65d667d238fd.PNG)

The following 1.12A screenshot shows the function for 1.11 - 1.13D (inclusive). This screenshot also shows the parameter and the cleaning convention.
![D2Client_DrawCenteredText_04_(1 12A)](https://user-images.githubusercontent.com/26683324/60941100-afcec780-a292-11e9-9aa4-d853356e30ef.PNG)
