### PR TITLE
Rename Unicode Text

### DIFF
--- a/1.00.txt
+++ b/1.00.txt
@@ -1,7 +1,6 @@
 Library	Name	Locator Type	Locator Value	Comments	
 D2Client.dll	DifficultyLevel	Offset	0x12EDDC	nDifficultyLevel	
 D2Client.dll	DrawCenteredUnicodeText	Offset	0x10EB		
-D2Client.dll	ScreenOpenMode	N/A	N/A		
 D2Client.dll	GeneralDisplayHeight	Offset	0x1681A4		
 D2Client.dll	GeneralDisplayWidth	Offset	0x1681A8		
 D2Client.dll	GeneralPlayAreaCameraShiftX	Offset	0x1348AC		
@@ -13,6 +12,7 @@ D2Client.dll	IsGameMenuOpen	Offset	0x143660
 D2Client.dll	IsHelpScreenOpen	Offset	0x1436C0		
 D2Client.dll	IsNewSkillButtonPressed	Offset	0x13DDF8		
 D2Client.dll	IsNewStatsButtonPressed	Offset	0x13DDF4		
+D2Client.dll	ScreenOpenMode	N/A	N/A		
 D2Client.dll	ScreenShiftX	N/A	N/A		
 D2Client.dll	ScreenShiftY	N/A	N/A		
 D2CMP.dll	CloseCelFile	Ordinal	10032		
@@ -30,9 +30,14 @@ D2GFX.dll	ResolutionMode	Offset	0x2A950	"0 = 640x480, 1 = Main Menu 800x600"
 D2GFX.dll	VideoMode	Offset	0x2A948	"1 = GDI, 2 = Software, 3 = DirectDraw, 4 = Glide, 5 = OpenGL, 6 = Direct3D, 7 = Rave"	
 D2Glide.dll	DisplayHeight	Offset	0x1DE04		
 D2Glide.dll	DisplayWidth	Offset	0x1DD44		
-D2Lang.dll	GetLocaleText	Ordinal	10004		
-D2Lang.dll	ToUnicodeString	Offset	0x1118	?toUnicode@Unicode@@SIPAU1@PAU1@PBDH@Z	Unicode::toUnicode
 D2Lang.dll	ConvertUnicodeToWin				
+D2Lang.dll	GetLocaleText	Ordinal	10004		
+D2Lang.dll	GetStringByIndex	Ordinal	10004		
+D2Lang.dll	ToUnicodeString	Offset	0x1118	?toUnicode@Unicode@@SIPAU1@PAU1@PBDH@Z	Unicode::toUnicode
+D2Lang.dll	Unicode_strcat	Offset	0x10B4		Unicode::strcat
+D2Lang.dll	Unicode_strlen	Offset	0x1055	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
+D2Lang.dll	Unicode_tolower	Offset	0x1014	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
+D2Lang.dll	Unicode_toupper	Offset	0x1154		Unicode::toUpper
 D2Lang.dll	UnicodeChar_Compare	Offset	0x1019	?compare@Unicode@@SIHU1@0@Z	Unicode::compare
 D2Lang.dll	UnicodeChar_Copy	Offset	0x1136	??4Unicode@@QAEAAU0@ABU0@@Z	Unicode::operator=
 D2Lang.dll	UnicodeChar_CreateWithNoArgs	Offset	0x10CD	??_FUnicode@@QAEXXZ	Unicode::`default constructor closure'
@@ -45,11 +50,6 @@ D2Lang.dll	UnicodeString_Compare	Offset	0x1050	?strcmp@Unicode@@SIHPBU1@0@Z	Unic
 D2Lang.dll	UnicodeString_CompareIgnoreCase	Offset	0x100A	?stricmp@Unicode@@SIHPBU1@0@Z	Unicode::stricmp
 D2Lang.dll	UnicodeString_FindChar	Offset	0x101E	?strchr@Unicode@@SIPAU1@PBU1@U1@@Z	Unicode::strchr
 D2Lang.dll	UnicodeString_Format	Offset	0x1046	?sprintf@Unicode@@SAXHPAU1@PBU1@ZZ	Unicode::sprintf
-D2Lang.dll	GetStringByIndex	Ordinal	10004		
-D2Lang.dll	Unicode_strcat	Offset	0x10B4		Unicode::strcat
-D2Lang.dll	Unicode_strlen	Offset	0x1055	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
-D2Lang.dll	Unicode_tolower	Offset	0x1014	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
-D2Lang.dll	Unicode_toupper	Offset	0x1154		Unicode::toUpper
 D2Lang.dll	UnicodeString_NCompareIgnoreCase	Offset	0x1091	?strnicmp@Unicode@@SIHPBU1@0I@Z	Unicode::strnicmp
 D2Lang.dll	UnloadSysMap	Offset	0x104B	?unloadSysMap@Unicode@@SIXXZ	Unicode::unloadSysMap
 D2Win.dll	DrawUnicodeText	Ordinal	10110		

--- a/1.00.txt
+++ b/1.00.txt
@@ -1,6 +1,6 @@
 Library	Name	Locator Type	Locator Value	Comments	
 D2Client.dll	DifficultyLevel	Offset	0x12EDDC	nDifficultyLevel	
-D2Client.dll	DrawCenteredText	Offset	0x10EB		
+D2Client.dll	DrawCenteredUnicodeText	Offset	0x10EB		
 D2Client.dll	ScreenOpenMode	N/A	N/A		
 D2Client.dll	GeneralDisplayHeight	Offset	0x1681A4		
 D2Client.dll	GeneralDisplayWidth	Offset	0x1681A8		
@@ -52,13 +52,13 @@ D2Lang.dll	Unicode_tolower	Offset	0x1014	?toLower@Unicode@@QBE?AU1@XZ	Unicode::t
 D2Lang.dll	Unicode_toupper	Offset	0x1154		Unicode::toUpper
 D2Lang.dll	UnicodeString_NCompareIgnoreCase	Offset	0x1091	?strnicmp@Unicode@@SIHPBU1@0I@Z	Unicode::strnicmp
 D2Lang.dll	UnloadSysMap	Offset	0x104B	?unloadSysMap@Unicode@@SIXXZ	Unicode::unloadSysMap
-D2Win.dll	DrawText	Ordinal	10110		
+D2Win.dll	DrawUnicodeText	Ordinal	10110		
 D2Win.dll	LoadCelFile	Ordinal	10035		
 D2Win.dll	LoadMPQ	Offset	0x1458A		
 D2Win.dll	MainMenuMousePositionX	Offset	0x72A90		
 D2Win.dll	MainMenuMousePositionY	Offset	0x72A94		
-D2Win.dll	SetPopUpText	Ordinal	10122		
-D2Win.dll	SetTextFont	Ordinal	10120		
+D2Win.dll	SetDrawUnicodeTextFont	Ordinal	10120		
+D2Win.dll	SetPopUpUnicodeText	Ordinal	10122		
 D2Win.dll	UnloadCelFile	Ordinal	10037		
 D2Win.dll	UnloadMPQ	Offset	0x14729		
 Fog.dll	AllocClientMemory	Ordinal	10033		

--- a/1.00.txt
+++ b/1.00.txt
@@ -31,7 +31,6 @@ D2GFX.dll	VideoMode	Offset	0x2A948	"1 = GDI, 2 = Software, 3 = DirectDraw, 4 = G
 D2Glide.dll	DisplayHeight	Offset	0x1DE04		
 D2Glide.dll	DisplayWidth	Offset	0x1DD44		
 D2Lang.dll	ConvertUnicodeToWin				
-D2Lang.dll	GetLocaleText	Ordinal	10004		
 D2Lang.dll	GetStringByIndex	Ordinal	10004		
 D2Lang.dll	ToUnicodeString	Offset	0x1118	?toUnicode@Unicode@@SIPAU1@PAU1@PBDH@Z	Unicode::toUnicode
 D2Lang.dll	Unicode_strcat	Offset	0x10B4		Unicode::strcat

--- a/1.03.txt
+++ b/1.03.txt
@@ -1,7 +1,6 @@
 Library	Name	Locator Type	Locator Value	Comments	
 D2Client.dll	DifficultyLevel	Offset	0x12EAC4	nDifficultyLevel	
 D2Client.dll	DrawCenteredUnicodeText	Offset	0x10E6		
-D2Client.dll	ScreenOpenMode	N/A	N/A		
 D2Client.dll	GeneralDisplayHeight	Offset	0x1680AC		
 D2Client.dll	GeneralDisplayWidth	Offset	0x1680B0		
 D2Client.dll	GeneralPlayAreaCameraShiftX	Offset	0x134594		
@@ -13,6 +12,7 @@ D2Client.dll	IsGameMenuOpen	Offset	0x143530
 D2Client.dll	IsHelpScreenOpen	Offset	0x143590		
 D2Client.dll	IsNewSkillButtonPressed	Offset	0x13DB30		
 D2Client.dll	IsNewStatsButtonPressed	Offset	0x13DB2C		
+D2Client.dll	ScreenOpenMode	N/A	N/A		
 D2Client.dll	ScreenShiftX	N/A	N/A		
 D2Client.dll	ScreenShiftY	N/A	N/A		
 D2CMP.dll	CloseCelFile	Ordinal	10032		

--- a/1.03.txt
+++ b/1.03.txt
@@ -1,6 +1,6 @@
 Library	Name	Locator Type	Locator Value	Comments	
 D2Client.dll	DifficultyLevel	Offset	0x12EAC4	nDifficultyLevel	
-D2Client.dll	DrawCenteredText	Offset	0x10E6		
+D2Client.dll	DrawCenteredUnicodeText	Offset	0x10E6		
 D2Client.dll	ScreenOpenMode	N/A	N/A		
 D2Client.dll	GeneralDisplayHeight	Offset	0x1680AC		
 D2Client.dll	GeneralDisplayWidth	Offset	0x1680B0		
@@ -35,13 +35,13 @@ D2Lang.dll	Unicode_strcat	Offset	0x10B4		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x1055	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x1014	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x1154		Unicode::toUpper
-D2Win.dll	DrawText	Ordinal	10110		
+D2Win.dll	DrawUnicodeText	Ordinal	10110		
 D2Win.dll	LoadCelFile	Ordinal	10035		
 D2Win.dll	LoadMPQ	Offset	0x146FA		
 D2Win.dll	MainMenuMousePositionX	Offset	0x72A98		
 D2Win.dll	MainMenuMousePositionY	Offset	0x72A9C		
-D2Win.dll	SetPopUpText	Ordinal	10122		
-D2Win.dll	SetTextFont	Ordinal	10120		
+D2Win.dll	SetDrawUnicodeTextFont	Ordinal	10120		
+D2Win.dll	SetPopUpUnicodeText	Ordinal	10122		
 D2Win.dll	UnloadCelFile	Ordinal	10037		
 D2Win.dll	UnloadMPQ	Offset	0x148A7		
 Fog.dll	AllocClientMemory	Ordinal	10033		

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -1,7 +1,6 @@
 Library	Name	Locator Type	Locator Value	Comments	
 D2Client.dll	DifficultyLevel	Offset	0xE3024	nDifficultyLevel	
 D2Client.dll	DrawCenteredUnicodeText	Offset	0x21ED0		
-D2Client.dll	ScreenOpenMode	N/A	N/A		
 D2Client.dll	GeneralDisplayHeight	Offset	0xFB594		
 D2Client.dll	GeneralDisplayWidth	Offset	0xFB598		
 D2Client.dll	GeneralPlayAreaCameraShiftX	Offset	0xE7B4C		
@@ -13,6 +12,7 @@ D2Client.dll	IsGameMenuOpen	Offset	0xF4D98
 D2Client.dll	IsHelpScreenOpen	Offset	0xF4DF8		
 D2Client.dll	IsNewSkillButtonPressed	Offset	0xF01F8		
 D2Client.dll	IsNewStatsButtonPressed	Offset	0xF01F4		
+D2Client.dll	ScreenOpenMode	N/A	N/A		
 D2Client.dll	ScreenShiftX	N/A	N/A		
 D2Client.dll	ScreenShiftY	N/A	N/A		
 D2CMP.dll	CloseCelFile	Ordinal	10032		

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -1,6 +1,6 @@
 Library	Name	Locator Type	Locator Value	Comments	
 D2Client.dll	DifficultyLevel	Offset	0xE3024	nDifficultyLevel	
-D2Client.dll	DrawCenteredText	Offset	0x21ED0		
+D2Client.dll	DrawCenteredUnicodeText	Offset	0x21ED0		
 D2Client.dll	ScreenOpenMode	N/A	N/A		
 D2Client.dll	GeneralDisplayHeight	Offset	0xFB594		
 D2Client.dll	GeneralDisplayWidth	Offset	0xFB598		
@@ -35,13 +35,13 @@ D2Lang.dll	Unicode_strcat	Offset	0x13A0		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x1490	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10E0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10B0		Unicode::toUpper
-D2Win.dll	DrawText	Ordinal	10110		
+D2Win.dll	DrawUnicodeText	Ordinal	10110		
 D2Win.dll	LoadCelFile	Ordinal	10035		
 D2Win.dll	LoadMPQ	Offset	0x10595		
 D2Win.dll	MainMenuMousePositionX	Offset	0x5BCB8		
 D2Win.dll	MainMenuMousePositionY	Offset	0x5BCBC		
-D2Win.dll	SetPopUpText	Ordinal	10122		
-D2Win.dll	SetTextFont	Ordinal	10120		
+D2Win.dll	SetDrawUnicodeTextFont	Ordinal	10120		
+D2Win.dll	SetPopUpUnicodeText	Ordinal	10122		
 D2Win.dll	UnloadCelFile	Ordinal	10037		
 D2Win.dll	UnloadMPQ	Offset	0x10742		
 Fog.dll	AllocClientMemory	Ordinal	10033		

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -1,6 +1,6 @@
 Library	Name	Locator Type	Locator Value	Comments	
 D2Client.dll	DifficultyLevel	Offset	0x110BBC	nDifficultyLevel	
-D2Client.dll	DrawCenteredText	Offset	0x29760		
+D2Client.dll	DrawCenteredUnicodeText	Offset	0x29760		
 D2Client.dll	ScreenOpenMode	Offset	0x115C10		
 D2Client.dll	GeneralDisplayHeight	Offset	0xD40E0		
 D2Client.dll	GeneralDisplayWidth	Offset	0xD40DC		
@@ -35,13 +35,13 @@ D2Lang.dll	Unicode_strcat	Offset	0x13A0		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x1490	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10E0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10B0		Unicode::toUpper
-D2Win.dll	DrawText	Ordinal	10117		
+D2Win.dll	DrawUnicodeText	Ordinal	10117		
 D2Win.dll	LoadCelFile	Ordinal	10039		
 D2Win.dll	LoadMPQ	Offset	0x142FB		
 D2Win.dll	MainMenuMousePositionX	Offset	0x618A0		
 D2Win.dll	MainMenuMousePositionY	Offset	0x618A4		
-D2Win.dll	SetPopUpText	Ordinal	10129		
-D2Win.dll	SetTextFont	Ordinal	10127		
+D2Win.dll	SetDrawUnicodeTextFont	Ordinal	10127		
+D2Win.dll	SetPopUpUnicodeText	Ordinal	10129		
 D2Win.dll	UnloadCelFile	Ordinal	10041		
 D2Win.dll	UnloadMPQ	Offset	0x144A6		
 Fog.dll	AllocClientMemory	Ordinal	10042		

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -1,7 +1,6 @@
 Library	Name	Locator Type	Locator Value	Comments	
 D2Client.dll	DifficultyLevel	Offset	0x110BBC	nDifficultyLevel	
 D2Client.dll	DrawCenteredUnicodeText	Offset	0x29760		
-D2Client.dll	ScreenOpenMode	Offset	0x115C10		
 D2Client.dll	GeneralDisplayHeight	Offset	0xD40E0		
 D2Client.dll	GeneralDisplayWidth	Offset	0xD40DC		
 D2Client.dll	GeneralPlayAreaCameraShiftX	Offset	0x115C14		
@@ -13,6 +12,7 @@ D2Client.dll	IsGameMenuOpen	Offset	0x1248D8
 D2Client.dll	IsHelpScreenOpen	Offset	0x124938		
 D2Client.dll	IsNewSkillButtonPressed	Offset	0x11FE88		
 D2Client.dll	IsNewStatsButtonPressed	Offset	0x11FE84		
+D2Client.dll	ScreenOpenMode	Offset	0x115C10		
 D2Client.dll	ScreenShiftX	Offset	0x124954		
 D2Client.dll	ScreenShiftY	Offset	0x124958		
 D2CMP.dll	CloseCelFile	Ordinal	10032		

--- a/1.10.txt
+++ b/1.10.txt
@@ -1,7 +1,6 @@
 Library	Name	Locator Type	Locator Value	Comments	
 D2Client.dll	DifficultyLevel	Offset	0x10795C	nDifficultyLevel	
 D2Client.dll	DrawCenteredUnicodeText	Offset	0x2FCD0		
-D2Client.dll	ScreenOpenMode	Offset	0x10B9C4		
 D2Client.dll	GeneralDisplayHeight	Offset	0xD40F0		
 D2Client.dll	GeneralDisplayWidth	Offset	0xD40EC		
 D2Client.dll	GeneralPlayAreaCameraShiftX	Offset	0x10B9C8		
@@ -13,6 +12,7 @@ D2Client.dll	IsGameMenuOpen	Offset	0x11A6CC
 D2Client.dll	IsHelpScreenOpen	Offset	0x11A72C		
 D2Client.dll	IsNewSkillButtonPressed	Offset	0x115BC0		
 D2Client.dll	IsNewStatsButtonPressed	Offset	0x115BBC		
+D2Client.dll	ScreenOpenMode	Offset	0x10B9C4		
 D2Client.dll	ScreenShiftX	Offset	0x11A748		
 D2Client.dll	ScreenShiftY	Offset	0x11A74C		
 D2CMP.dll	CloseCelFile	Ordinal	10032		

--- a/1.10.txt
+++ b/1.10.txt
@@ -1,6 +1,6 @@
 Library	Name	Locator Type	Locator Value	Comments	
 D2Client.dll	DifficultyLevel	Offset	0x10795C	nDifficultyLevel	
-D2Client.dll	DrawCenteredText	Offset	0x2FCD0		
+D2Client.dll	DrawCenteredUnicodeText	Offset	0x2FCD0		
 D2Client.dll	ScreenOpenMode	Offset	0x10B9C4		
 D2Client.dll	GeneralDisplayHeight	Offset	0xD40F0		
 D2Client.dll	GeneralDisplayWidth	Offset	0xD40EC		
@@ -35,13 +35,13 @@ D2Lang.dll	Unicode_strcat	Offset	0x13F0		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x14C0	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10E0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10B0		Unicode::toUpper
-D2Win.dll	DrawText	Ordinal	10117		
+D2Win.dll	DrawUnicodeText	Ordinal	10117		
 D2Win.dll	LoadCelFile	Ordinal	10039		
 D2Win.dll	LoadMPQ	Offset	0x12399		
 D2Win.dll	MainMenuMousePositionX	Offset	0x5E234		
 D2Win.dll	MainMenuMousePositionY	Offset	0x5E238		
-D2Win.dll	SetPopUpText	Ordinal	10129		
-D2Win.dll	SetTextFont	Ordinal	10127		
+D2Win.dll	SetDrawUnicodeTextFont	Ordinal	10127		
+D2Win.dll	SetPopUpUnicodeText	Ordinal	10129		
 D2Win.dll	UnloadCelFile	Ordinal	10041		
 D2Win.dll	UnloadMPQ	Offset	0x12548		
 Fog.dll	AllocClientMemory	Ordinal	10042		

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -1,7 +1,6 @@
 Library	Name	Locator Type	Locator Value	Comments	
 D2Client.dll	DifficultyLevel	Offset	0x11BFF4	nDifficultyLevel	
 D2Client.dll	DrawCenteredUnicodeText	Offset	0x6A8C0		
-D2Client.dll	ScreenOpenMode	Offset	0x11C1D0		
 D2Client.dll	GeneralDisplayHeight	Offset	0xDC6E4		
 D2Client.dll	GeneralDisplayWidth	Offset	0xDC6E0		
 D2Client.dll	GeneralPlayAreaCameraShiftX	Offset	0x11C1D4		
@@ -13,6 +12,7 @@ D2Client.dll	IsGameMenuOpen	Offset	0x102B7C
 D2Client.dll	IsHelpScreenOpen	Offset	0x102BDC		
 D2Client.dll	IsNewSkillButtonPressed	Offset	0x11C348		
 D2Client.dll	IsNewStatsButtonPressed	Offset	0x11C344		
+D2Client.dll	ScreenOpenMode	Offset	0x11C1D0		
 D2Client.dll	ScreenShiftX	Offset	0x11BD28		
 D2Client.dll	ScreenShiftY	Offset	0x11BD2C		
 D2CMP.dll	CloseCelFile	Ordinal	10106		

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -1,6 +1,6 @@
 Library	Name	Locator Type	Locator Value	Comments	
 D2Client.dll	DifficultyLevel	Offset	0x11BFF4	nDifficultyLevel	
-D2Client.dll	DrawCenteredText	Offset	0x6A8C0		
+D2Client.dll	DrawCenteredUnicodeText	Offset	0x6A8C0		
 D2Client.dll	ScreenOpenMode	Offset	0x11C1D0		
 D2Client.dll	GeneralDisplayHeight	Offset	0xDC6E4		
 D2Client.dll	GeneralDisplayWidth	Offset	0xDC6E0		
@@ -35,13 +35,13 @@ D2Lang.dll	Unicode_strcat	Offset	0xA610		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0xA6E0	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10C0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10A0		Unicode::toUpper
-D2Win.dll	DrawText	Ordinal	10001		
+D2Win.dll	DrawUnicodeText	Ordinal	10001		
 D2Win.dll	LoadCelFile	Ordinal	10186		
 D2Win.dll	LoadMPQ	Offset	0x7E40		
 D2Win.dll	MainMenuMousePositionX	Offset	0x5C700		
 D2Win.dll	MainMenuMousePositionY	Offset	0x5C704		
-D2Win.dll	SetPopUpText	Ordinal	10031		
-D2Win.dll	SetTextFont	Ordinal	10010		
+D2Win.dll	SetDrawUnicodeTextFont	Ordinal	10010		
+D2Win.dll	SetPopUpUnicodeText	Ordinal	10031		
 D2Win.dll	UnloadCelFile	Ordinal	10130		
 D2Win.dll	UnloadMPQ	Offset	0x78D0		
 Fog.dll	AllocClientMemory	Ordinal	10042		

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -1,6 +1,6 @@
 Library	Name	Locator Type	Locator Value	Comments	
 D2Client.dll	DifficultyLevel	Offset	0x11C390	nDifficultyLevel	
-D2Client.dll	DrawCenteredText	Offset	0xBC4E0		
+D2Client.dll	DrawCenteredUnicodeText	Offset	0xBC4E0		
 D2Client.dll	ScreenOpenMode	Offset	0x11C414		
 D2Client.dll	GeneralDisplayHeight	Offset	0xDBC4C		
 D2Client.dll	GeneralDisplayWidth	Offset	0xDBC48		
@@ -38,13 +38,13 @@ D2Lang.dll	Unicode_strcat	Offset	0xAFE0		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0xB0B0	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10C0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10A0		Unicode::toUpper
-D2Win.dll	DrawText	Ordinal	10150		
+D2Win.dll	DrawUnicodeText	Ordinal	10150		
 D2Win.dll	LoadCelFile	Ordinal	10111		
 D2Win.dll	LoadMPQ	Offset	0x7E60		
 D2Win.dll	MainMenuMousePositionX	Offset	0x21488		
 D2Win.dll	MainMenuMousePositionY	Offset	0x2148C		
-D2Win.dll	SetPopUpText	Ordinal	10085		
-D2Win.dll	SetTextFont	Ordinal	10184		
+D2Win.dll	SetDrawUnicodeTextFont	Ordinal	10184		
+D2Win.dll	SetPopUpUnicodeText	Ordinal	10085		
 D2Win.dll	UnloadCelFile	Ordinal	10126		
 D2Win.dll	UnloadMPQ	Offset	0x78F0		
 Fog.dll	AllocClientMemory	Ordinal	10042		

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -15,7 +15,6 @@ D2Client.dll	IsNewStatsButtonPressed	Offset	0x11C308
 D2Client.dll	ScreenOpenMode	Offset	0x11C414		
 D2Client.dll	ScreenShiftX	Offset	0x11B9A0		
 D2Client.dll	ScreenShiftY	Offset	0x11B9A4		
-D2Client.dll	ScreenXShift	Offset	0x11C418		
 D2CMP.dll	CloseCelFile	Ordinal	10065		
 D2DDraw.dll	DisplayHeight	Offset	0x101CC		
 D2DDraw.dll	DisplayWidth	Offset	0x101D4		

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -1,7 +1,6 @@
 Library	Name	Locator Type	Locator Value	Comments	
 D2Client.dll	DifficultyLevel	Offset	0x11C390	nDifficultyLevel	
 D2Client.dll	DrawCenteredUnicodeText	Offset	0xBC4E0		
-D2Client.dll	ScreenOpenMode	Offset	0x11C414		
 D2Client.dll	GeneralDisplayHeight	Offset	0xDBC4C		
 D2Client.dll	GeneralDisplayWidth	Offset	0xDBC48		
 D2Client.dll	GeneralPlayAreaCameraShiftX	Offset	0x11C418		
@@ -11,11 +10,12 @@ D2Client.dll	InventoryArrangeMode	Offset	0x11B99C
 D2Client.dll	IsAutomapOpen	Offset	0xFADA8		
 D2Client.dll	IsGameMenuOpen	Offset	0xFADA4		
 D2Client.dll	IsHelpScreenOpen	Offset	0xFAE04		
-D2Client.dll	ScreenXShift	Offset	0x11C418		
 D2Client.dll	IsNewSkillButtonPressed	Offset	0x11C30C		
 D2Client.dll	IsNewStatsButtonPressed	Offset	0x11C308		
+D2Client.dll	ScreenOpenMode	Offset	0x11C414		
 D2Client.dll	ScreenShiftX	Offset	0x11B9A0		
 D2Client.dll	ScreenShiftY	Offset	0x11B9A4		
+D2Client.dll	ScreenXShift	Offset	0x11C418		
 D2CMP.dll	CloseCelFile	Ordinal	10065		
 D2DDraw.dll	DisplayHeight	Offset	0x101CC		
 D2DDraw.dll	DisplayWidth	Offset	0x101D4		

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -1,7 +1,6 @@
 Library	Name	Locator Type	Locator Value	Comments	
 D2Client.dll	DifficultyLevel	Offset	0x11D1D8	nDifficultyLevel	
 D2Client.dll	DrawCenteredUnicodeText	Offset	0xBEC80		
-D2Client.dll	ScreenOpenMode	Offset	0x11D070		
 D2Client.dll	GeneralDisplayHeight	Offset	0xF7038		
 D2Client.dll	GeneralDisplayWidth	Offset	0xF7034		
 D2Client.dll	GeneralPlayAreaCameraShiftX	Offset	0x11D074		
@@ -13,6 +12,7 @@ D2Client.dll	IsGameMenuOpen	Offset	0x11C8B4
 D2Client.dll	IsHelpScreenOpen	Offset	0x11C914		
 D2Client.dll	IsNewSkillButtonPressed	Offset	0x11D31C		
 D2Client.dll	IsNewStatsButtonPressed	Offset	0x11D318		
+D2Client.dll	ScreenOpenMode	Offset	0x11D070		
 D2Client.dll	ScreenShiftX	Offset	0x11D354		
 D2Client.dll	ScreenShiftY	Offset	0x11D358		
 D2CMP.dll	CloseCelFile	Ordinal	10020		

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -1,6 +1,6 @@
 Library	Name	Locator Type	Locator Value	Comments	
 D2Client.dll	DifficultyLevel	Offset	0x11D1D8	nDifficultyLevel	
-D2Client.dll	DrawCenteredText	Offset	0xBEC80		
+D2Client.dll	DrawCenteredUnicodeText	Offset	0xBEC80		
 D2Client.dll	ScreenOpenMode	Offset	0x11D070		
 D2Client.dll	GeneralDisplayHeight	Offset	0xF7038		
 D2Client.dll	GeneralDisplayWidth	Offset	0xF7034		
@@ -35,13 +35,13 @@ D2Lang.dll	Unicode_strcat	Offset	0x8B90		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x8C60	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10C0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10A0		Unicode::toUpper
-D2Win.dll	DrawText	Ordinal	10076		
+D2Win.dll	DrawUnicodeText	Ordinal	10076		
 D2Win.dll	LoadCelFile	Ordinal	10023		
 D2Win.dll	LoadMPQ	Offset	0x7E50		
 D2Win.dll	MainMenuMousePositionX	Offset	0x8DB1C		
 D2Win.dll	MainMenuMousePositionY	Offset	0x8DB20		
-D2Win.dll	SetPopUpText	Ordinal	10137		
-D2Win.dll	SetTextFont	Ordinal	10047		
+D2Win.dll	SetDrawUnicodeTextFont	Ordinal	10047		
+D2Win.dll	SetPopUpUnicodeText	Ordinal	10137		
 D2Win.dll	UnloadCelFile	Ordinal	10189		
 D2Win.dll	UnloadMPQ	Offset	0x78E0		
 Fog.dll	AllocClientMemory	Ordinal	10042		

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -1,7 +1,6 @@
 Library	Name	Locator Type	Locator Value	Comments	
 D2Client.dll	DifficultyLevel	Offset	0x397694	nDifficultyLevel	
 D2Client.dll	DrawCenteredUnicodeText	Offset	0xA3750		
-D2Client.dll	ScreenOpenMode	Offset	0x39C298		
 D2Client.dll	GeneralDisplayHeight	Offset	0x30FF4C		
 D2Client.dll	GeneralDisplayWidth	Offset	0x30FF48		
 D2Client.dll	GeneralPlayAreaCameraShiftX	Offset	0x39C29C		
@@ -13,6 +12,7 @@ D2Client.dll	IsGameMenuOpen	Offset	0x39986C
 D2Client.dll	IsHelpScreenOpen	Offset	0x3998CC		
 D2Client.dll	IsNewSkillButtonPressed	Offset	0x3B7370		
 D2Client.dll	IsNewStatsButtonPressed	Offset	0x3B736C		
+D2Client.dll	ScreenOpenMode	Offset	0x39C298		
 D2Client.dll	ScreenShiftX	Offset	0x3998E0		
 D2Client.dll	ScreenShiftY	Offset	0x3998E4		
 D2CMP.dll	CloseCelFile	Offset	0x200820		

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -1,6 +1,6 @@
 Library	Name	Locator Type	Locator Value	Comments	
 D2Client.dll	DifficultyLevel	Offset	0x397694	nDifficultyLevel	
-D2Client.dll	DrawCenteredText	Offset	0xA3750		
+D2Client.dll	DrawCenteredUnicodeText	Offset	0xA3750		
 D2Client.dll	ScreenOpenMode	Offset	0x39C298		
 D2Client.dll	GeneralDisplayHeight	Offset	0x30FF4C		
 D2Client.dll	GeneralDisplayWidth	Offset	0x30FF48		
@@ -35,13 +35,13 @@ D2Lang.dll	Unicode_strcat	Offset	0x123C50		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x123D50	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0xADD70	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x29E40		Unicode::toUpper
-D2Win.dll	DrawText	Offset	0xFFB70		
+D2Win.dll	DrawUnicodeText	Offset	0xFFB70		
 D2Win.dll	LoadCelFile	Offset	0xF7F80		
 D2Win.dll	LoadMPQ	Offset	0x114FF7		
 D2Win.dll	MainMenuMousePositionX	Offset	0x3CC62C		
 D2Win.dll	MainMenuMousePositionY	Offset	0x3CC630		
-D2Win.dll	SetPopUpText	Offset	0xFFAD0		
-D2Win.dll	SetTextFont	Offset	0x100750		
+D2Win.dll	SetDrawUnicodeTextFont	Offset	0x100750		
+D2Win.dll	SetPopUpUnicodeText	Offset	0xFFAD0		
 D2Win.dll	UnloadCelFile	Offset	0xF80B0		
 D2Win.dll	UnloadMPQ	Offset	0x115071		
 Fog.dll	AllocClientMemory	Offset	0x6B90		

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -1,6 +1,6 @@
 Library	Name	Locator Type	Locator Value	Comments	
 D2Client.dll	DifficultyLevel	Offset	0x3A060C	nDifficultyLevel	
-D2Client.dll	DrawCenteredText	Offset	0xA7080		
+D2Client.dll	DrawCenteredUnicodeText	Offset	0xA7080		
 D2Client.dll	ScreenOpenMode	Offset	0x3A5210		
 D2Client.dll	GeneralDisplayHeight	Offset	0x311470		
 D2Client.dll	GeneralDisplayWidth	Offset	0x31146C		
@@ -35,13 +35,13 @@ D2Lang.dll	Unicode_strcat	Offset	0x126700		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x126800	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0xB15F3	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x2E650		Unicode::toUpper
-D2Win.dll	DrawText	Offset	0x102320		
+D2Win.dll	DrawUnicodeText	Offset	0x102320		
 D2Win.dll	LoadCelFile	Offset	0xFA9B0		
 D2Win.dll	LoadMPQ	Offset	0x117332		
 D2Win.dll	MainMenuMousePositionX	Offset	0x3D55A4		
 D2Win.dll	MainMenuMousePositionY	Offset	0x3D55A8		
-D2Win.dll	SetPopUpText	Offset	0x102280		
-D2Win.dll	SetTextFont	Offset	0x102EF0		
+D2Win.dll	SetDrawUnicodeTextFont	Offset	0x102EF0		
+D2Win.dll	SetPopUpUnicodeText	Offset	0x102280		
 D2Win.dll	UnloadCelFile	Offset	0xFAAE0		
 D2Win.dll	UnloadMPQ	Offset	0x1173AC		
 Fog.dll	AllocClientMemory	Offset	0xB380		

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -1,7 +1,6 @@
 Library	Name	Locator Type	Locator Value	Comments	
 D2Client.dll	DifficultyLevel	Offset	0x3A060C	nDifficultyLevel	
 D2Client.dll	DrawCenteredUnicodeText	Offset	0xA7080		
-D2Client.dll	ScreenOpenMode	Offset	0x3A5210		
 D2Client.dll	GeneralDisplayHeight	Offset	0x311470		
 D2Client.dll	GeneralDisplayWidth	Offset	0x31146C		
 D2Client.dll	GeneralPlayAreaCameraShiftX	Offset	0x3A5214		
@@ -13,6 +12,7 @@ D2Client.dll	IsGameMenuOpen	Offset	0x3A27E4
 D2Client.dll	IsHelpScreenOpen	Offset	0x3A2844		
 D2Client.dll	IsNewSkillButtonPressed	Offset	0x3C02E8		
 D2Client.dll	IsNewStatsButtonPressed	Offset	0x3C02E4		
+D2Client.dll	ScreenOpenMode	Offset	0x3A5210		
 D2Client.dll	ScreenShiftX	Offset	0x3A2858		
 D2Client.dll	ScreenShiftY	Offset	0x3A285C		
 D2CMP.dll	CloseCelFile	Offset	0x201A50		


### PR DESCRIPTION
The functions related to UnicodeChar Text rendering are being renamed due to the function name `DrawText` being occupied by a [Windows API function of the same name](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-drawtext). The first commit primarily fixes the name overlap with [D2Win DrawText](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/37) by renaming it to `D2Win DrawUnicodeText`. For consistency, the following addresses have also been renamed:
- [D2Win SetTextFont](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/41) to `D2Win SetUnicodeTextFont`.
- [D2Win SetPopUpText](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/38) to `D2Win SetPopUpUnicodeText`.
- [D2Client DrawCenteredText](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/39) to `D2Client DrawCenteredUnicodeText`.

Some other changes include sorting and dropping some incomplete or redundant addresses.
