### PR TITLE
Add D2Win SetTextFont

### DIFF
--- a/1.00.txt
+++ b/1.00.txt
@@ -58,6 +58,7 @@ D2Win.dll	LoadMPQ	Offset	0x1458A
 D2Win.dll	MainMenuMousePositionX	Offset	0x72A90		
 D2Win.dll	MainMenuMousePositionY	Offset	0x72A94		
 D2Win.dll	SetPopUpText	Ordinal	10122		
+D2Win.dll	SetTextFont	Ordinal	10120		
 D2Win.dll	UnloadCelFile	Ordinal	10037		
 D2Win.dll	UnloadMPQ	Offset	0x14729		
 Fog.dll	AllocClientMemory	Ordinal	10033		

--- a/1.03.txt
+++ b/1.03.txt
@@ -41,6 +41,7 @@ D2Win.dll	LoadMPQ	Offset	0x146FA
 D2Win.dll	MainMenuMousePositionX	Offset	0x72A98		
 D2Win.dll	MainMenuMousePositionY	Offset	0x72A9C		
 D2Win.dll	SetPopUpText	Ordinal	10122		
+D2Win.dll	SetTextFont	Ordinal	10120		
 D2Win.dll	UnloadCelFile	Ordinal	10037		
 D2Win.dll	UnloadMPQ	Offset	0x148A7		
 Fog.dll	AllocClientMemory	Ordinal	10033		

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -41,6 +41,7 @@ D2Win.dll	LoadMPQ	Offset	0x10595
 D2Win.dll	MainMenuMousePositionX	Offset	0x5BCB8		
 D2Win.dll	MainMenuMousePositionY	Offset	0x5BCBC		
 D2Win.dll	SetPopUpText	Ordinal	10122		
+D2Win.dll	SetTextFont	Ordinal	10120		
 D2Win.dll	UnloadCelFile	Ordinal	10037		
 D2Win.dll	UnloadMPQ	Offset	0x10742		
 Fog.dll	AllocClientMemory	Ordinal	10033		

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -41,6 +41,7 @@ D2Win.dll	LoadMPQ	Offset	0x142FB
 D2Win.dll	MainMenuMousePositionX	Offset	0x618A0		
 D2Win.dll	MainMenuMousePositionY	Offset	0x618A4		
 D2Win.dll	SetPopUpText	Ordinal	10129		
+D2Win.dll	SetTextFont	Ordinal	10127		
 D2Win.dll	UnloadCelFile	Ordinal	10041		
 D2Win.dll	UnloadMPQ	Offset	0x144A6		
 Fog.dll	AllocClientMemory	Ordinal	10042		

--- a/1.10.txt
+++ b/1.10.txt
@@ -41,6 +41,7 @@ D2Win.dll	LoadMPQ	Offset	0x12399
 D2Win.dll	MainMenuMousePositionX	Offset	0x5E234		
 D2Win.dll	MainMenuMousePositionY	Offset	0x5E238		
 D2Win.dll	SetPopUpText	Ordinal	10129		
+D2Win.dll	SetTextFont	Ordinal	10127		
 D2Win.dll	UnloadCelFile	Ordinal	10041		
 D2Win.dll	UnloadMPQ	Offset	0x12548		
 Fog.dll	AllocClientMemory	Ordinal	10042		

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -41,6 +41,7 @@ D2Win.dll	LoadMPQ	Offset	0x7E40
 D2Win.dll	MainMenuMousePositionX	Offset	0x5C700		
 D2Win.dll	MainMenuMousePositionY	Offset	0x5C704		
 D2Win.dll	SetPopUpText	Ordinal	10031		
+D2Win.dll	SetTextFont	Ordinal	10010		
 D2Win.dll	UnloadCelFile	Ordinal	10130		
 D2Win.dll	UnloadMPQ	Offset	0x78D0		
 Fog.dll	AllocClientMemory	Ordinal	10042		

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -44,6 +44,7 @@ D2Win.dll	LoadMPQ	Offset	0x7E60
 D2Win.dll	MainMenuMousePositionX	Offset	0x21488		
 D2Win.dll	MainMenuMousePositionY	Offset	0x2148C		
 D2Win.dll	SetPopUpText	Ordinal	10085		
+D2Win.dll	SetTextFont	Ordinal	10184		
 D2Win.dll	UnloadCelFile	Ordinal	10126		
 D2Win.dll	UnloadMPQ	Offset	0x78F0		
 Fog.dll	AllocClientMemory	Ordinal	10042		

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -41,6 +41,7 @@ D2Win.dll	LoadMPQ	Offset	0x7E50
 D2Win.dll	MainMenuMousePositionX	Offset	0x8DB1C		
 D2Win.dll	MainMenuMousePositionY	Offset	0x8DB20		
 D2Win.dll	SetPopUpText	Ordinal	10137		
+D2Win.dll	SetTextFont	Ordinal	10047		
 D2Win.dll	UnloadCelFile	Ordinal	10189		
 D2Win.dll	UnloadMPQ	Offset	0x78E0		
 Fog.dll	AllocClientMemory	Ordinal	10042		

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -41,6 +41,7 @@ D2Win.dll	LoadMPQ	Offset	0x114FF7
 D2Win.dll	MainMenuMousePositionX	Offset	0x3CC62C		
 D2Win.dll	MainMenuMousePositionY	Offset	0x3CC630		
 D2Win.dll	SetPopUpText	Offset	0xFFAD0		
+D2Win.dll	SetTextFont	Offset	0x100750		
 D2Win.dll	UnloadCelFile	Offset	0xF80B0		
 D2Win.dll	UnloadMPQ	Offset	0x115071		
 Fog.dll	AllocClientMemory	Offset	0x6B90		

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -41,6 +41,7 @@ D2Win.dll	LoadMPQ	Offset	0x117332
 D2Win.dll	MainMenuMousePositionX	Offset	0x3D55A4		
 D2Win.dll	MainMenuMousePositionY	Offset	0x3D55A8		
 D2Win.dll	SetPopUpText	Offset	0x102280		
+D2Win.dll	SetTextFont	Offset	0x102EF0		
 D2Win.dll	UnloadCelFile	Offset	0xFAAE0		
 D2Win.dll	UnloadMPQ	Offset	0x1173AC		
 Fog.dll	AllocClientMemory	Offset	0xB380		


### PR DESCRIPTION
The function sets the text font that is used when calling [D2Win DrawText](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/37). The function then returns the value of the text font before calling the function.

The function can be located by opening and closing the skill tree screen, scanning 0 for closed and 1 for opened. A function uses this variable to control whether a function is executed or not. Inside of that function, one of the first, if not the first, D2Win function that is called is the target function.

## Function Definition
### All Versions
```C
int32_t D2Win_SetTextFont(
  int32_t text_font_id
)
```
- `text_font_id` in ecx

The parameter `text_font_id` is a 32-bit value. Signed or unsigned makes no difference. These are the possible values and associate effects:
```
0 = Formal_8
1 = Exocet_16
2 = DiabloMenu_30
3 = DiabloMenu_42
4 = Formal_10
5 = Formal_12
6 = Formal_6
7 = DiabloMenu_24
8 = FormalWide_11
9 = Exocet_10
10 = Exocet_9
11 = Exocet_8
12 = (same as 6)
13 = Formal_11
```

Note that list may not be entirely accurate.

## Screenshots
The following 1.00 screenshot shows the function's calling convention and parameter.
![D2Win_SetTextFont_01_(1 00)](https://user-images.githubusercontent.com/26683324/61428128-b6ce8900-a8d5-11e9-976d-b8d1c9d9b2b9.PNG)

The following 1.00 screenshot shows the function's cleanup convention and return value.
![D2Win_SetTextFont_02_(1 00)](https://user-images.githubusercontent.com/26683324/61428129-b6ce8900-a8d5-11e9-9546-78eb0fd59e4d.PNG)

The following 1.10 screenshot shows the development names used for each of the fonts.
![TextFont_Names_(1 10)](https://user-images.githubusercontent.com/26683324/61428304-67d52380-a8d6-11e9-92ac-4be93dfe67d2.PNG)

The following 1.00 screenshot shows the different fonts in ascending order, starting from the font associated with the value 0.
![TextFont_00_(1 00)](https://user-images.githubusercontent.com/26683324/61428344-9ce17600-a8d6-11e9-908f-50998b6360d4.jpg)
![TextFont_01_(1 00)](https://user-images.githubusercontent.com/26683324/61428345-9ce17600-a8d6-11e9-80c7-214dc2fc3486.jpg)
![TextFont_02_(1 00)](https://user-images.githubusercontent.com/26683324/61428346-9ce17600-a8d6-11e9-85ab-13c60ee7191a.jpg)
![TextFont_03_(1 00)](https://user-images.githubusercontent.com/26683324/61428347-9ce17600-a8d6-11e9-951f-7b20729ea0fe.jpg)
![TextFont_04_(1 00)](https://user-images.githubusercontent.com/26683324/61428348-9ce17600-a8d6-11e9-83b7-f9ff3bda9222.jpg)
![TextFont_05_(1 00)](https://user-images.githubusercontent.com/26683324/61428349-9d7a0c80-a8d6-11e9-87b0-8e3b7429e5cc.jpg)
![TextFont_06_(1 00)](https://user-images.githubusercontent.com/26683324/61428350-9d7a0c80-a8d6-11e9-9bfc-cd9be51bf4ff.jpg)
![TextFont_07_(1 00)](https://user-images.githubusercontent.com/26683324/61428351-9d7a0c80-a8d6-11e9-8e2d-2c4b4f32baeb.jpg)
![TextFont_08_(1 00)](https://user-images.githubusercontent.com/26683324/61428352-9d7a0c80-a8d6-11e9-9ed5-e776da746225.jpg)
![TextFont_09_(1 00)](https://user-images.githubusercontent.com/26683324/61428353-9d7a0c80-a8d6-11e9-9c17-95b8bc5ae029.jpg)
![TextFont_10_(1 00)](https://user-images.githubusercontent.com/26683324/61428354-9d7a0c80-a8d6-11e9-94ee-e61e25d61394.jpg)
![TextFont_11_(1 00)](https://user-images.githubusercontent.com/26683324/61428355-9d7a0c80-a8d6-11e9-8480-8e87967da1e6.jpg)
![TextFont_12_(1 00)](https://user-images.githubusercontent.com/26683324/61428356-9e12a300-a8d6-11e9-876a-c796481cfbda.jpg)
![TextFont_13_(1 00)](https://user-images.githubusercontent.com/26683324/61428357-9e12a300-a8d6-11e9-8657-6b66c961b5b0.jpg)
