### PR TITLE
Add CelDisplayLeft and CelDisplayRight

### DIFF
--- a/1.00.txt
+++ b/1.00.txt
@@ -19,6 +19,8 @@ D2CMP.dll	GetCelFromCelContext	Ordinal	10036
 D2CMP.dll	CloseCelFile	Ordinal	10032		
 D2DDraw.dll	BitBlockHeight	Offset	0x194E4		
 D2DDraw.dll	BitBlockWidth	Offset	0x190DC		
+D2DDraw.dll	CelDisplayLeft	Offset	0x19C3C		
+D2DDraw.dll	CelDisplayRight	Offset	0x19C38		
 D2DDraw.dll	DisplayHeight	Offset	0x190D0		
 D2DDraw.dll	DisplayWidth	Offset	0x190D8		
 D2Direct3D.dll	DisplayHeight	Offset	0x26930		

--- a/1.03.txt
+++ b/1.03.txt
@@ -19,6 +19,8 @@ D2CMP.dll	GetCelFromCelContext	Ordinal	10036
 D2CMP.dll	CloseCelFile	Ordinal	10032		
 D2DDraw.dll	BitBlockHeight	Offset	0x194E4		
 D2DDraw.dll	BitBlockWidth	Offset	0x190DC		
+D2DDraw.dll	CelDisplayLeft	Offset	0x19C3C		
+D2DDraw.dll	CelDisplayRight	Offset	0x19C38		
 D2DDraw.dll	DisplayHeight	Offset	0x190D0		
 D2DDraw.dll	DisplayWidth	Offset	0x190D8		
 D2Direct3D.dll	DisplayHeight	Offset	0x26930		

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -19,6 +19,8 @@ D2CMP.dll	GetCelFromCelContext	Ordinal	10036
 D2CMP.dll	CloseCelFile	Ordinal	10032		
 D2DDraw.dll	BitBlockHeight	Offset	0x11B0C		
 D2DDraw.dll	BitBlockWidth	Offset	0x11704		
+D2DDraw.dll	CelDisplayLeft	Offset	0x11F6C		
+D2DDraw.dll	CelDisplayRight	Offset	0x11F68		
 D2DDraw.dll	DisplayHeight	Offset	0x116F8		
 D2DDraw.dll	DisplayWidth	Offset	0x11700		
 D2Direct3D.dll	DisplayHeight	Offset	0x1A708		

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -19,6 +19,8 @@ D2CMP.dll	GetCelFromCelContext	Ordinal	10036
 D2CMP.dll	CloseCelFile	Ordinal	10032		
 D2DDraw.dll	BitBlockHeight	Offset	0x11B7C		
 D2DDraw.dll	BitBlockWidth	Offset	0x11774		
+D2DDraw.dll	CelDisplayLeft	Offset	0x11FDC		
+D2DDraw.dll	CelDisplayRight	Offset	0x11FD8		
 D2DDraw.dll	DisplayHeight	Offset	0x11768		
 D2DDraw.dll	DisplayWidth	Offset	0x11770		
 D2Direct3D.dll	DisplayHeight	Offset	0x1B708		

--- a/1.10.txt
+++ b/1.10.txt
@@ -19,6 +19,8 @@ D2CMP.dll	GetCelFromCelContext	Ordinal	10036
 D2CMP.dll	CloseCelFile	Ordinal	10032		
 D2DDraw.dll	BitBlockHeight	Offset	0x11BBC		
 D2DDraw.dll	BitBlockWidth	Offset	0x117B4		
+D2DDraw.dll	CelDisplayLeft	Offset	0x1201C		
+D2DDraw.dll	CelDisplayRight	Offset	0x12018		
 D2DDraw.dll	DisplayHeight	Offset	0x117A8		
 D2DDraw.dll	DisplayWidth	Offset	0x117B0		
 D2Direct3D.dll	DisplayHeight	Offset	0x1A7AC		

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -19,6 +19,8 @@ D2CMP.dll	GetCelFromCelContext	Ordinal	10038
 D2CMP.dll	CloseCelFile	Ordinal	10106		
 D2DDraw.dll	BitBlockHeight	Offset	0xFDD8		
 D2DDraw.dll	BitBlockWidth	Offset	0xFDC8		
+D2DDraw.dll	CelDisplayLeft	Offset	0xFEE4		
+D2DDraw.dll	CelDisplayRight	Offset	0xFEE8		
 D2DDraw.dll	DisplayHeight	Offset	0xFDCC		
 D2DDraw.dll	DisplayWidth	Offset	0xFDD4		
 D2Direct3D.dll	DisplayHeight	Offset	0x196F4		

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -19,6 +19,8 @@ D2CMP.dll	GetCelFromCelContext	Ordinal	10021
 D2CMP.dll	CloseCelFile	Ordinal	10065		
 D2DDraw.dll	BitBlockHeight	Offset	0x101D8		
 D2DDraw.dll	BitBlockWidth	Offset	0x101C8		
+D2DDraw.dll	CelDisplayLeft	Offset	0x101E8		
+D2DDraw.dll	CelDisplayRight	Offset	0x101EC		
 D2DDraw.dll	DisplayHeight	Offset	0x101CC		
 D2DDraw.dll	DisplayWidth	Offset	0x101D4		
 D2Direct3D.dll	DisplayHeight	Offset	0x1AFD4		

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -19,6 +19,8 @@ D2CMP.dll	GetCelFromCelContext	Ordinal	10035
 D2CMP.dll	CloseCelFile	Ordinal	10020		
 D2DDraw.dll	BitBlockHeight	Offset	0x100E8		
 D2DDraw.dll	BitBlockWidth	Offset	0x100D8		
+D2DDraw.dll	CelDisplayLeft	Offset	0xF380		
+D2DDraw.dll	CelDisplayRight	Offset	0xF384		
 D2DDraw.dll	DisplayHeight	Offset	0x100DC		
 D2DDraw.dll	DisplayWidth	Offset	0x100E4		
 D2Direct3D.dll	DisplayHeight	Offset	0x32DFC		

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -19,6 +19,8 @@ D2CMP.dll	GetCelFromCelContext	Offset	0x200620
 D2CMP.dll	CloseCelFile	Offset	0x200820		
 D2DDraw.dll	BitBlockHeight	Offset	0x3C01C4		
 D2DDraw.dll	BitBlockWidth	Offset	0x3C01C0		
+D2DDraw.dll	CelDisplayLeft	Offset	0x478324		
+D2DDraw.dll	CelDisplayRight	Offset	0x478328		
 D2DDraw.dll	DisplayHeight	Offset	0x4782DC		
 D2DDraw.dll	DisplayWidth	Offset	0x4782E0		
 D2Direct3D.dll	DisplayHeight	Offset	0x3C01C4		

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -19,6 +19,8 @@ D2CMP.dll	GetCelFromCelContext	Offset	0x201840
 D2CMP.dll	CloseCelFile	Offset	0x201A50		
 D2DDraw.dll	BitBlockHeight	Offset	0x3C913C		
 D2DDraw.dll	BitBlockWidth	Offset	0x3C9138		
+D2DDraw.dll	CelDisplayLeft	Offset	0x48129C		
+D2DDraw.dll	CelDisplayRight	Offset	0x4812A0		
 D2DDraw.dll	DisplayHeight	Offset	0x481254		
 D2DDraw.dll	DisplayWidth	Offset	0x481258		
 D2Direct3D.dll	DisplayHeight	Offset	0x3C913C		


### PR DESCRIPTION
The variables are involved in the display of `CelContext` images, by limiting their appearance on the left and right side of the screen. They are both of type `int32_t`.

The variables can be located in DirectDraw mode by repeatedly entering and exiting the game, with the ingame resolution set to 640x480. Scan for the values 640 and 800, matching the display width.

The following 1.00 screenshot shows what happens when `D2DDraw CelDisplayRight` is changed.
![D2DDraw_CelDisplayLeftAndRight_02_(1 10)](https://user-images.githubusercontent.com/26683324/64088683-74cb9c00-ccf7-11e9-8dba-0abe4289d708.jpg)

The following 1.10 screenshot shows the variables being modifed.
![D2DDraw_CelDisplayLeftAndRight_01_(1 10)](https://user-images.githubusercontent.com/26683324/64088690-80b75e00-ccf7-11e9-8e37-17b64a4a9dcd.PNG)
