### PR TITLE
Add D2GFX DrawRectangle

### DIFF
--- a/1.00.txt
+++ b/1.00.txt
@@ -25,6 +25,7 @@ D2GDI.dll	BitBlockWidth	Offset	0xB434
 D2GDI.dll	CelDisplayLeft	Offset	0xBF80		
 D2GDI.dll	CelDisplayRight	Offset	0xBF7C		
 D2GFX.dll	DrawCelContext	Ordinal	10076		
+D2GFX.dll	DrawRectangle	Ordinal	10059		
 D2GFX.dll	ResolutionMode	Offset	0x2A950	"0 = 640x480, 1 = Main Menu 800x600"	
 D2GFX.dll	VideoMode	Offset	0x2A948	"1 = GDI, 2 = Software, 3 = DirectDraw, 4 = Glide, 5 = OpenGL, 6 = Direct3D, 7 = Rave"	
 D2Glide.dll	DisplayHeight	Offset	0x1DE04		

--- a/1.03.txt
+++ b/1.03.txt
@@ -25,6 +25,7 @@ D2GDI.dll	BitBlockWidth	Offset	0xB434
 D2GDI.dll	CelDisplayLeft	Offset	0xBF80		
 D2GDI.dll	CelDisplayRight	Offset	0xBF7C		
 D2GFX.dll	DrawCelContext	Ordinal	10076		
+D2GFX.dll	DrawRectangle	Ordinal	10059		
 D2GFX.dll	ResolutionMode	Offset	0x2A990	"0 = 640x480, 1 = Main Menu 800x600"	
 D2GFX.dll	VideoMode	Offset	0x2A988	"1 = GDI, 2 = Software, 3 = DirectDraw, 4 = Glide, 5 = OpenGL, 6 = Direct3D, 7 = Rave"	
 D2Glide.dll	DisplayHeight	Offset	0x1DDC4		

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -25,6 +25,7 @@ D2GDI.dll	BitBlockWidth	Offset	0xAFBC
 D2GDI.dll	CelDisplayLeft	Offset	0xB8EC		
 D2GDI.dll	CelDisplayRight	Offset	0xB8E8		
 D2GFX.dll	DrawCelContext	Ordinal	10076		
+D2GFX.dll	DrawRectangle	Ordinal	10059		
 D2GFX.dll	ResolutionMode	Offset	0x1D060	"0 = 640x480, 1 = Main Menu 800x600"	
 D2GFX.dll	VideoMode	Offset	0x1D058	"1 = GDI, 2 = Software, 3 = DirectDraw, 4 = Glide, 5 = OpenGL, 6 = Direct3D, 7 = Rave"	
 D2Glide.dll	DisplayHeight	Offset	0x153AC		

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -25,6 +25,7 @@ D2GDI.dll	BitBlockWidth	Offset	0xC03C
 D2GDI.dll	CelDisplayLeft	Offset	0xC96C		
 D2GDI.dll	CelDisplayRight	Offset	0xC968		
 D2GFX.dll	DrawCelContext	Ordinal	10072		
+D2GFX.dll	DrawRectangle	Ordinal	10055		
 D2GFX.dll	ResolutionMode	Offset	0x1D210	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
 D2GFX.dll	VideoMode	Offset	0x1D208	"1 = GDI, 2 = Software, 3 = DirectDraw, 4 = Glide, 5 = OpenGL, 6 = Direct3D, 7 = Rave"	
 D2Glide.dll	DisplayHeight	Offset	0x153CC		

--- a/1.10.txt
+++ b/1.10.txt
@@ -25,6 +25,7 @@ D2GDI.dll	BitBlockWidth	Offset	0xC07C
 D2GDI.dll	CelDisplayLeft	Offset	0xC9B4		
 D2GDI.dll	CelDisplayRight	Offset	0xC9B0		
 D2GFX.dll	DrawCelContext	Ordinal	10072		
+D2GFX.dll	DrawRectangle	Ordinal	10055		
 D2GFX.dll	ResolutionMode	Offset	0x1D26C	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
 D2GFX.dll	VideoMode	Offset	0x1D264	"1 = GDI, 2 = Software, 3 = DirectDraw, 4 = Glide, 5 = OpenGL, 6 = Direct3D, 7 = Rave"	
 D2Glide.dll	DisplayHeight	Offset	0x15468		

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -25,6 +25,7 @@ D2GDI.dll	BitBlockWidth	Offset	0xCA88
 D2GDI.dll	CelDisplayLeft	Offset	0xC040		
 D2GDI.dll	CelDisplayRight	Offset	0xC044		
 D2GFX.dll	DrawCelContext	Ordinal	10024		
+D2GFX.dll	DrawRectangle	Ordinal	10062		
 D2GFX.dll	ResolutionMode	Offset	0x1D454	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
 D2GFX.dll	VideoMode	Offset	0x1D44C	"1 = GDI, 2 = Software, 3 = DirectDraw, 4 = Glide, 5 = OpenGL, 6 = Direct3D, 7 = Rave"	
 D2Glide.dll	DisplayHeight	Offset	0x16E8C		

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -26,6 +26,7 @@ D2GDI.dll	BitBlockWidth	Offset	0xCA80
 D2GDI.dll	CelDisplayLeft	Offset	0xCA98		
 D2GDI.dll	CelDisplayRight	Offset	0xCA9C		
 D2GFX.dll	DrawCelContext	Ordinal	10041		
+D2GFX.dll	DrawRectangle	Ordinal	10014		
 D2GFX.dll	ResolutionMode	Offset	0x11260	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
 D2GFX.dll	VideoMode	Offset	0x11258	"1 = GDI, 2 = Software, 3 = DirectDraw, 4 = Glide, 5 = OpenGL, 6 = Direct3D, 7 = Rave"	
 D2Glide.dll	DisplayHeight	Offset	0x15B04		

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -25,6 +25,7 @@ D2GDI.dll	BitBlockWidth	Offset	0xC970
 D2GDI.dll	CelDisplayLeft	Offset	0xCA94		
 D2GDI.dll	CelDisplayRight	Offset	0xCA98		
 D2GFX.dll	DrawCelContext	Ordinal	10042		
+D2GFX.dll	DrawRectangle	Ordinal	10028		
 D2GFX.dll	ResolutionMode	Offset	0x14A40	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
 D2GFX.dll	VideoMode	Offset	0x14A38	"1 = GDI, 2 = Software, 3 = DirectDraw, 4 = Glide, 5 = OpenGL, 6 = Direct3D, 7 = Rave"	
 D2Glide.dll	DisplayHeight	Offset	0x15B14		

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -25,6 +25,7 @@ D2GDI.dll	BitBlockWidth	Offset	0x3C01C0
 D2GDI.dll	CelDisplayLeft	Offset	0x5810F0		
 D2GDI.dll	CelDisplayRight	Offset	0x5810F4		
 D2GFX.dll	DrawCelContext	Offset	0xF3AA0		
+D2GFX.dll	DrawRectangle	Offset	0xF3910		
 D2GFX.dll	ResolutionMode	Offset	0x3BFD40	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
 D2GFX.dll	VideoMode	Offset	0x3BFD38	"1 = GDI, 2 = Software, 3 = DirectDraw, 4 = Glide, 5 = OpenGL, 6 = Direct3D, 7 = Rave"	
 D2Glide.dll	DisplayHeight	Offset	0x3C01C4		

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -25,6 +25,7 @@ D2GDI.dll	BitBlockWidth	Offset	0x3C9138
 D2GDI.dll	CelDisplayLeft	Offset	0x58A168		
 D2GDI.dll	CelDisplayRight	Offset	0x58A16C		
 D2GFX.dll	DrawCelContext	Offset	0xF6480		
+D2GFX.dll	DrawRectangle	Offset	0xF6300		
 D2GFX.dll	ResolutionMode	Offset	0x3C8CB8	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
 D2GFX.dll	VideoMode	Offset	0x3C8CB0	"1 = GDI, 2 = Software, 3 = DirectDraw, 4 = Glide, 5 = OpenGL, 6 = Direct3D, 7 = Rave"	
 D2Glide.dll	DisplayHeight	Offset	0x3C913C		


### PR DESCRIPTION
The function draws a rectangle to the screen by calling the appropriate function for the active video mode. The rectangle's position, dimensions, color, and level of transparency can be controlled.

The function can be located by mousing over any HUD element that displays red text with a black background rectangle (such as the left or right action icons) and scanning for the value 1. Move the mouse away from the HUD element and rescan for the value 0. Repeat until a global variable reveals itself. A function will be accessing this variable.  The target function is called inside of that function, with at least two or three calls in that function alone.

## Function Definition
### All Versions
```C
void D2GFX_DrawRectangle(
  int32_t left,
  int32_t top,
  int32_t right,
  int32_t bottom,
  uint32_t primitive_color_id,
  uint32_t draw_cel_context_effect
)
```
- All parameters on the stack
  - Callee cleans the stack

## Screenshots
The following 1.00 screenshot shows the function parameters being modified to display the stamina bar with different parameters. The parameter `draw_cel_context_effect` is the same as the one in [D2GFX DrawCelContext](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/34).
![D2GFX_DrawRectangle_03_(1 00)](https://user-images.githubusercontent.com/26683324/61195393-7e803e00-a67c-11e9-9c79-c039d8b1c4fb.jpg)

The following 1.00 screenshot shows the function itself. It is a wrapper for the active video mode. It also shows the function's cleanup convention.
![D2GFX_DrawRectangle_01_(1 00)](https://user-images.githubusercontent.com/26683324/61195427-c2734300-a67c-11e9-9eaf-92d9a52c3bce.PNG)

The following 1.10 screenshot shows that `primitive_color_id` is a `uint32_t` but has only 256 possible values, because the function manipulates the parameter as if it were a `uint8_t`.
![D2GFX_DrawRectangle_02_(1 10)](https://user-images.githubusercontent.com/26683324/61195438-d74fd680-a67c-11e9-82f4-20ee171e773a.PNG)

The following 1.10 screenshot shows that `left`, `top`, `right`, and `bottom` are all `int32_t`.
![D2GFX_DrawRectangle_04_(1 10)](https://user-images.githubusercontent.com/26683324/61195474-19791800-a67d-11e9-86ee-8d989b3d2ddc.jpg)

This final screenshot was taken by Loli (the author of Loli BH), which displays all the colors and their associated values.
![D2GFX_DrawRectangle_05_(NONE)](https://user-images.githubusercontent.com/26683324/61195514-56dda580-a67d-11e9-87e7-0ccfdf99b821.png)
