### PR TITLE
Add D2CMP GetCelFromCelContext

### DIFF
--- a/1.00.txt
+++ b/1.00.txt
@@ -15,6 +15,7 @@ D2Client.dll	IsNewStatsButtonPressed	Offset	0x13DDF4
 D2Client.dll	ScreenOpenMode	N/A	N/A		
 D2Client.dll	ScreenShiftX	N/A	N/A		
 D2Client.dll	ScreenShiftY	N/A	N/A		
+D2CMP.dll	GetCelFromCelContext	Ordinal	10036		
 D2CMP.dll	CloseCelFile	Ordinal	10032		
 D2DDraw.dll	DisplayHeight	Offset	0x190D0		
 D2DDraw.dll	DisplayWidth	Offset	0x190D8		

--- a/1.03.txt
+++ b/1.03.txt
@@ -15,6 +15,7 @@ D2Client.dll	IsNewStatsButtonPressed	Offset	0x13DB2C
 D2Client.dll	ScreenOpenMode	N/A	N/A		
 D2Client.dll	ScreenShiftX	N/A	N/A		
 D2Client.dll	ScreenShiftY	N/A	N/A		
+D2CMP.dll	GetCelFromCelContext	Ordinal	10036		
 D2CMP.dll	CloseCelFile	Ordinal	10032		
 D2DDraw.dll	DisplayHeight	Offset	0x190D0		
 D2DDraw.dll	DisplayWidth	Offset	0x190D8		

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -15,6 +15,7 @@ D2Client.dll	IsNewStatsButtonPressed	Offset	0xF01F4
 D2Client.dll	ScreenOpenMode	N/A	N/A		
 D2Client.dll	ScreenShiftX	N/A	N/A		
 D2Client.dll	ScreenShiftY	N/A	N/A		
+D2CMP.dll	GetCelFromCelContext	Ordinal	10036		
 D2CMP.dll	CloseCelFile	Ordinal	10032		
 D2DDraw.dll	DisplayHeight	Offset	0x116F8		
 D2DDraw.dll	DisplayWidth	Offset	0x11700		

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -15,6 +15,7 @@ D2Client.dll	IsNewStatsButtonPressed	Offset	0x11FE84
 D2Client.dll	ScreenOpenMode	Offset	0x115C10		
 D2Client.dll	ScreenShiftX	Offset	0x124954		
 D2Client.dll	ScreenShiftY	Offset	0x124958		
+D2CMP.dll	GetCelFromCelContext	Ordinal	10036		
 D2CMP.dll	CloseCelFile	Ordinal	10032		
 D2DDraw.dll	DisplayHeight	Offset	0x11768		
 D2DDraw.dll	DisplayWidth	Offset	0x11770		

--- a/1.10.txt
+++ b/1.10.txt
@@ -15,6 +15,7 @@ D2Client.dll	IsNewStatsButtonPressed	Offset	0x115BBC
 D2Client.dll	ScreenOpenMode	Offset	0x10B9C4		
 D2Client.dll	ScreenShiftX	Offset	0x11A748		
 D2Client.dll	ScreenShiftY	Offset	0x11A74C		
+D2CMP.dll	GetCelFromCelContext	Ordinal	10036		
 D2CMP.dll	CloseCelFile	Ordinal	10032		
 D2DDraw.dll	DisplayHeight	Offset	0x117A8		
 D2DDraw.dll	DisplayWidth	Offset	0x117B0		

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -15,6 +15,7 @@ D2Client.dll	IsNewStatsButtonPressed	Offset	0x11C344
 D2Client.dll	ScreenOpenMode	Offset	0x11C1D0		
 D2Client.dll	ScreenShiftX	Offset	0x11BD28		
 D2Client.dll	ScreenShiftY	Offset	0x11BD2C		
+D2CMP.dll	GetCelFromCelContext	Ordinal	10038		
 D2CMP.dll	CloseCelFile	Ordinal	10106		
 D2DDraw.dll	DisplayHeight	Offset	0xFDCC		
 D2DDraw.dll	DisplayWidth	Offset	0xFDD4		

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -15,6 +15,7 @@ D2Client.dll	IsNewStatsButtonPressed	Offset	0x11C308
 D2Client.dll	ScreenOpenMode	Offset	0x11C414		
 D2Client.dll	ScreenShiftX	Offset	0x11B9A0		
 D2Client.dll	ScreenShiftY	Offset	0x11B9A4		
+D2CMP.dll	GetCelFromCelContext	Ordinal	10021		
 D2CMP.dll	CloseCelFile	Ordinal	10065		
 D2DDraw.dll	DisplayHeight	Offset	0x101CC		
 D2DDraw.dll	DisplayWidth	Offset	0x101D4		
@@ -38,6 +39,7 @@ D2Lang.dll	Unicode_strlen	Offset	0xB0B0	?strlen@Unicode@@SIHPBU1@@Z	Unicode::str
 D2Lang.dll	Unicode_tolower	Offset	0x10C0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10A0		Unicode::toUpper
 D2Win.dll	DrawUnicodeText	Ordinal	10150		
+D2Win.dll	HasWindowFocus	Offset	0x1FBA8		
 D2Win.dll	LoadCelFile	Ordinal	10111		
 D2Win.dll	LoadMPQ	Offset	0x7E60		
 D2Win.dll	MainMenuMousePositionX	Offset	0x21488		

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -15,6 +15,7 @@ D2Client.dll	IsNewStatsButtonPressed	Offset	0x11D318
 D2Client.dll	ScreenOpenMode	Offset	0x11D070		
 D2Client.dll	ScreenShiftX	Offset	0x11D354		
 D2Client.dll	ScreenShiftY	Offset	0x11D358		
+D2CMP.dll	GetCelFromCelContext	Ordinal	10035		
 D2CMP.dll	CloseCelFile	Ordinal	10020		
 D2DDraw.dll	DisplayHeight	Offset	0x100DC		
 D2DDraw.dll	DisplayWidth	Offset	0x100E4		

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -15,6 +15,7 @@ D2Client.dll	IsNewStatsButtonPressed	Offset	0x3B736C
 D2Client.dll	ScreenOpenMode	Offset	0x39C298		
 D2Client.dll	ScreenShiftX	Offset	0x3998E0		
 D2Client.dll	ScreenShiftY	Offset	0x3998E4		
+D2CMP.dll	GetCelFromCelContext	Offset	0x200620		
 D2CMP.dll	CloseCelFile	Offset	0x200820		
 D2DDraw.dll	DisplayHeight	Offset	0x4782DC		
 D2DDraw.dll	DisplayWidth	Offset	0x4782E0		

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -15,6 +15,7 @@ D2Client.dll	IsNewStatsButtonPressed	Offset	0x3C02E4
 D2Client.dll	ScreenOpenMode	Offset	0x3A5210		
 D2Client.dll	ScreenShiftX	Offset	0x3A2858		
 D2Client.dll	ScreenShiftY	Offset	0x3A285C		
+D2CMP.dll	GetCelFromCelContext	Offset	0x201840		
 D2CMP.dll	CloseCelFile	Offset	0x201A50		
 D2DDraw.dll	DisplayHeight	Offset	0x481254		
 D2DDraw.dll	DisplayWidth	Offset	0x481258		


### PR DESCRIPTION
The function retrieves a `Cel` from the `CelContext`'s `CelFile`, using the `direction` and the `frame` of the `CelContext` to determine which `Cel` to retrieve.

The function can be located during the call in [D2GFX DrawCelContext](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/34). This method has been tested in GDI, and the set of screenshots below will explain this process.

## Function Definition
### All Versions
```C
Cel* D2CMP_GetCelFromCelContext(CelContext* cel_context)
```
- All parameters on the stack
  - Callee cleans the stack

## Screenshots
The following 1.00 screenshot shows the function itself. This shows that the parameter `cel_context` is of type `CelContext*`. In addition, it also shows the function's cleanup convention.
![D2CMP_GetCelFromCelContext_02_(1 00)](https://user-images.githubusercontent.com/26683324/62416534-779c7980-b5f1-11e9-979b-34a60807aa69.PNG)

The following 1.00 screenshots show how to locate the function (in GDI video mode).
![D2CMP_GetCelFromCelContext_03_(1 00)](https://user-images.githubusercontent.com/26683324/62416535-779c7980-b5f1-11e9-9839-0b27f2abb34b.PNG)
![D2CMP_GetCelFromCelContext_04_(1 00)](https://user-images.githubusercontent.com/26683324/62416536-779c7980-b5f1-11e9-86af-11e36ecb7761.PNG)
