### PR TITLE
Add D2Win GetUnicodeTextDrawWidth

### DIFF
--- a/1.00.txt
+++ b/1.00.txt
@@ -57,6 +57,8 @@ D2Lang.dll	UnicodeString_Format	Offset	0x1046	?sprintf@Unicode@@SAXHPAU1@PBU1@ZZ
 D2Lang.dll	UnicodeString_NCompareIgnoreCase	Offset	0x1091	?strnicmp@Unicode@@SIHPBU1@0I@Z	Unicode::strnicmp
 D2Lang.dll	UnloadSysMap	Offset	0x104B	?unloadSysMap@Unicode@@SIXXZ	Unicode::unloadSysMap
 D2Win.dll	DrawUnicodeText	Ordinal	10110		
+D2Win.dll	GetUnicodeTextDrawWidth	Ordinal	10114		
+D2Win.dll	GetUnicodeTextNDrawWidth	Ordinal	10115		
 D2Win.dll	LoadCelFile	Ordinal	10035		
 D2Win.dll	LoadMPQ	Offset	0x1458A		
 D2Win.dll	MainMenuMousePositionX	Offset	0x72A90		

--- a/1.03.txt
+++ b/1.03.txt
@@ -41,6 +41,8 @@ D2Lang.dll	Unicode_strlen	Offset	0x1055	?strlen@Unicode@@SIHPBU1@@Z	Unicode::str
 D2Lang.dll	Unicode_tolower	Offset	0x1014	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x1154		Unicode::toUpper
 D2Win.dll	DrawUnicodeText	Ordinal	10110		
+D2Win.dll	GetUnicodeTextDrawWidth	Ordinal	10114		
+D2Win.dll	GetUnicodeTextNDrawWidth	Ordinal	10115		
 D2Win.dll	LoadCelFile	Ordinal	10035		
 D2Win.dll	LoadMPQ	Offset	0x146FA		
 D2Win.dll	MainMenuMousePositionX	Offset	0x72A98		

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -41,6 +41,8 @@ D2Lang.dll	Unicode_strlen	Offset	0x1490	?strlen@Unicode@@SIHPBU1@@Z	Unicode::str
 D2Lang.dll	Unicode_tolower	Offset	0x10E0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10B0		Unicode::toUpper
 D2Win.dll	DrawUnicodeText	Ordinal	10110		
+D2Win.dll	GetUnicodeTextDrawWidth	Ordinal	10114		
+D2Win.dll	GetUnicodeTextNDrawWidth	Ordinal	10115		
 D2Win.dll	LoadCelFile	Ordinal	10035		
 D2Win.dll	LoadMPQ	Offset	0x10595		
 D2Win.dll	MainMenuMousePositionX	Offset	0x5BCB8		

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -41,6 +41,8 @@ D2Lang.dll	Unicode_strlen	Offset	0x1490	?strlen@Unicode@@SIHPBU1@@Z	Unicode::str
 D2Lang.dll	Unicode_tolower	Offset	0x10E0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10B0		Unicode::toUpper
 D2Win.dll	DrawUnicodeText	Ordinal	10117		
+D2Win.dll	GetUnicodeTextDrawWidth	Ordinal	10121		
+D2Win.dll	GetUnicodeTextNDrawWidth	Ordinal	10122		
 D2Win.dll	LoadCelFile	Ordinal	10039		
 D2Win.dll	LoadMPQ	Offset	0x142FB		
 D2Win.dll	MainMenuMousePositionX	Offset	0x618A0		

--- a/1.10.txt
+++ b/1.10.txt
@@ -41,6 +41,8 @@ D2Lang.dll	Unicode_strlen	Offset	0x14C0	?strlen@Unicode@@SIHPBU1@@Z	Unicode::str
 D2Lang.dll	Unicode_tolower	Offset	0x10E0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10B0		Unicode::toUpper
 D2Win.dll	DrawUnicodeText	Ordinal	10117		
+D2Win.dll	GetUnicodeTextDrawWidth	Ordinal	10121		
+D2Win.dll	GetUnicodeTextNDrawWidth	Ordinal	10122		
 D2Win.dll	LoadCelFile	Ordinal	10039		
 D2Win.dll	LoadMPQ	Offset	0x12399		
 D2Win.dll	MainMenuMousePositionX	Offset	0x5E234		

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -41,6 +41,8 @@ D2Lang.dll	Unicode_strlen	Offset	0xA6E0	?strlen@Unicode@@SIHPBU1@@Z	Unicode::str
 D2Lang.dll	Unicode_tolower	Offset	0x10C0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10A0		Unicode::toUpper
 D2Win.dll	DrawUnicodeText	Ordinal	10001		
+D2Win.dll	GetUnicodeTextDrawWidth	Ordinal	10132		
+D2Win.dll	GetUnicodeTextNDrawWidth	Ordinal	10041		
 D2Win.dll	LoadCelFile	Ordinal	10186		
 D2Win.dll	LoadMPQ	Offset	0x7E40		
 D2Win.dll	MainMenuMousePositionX	Offset	0x5C700		

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -43,6 +43,8 @@ D2Lang.dll	Unicode_strlen	Offset	0xB0B0	?strlen@Unicode@@SIHPBU1@@Z	Unicode::str
 D2Lang.dll	Unicode_tolower	Offset	0x10C0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10A0		Unicode::toUpper
 D2Win.dll	DrawUnicodeText	Ordinal	10150		
+D2Win.dll	GetUnicodeTextDrawWidth	Ordinal	10028		
+D2Win.dll	GetUnicodeTextNDrawWidth	Ordinal	10055		
 D2Win.dll	HasWindowFocus	Offset	0x1FBA8		
 D2Win.dll	LoadCelFile	Ordinal	10111		
 D2Win.dll	LoadMPQ	Offset	0x7E60		

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -41,6 +41,8 @@ D2Lang.dll	Unicode_strlen	Offset	0x8C60	?strlen@Unicode@@SIHPBU1@@Z	Unicode::str
 D2Lang.dll	Unicode_tolower	Offset	0x10C0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10A0		Unicode::toUpper
 D2Win.dll	DrawUnicodeText	Ordinal	10076		
+D2Win.dll	GetUnicodeTextDrawWidth	Ordinal	10150		
+D2Win.dll	GetUnicodeTextNDrawWidth	Ordinal	10148		
 D2Win.dll	LoadCelFile	Ordinal	10023		
 D2Win.dll	LoadMPQ	Offset	0x7E50		
 D2Win.dll	MainMenuMousePositionX	Offset	0x8DB1C		

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -41,6 +41,8 @@ D2Lang.dll	Unicode_strlen	Offset	0x123D50	?strlen@Unicode@@SIHPBU1@@Z	Unicode::s
 D2Lang.dll	Unicode_tolower	Offset	0xADD70	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x29E40		Unicode::toUpper
 D2Win.dll	DrawUnicodeText	Offset	0xFFB70		
+D2Win.dll	GetUnicodeTextDrawWidth	Offset	0xFF010		
+D2Win.dll	GetUnicodeTextNDrawWidth	Offset	0xFEFD0		
 D2Win.dll	LoadCelFile	Offset	0xF7F80		
 D2Win.dll	LoadMPQ	Offset	0x114FF7		
 D2Win.dll	MainMenuMousePositionX	Offset	0x3CC62C		

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -41,6 +41,8 @@ D2Lang.dll	Unicode_strlen	Offset	0x126800	?strlen@Unicode@@SIHPBU1@@Z	Unicode::s
 D2Lang.dll	Unicode_tolower	Offset	0xB15F3	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x2E650		Unicode::toUpper
 D2Win.dll	DrawUnicodeText	Offset	0x102320		
+D2Win.dll	GetUnicodeTextDrawWidth	Offset	0x101820		
+D2Win.dll	GetUnicodeTextNDrawWidth	Offset	0x1017D0		
 D2Win.dll	LoadCelFile	Offset	0xFA9B0		
 D2Win.dll	LoadMPQ	Offset	0x117332		
 D2Win.dll	MainMenuMousePositionX	Offset	0x3D55A4		


### PR DESCRIPTION
Although the title is `D2Win GetUnicodeTextDrawWidth`, this PR also concerns `GetUnicodeTextNDrawWidth` due to their similarities.

The functions return the amount of horizontal pixels required to display the specified `UnicodeChar` text with the current font.

`GetUnicodeTextDrawWidth` can be located by looking for the bytes `B9 93 0F 00 00`, which are the byte codes for the assembly instruction `mov ecx, 0xf93`.

Prior to 1.12A, `GetUnicodeTextNDrawWidth` can be located by copying non-memory access byte codes in `GetUnicodeTextDrawWidth` and looking for those same bytecodes in a different location. In 1.12A and above, `GetUnicodeTextDrawWidth` calls `GetUnicodeTextNDrawWidth`, so finding the latter is relatively trivial after finding the former.

## Function Definition

### All Versions
```C
int32_t D2Win_GetUnicodeTextDrawWidth(
    const UnicodeChar* unicode_text
);
```
- `unicode_text` in ecx

In 1.12A and above, `D2Win GetUnicodeTextDrawWidth` merely performs a [D2Lang_Unicode_strlen](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/9), which is then passed into a direct call to `D2Win GetUnicodeTextNDrawWidth`.

```C
int32_t D2Win_GetUnicodeTextNDrawWidth(
    const UnicodeChar* unicode_text,
    int32_t length
);
```
- `unicode_text` in ecx
- `length` in edx

## Screenshots

### D2Win GetUnicodeTextDrawWidth
The following 1.00 screenshot shows that the parameter `unicode_text` is a `UnicodeChar*`.
![D2Win_GetUnicodeTextDrawWidth_01_(1 00)](https://user-images.githubusercontent.com/26683324/65481896-04beba80-de4c-11e9-8717-f32f613f611b.PNG)

The following 1.00 screenshot shows that the calling convention of the function. In addition, the function also takes in the return value of [D2Lang GetStringByIndex](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/13), which is a `const UnicodeChar*`. This supports the conclusion that `unicode_text` is const. 
![D2Win_GetUnicodeTextDrawWidth_02_(1 00)](https://user-images.githubusercontent.com/26683324/65481897-05575100-de4c-11e9-9ed3-9c685fbd3b5f.PNG)

### D2Win GetUnicodeTextNDrawWidth
The following 1.00 screenshot shows that the parameter `unicode_text` is a `UnicodeChar*` and the parameter `length` is a 32-bit integer.
![D2Win_GetUnicodeTextNDrawWidth_01_(1 00)](https://user-images.githubusercontent.com/26683324/65481898-05575100-de4c-11e9-9407-77700d0354b6.PNG)

The following 1.00 screenshot shows that the parameter `unicode_text` is a `UnicodeChar*`. The return type is also shown to be an `int32_t`.
![D2Win_GetUnicodeTextNDrawWidth_02_(1 00)](https://user-images.githubusercontent.com/26683324/65481899-05575100-de4c-11e9-8ef9-a6c66a76c27e.PNG)