### PR TITLE
Add D2DDraw BitBlockWidth and BitBlockHeight

### DIFF
--- a/1.00.txt
+++ b/1.00.txt
@@ -17,6 +17,8 @@ D2Client.dll	ScreenShiftX	N/A	N/A
 D2Client.dll	ScreenShiftY	N/A	N/A		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10036		
 D2CMP.dll	CloseCelFile	Ordinal	10032		
+D2DDraw.dll	BitBlockHeight	Offset	0x194E4		
+D2DDraw.dll	BitBlockWidth	Offset	0x190DC		
 D2DDraw.dll	DisplayHeight	Offset	0x190D0		
 D2DDraw.dll	DisplayWidth	Offset	0x190D8		
 D2Direct3D.dll	DisplayHeight	Offset	0x26930		

--- a/1.03.txt
+++ b/1.03.txt
@@ -17,6 +17,8 @@ D2Client.dll	ScreenShiftX	N/A	N/A
 D2Client.dll	ScreenShiftY	N/A	N/A		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10036		
 D2CMP.dll	CloseCelFile	Ordinal	10032		
+D2DDraw.dll	BitBlockHeight	Offset	0x194E4		
+D2DDraw.dll	BitBlockWidth	Offset	0x190DC		
 D2DDraw.dll	DisplayHeight	Offset	0x190D0		
 D2DDraw.dll	DisplayWidth	Offset	0x190D8		
 D2Direct3D.dll	DisplayHeight	Offset	0x26930		

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -17,6 +17,8 @@ D2Client.dll	ScreenShiftX	N/A	N/A
 D2Client.dll	ScreenShiftY	N/A	N/A		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10036		
 D2CMP.dll	CloseCelFile	Ordinal	10032		
+D2DDraw.dll	BitBlockHeight	Offset	0x11B0C		
+D2DDraw.dll	BitBlockWidth	Offset	0x11704		
 D2DDraw.dll	DisplayHeight	Offset	0x116F8		
 D2DDraw.dll	DisplayWidth	Offset	0x11700		
 D2Direct3D.dll	DisplayHeight	Offset	0x1A708		

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -17,6 +17,8 @@ D2Client.dll	ScreenShiftX	Offset	0x124954
 D2Client.dll	ScreenShiftY	Offset	0x124958		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10036		
 D2CMP.dll	CloseCelFile	Ordinal	10032		
+D2DDraw.dll	BitBlockHeight	Offset	0x11B7C		
+D2DDraw.dll	BitBlockWidth	Offset	0x11774		
 D2DDraw.dll	DisplayHeight	Offset	0x11768		
 D2DDraw.dll	DisplayWidth	Offset	0x11770		
 D2Direct3D.dll	DisplayHeight	Offset	0x1B708		

--- a/1.10.txt
+++ b/1.10.txt
@@ -17,6 +17,8 @@ D2Client.dll	ScreenShiftX	Offset	0x11A748
 D2Client.dll	ScreenShiftY	Offset	0x11A74C		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10036		
 D2CMP.dll	CloseCelFile	Ordinal	10032		
+D2DDraw.dll	BitBlockHeight	Offset	0x11BBC		
+D2DDraw.dll	BitBlockWidth	Offset	0x117B4		
 D2DDraw.dll	DisplayHeight	Offset	0x117A8		
 D2DDraw.dll	DisplayWidth	Offset	0x117B0		
 D2Direct3D.dll	DisplayHeight	Offset	0x1A7AC		

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -17,6 +17,8 @@ D2Client.dll	ScreenShiftX	Offset	0x11BD28
 D2Client.dll	ScreenShiftY	Offset	0x11BD2C		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10038		
 D2CMP.dll	CloseCelFile	Ordinal	10106		
+D2DDraw.dll	BitBlockHeight	Offset	0xFDD8		
+D2DDraw.dll	BitBlockWidth	Offset	0xFDC8		
 D2DDraw.dll	DisplayHeight	Offset	0xFDCC		
 D2DDraw.dll	DisplayWidth	Offset	0xFDD4		
 D2Direct3D.dll	DisplayHeight	Offset	0x196F4		

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -17,6 +17,8 @@ D2Client.dll	ScreenShiftX	Offset	0x11B9A0
 D2Client.dll	ScreenShiftY	Offset	0x11B9A4		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10021		
 D2CMP.dll	CloseCelFile	Ordinal	10065		
+D2DDraw.dll	BitBlockHeight	Offset	0x101D8		
+D2DDraw.dll	BitBlockWidth	Offset	0x101C8		
 D2DDraw.dll	DisplayHeight	Offset	0x101CC		
 D2DDraw.dll	DisplayWidth	Offset	0x101D4		
 D2Direct3D.dll	DisplayHeight	Offset	0x1AFD4		

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -17,6 +17,8 @@ D2Client.dll	ScreenShiftX	Offset	0x11D354
 D2Client.dll	ScreenShiftY	Offset	0x11D358		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10035		
 D2CMP.dll	CloseCelFile	Ordinal	10020		
+D2DDraw.dll	BitBlockHeight	Offset	0x100E8		
+D2DDraw.dll	BitBlockWidth	Offset	0x100D8		
 D2DDraw.dll	DisplayHeight	Offset	0x100DC		
 D2DDraw.dll	DisplayWidth	Offset	0x100E4		
 D2Direct3D.dll	DisplayHeight	Offset	0x32DFC		

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -17,6 +17,8 @@ D2Client.dll	ScreenShiftX	Offset	0x3998E0
 D2Client.dll	ScreenShiftY	Offset	0x3998E4		
 D2CMP.dll	GetCelFromCelContext	Offset	0x200620		
 D2CMP.dll	CloseCelFile	Offset	0x200820		
+D2DDraw.dll	BitBlockHeight	Offset	0x3C01C4		
+D2DDraw.dll	BitBlockWidth	Offset	0x3C01C0		
 D2DDraw.dll	DisplayHeight	Offset	0x4782DC		
 D2DDraw.dll	DisplayWidth	Offset	0x4782E0		
 D2Direct3D.dll	DisplayHeight	Offset	0x3C01C4		

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -17,6 +17,8 @@ D2Client.dll	ScreenShiftX	Offset	0x3A2858
 D2Client.dll	ScreenShiftY	Offset	0x3A285C		
 D2CMP.dll	GetCelFromCelContext	Offset	0x201840		
 D2CMP.dll	CloseCelFile	Offset	0x201A50		
+D2DDraw.dll	BitBlockHeight	Offset	0x3C913C		
+D2DDraw.dll	BitBlockWidth	Offset	0x3C9138		
 D2DDraw.dll	DisplayHeight	Offset	0x481254		
 D2DDraw.dll	DisplayWidth	Offset	0x481258		
 D2Direct3D.dll	DisplayHeight	Offset	0x3C913C		


### PR DESCRIPTION
The variables correspond to the width and height used in a call to the [BitBlt](https://docs.microsoft.com/en-us/windows/desktop/api/wingdi/nf-wingdi-bitblt) function. The variables are both of type `int32_t`.

The variables can be located in DirectDraw mode by entering, then saving and exiting the game. When the resolution changes, scan for the values matching its current width and height. It is recommended to keep the ingame resolution to 640x480.

The following 1.00 screenshot shows the effects of changing `D2DDraw BitBlockWidth`.
![D2DDraw_BitBlockWidthAndHeight_02_(1 10)](https://user-images.githubusercontent.com/26683324/64088739-bc522800-ccf7-11e9-93e9-a4f33ef2c1ab.jpg)

The following 1.10 screenshot shows how the variables are used and that the function using them is a BitBlt function.
![D2DDraw_BitBlockWidthAndHeight_01_(1 10)](https://user-images.githubusercontent.com/26683324/64088450-5a44f300-ccf6-11e9-8006-c2526987465c.PNG)
