### PR TITLE
Add D2Win GetPopupUnicodeTextWidthAndHeight

### DIFF
--- a/1.00.txt
+++ b/1.00.txt
@@ -57,6 +57,7 @@ D2Lang.dll	UnicodeString_Format	Offset	0x1046	?sprintf@Unicode@@SAXHPAU1@PBU1@ZZ
 D2Lang.dll	UnicodeString_NCompareIgnoreCase	Offset	0x1091	?strnicmp@Unicode@@SIHPBU1@0I@Z	Unicode::strnicmp
 D2Lang.dll	UnloadSysMap	Offset	0x104B	?unloadSysMap@Unicode@@SIXXZ	Unicode::unloadSysMap
 D2Win.dll	DrawUnicodeText	Ordinal	10110		
+D2Win.dll	GetPopupUnicodeTextWidthAndHeight	Ordinal	10124		
 D2Win.dll	GetUnicodeTextDrawWidth	Ordinal	10114		
 D2Win.dll	GetUnicodeTextNDrawWidth	Ordinal	10115		
 D2Win.dll	LoadCelFile	Ordinal	10035		

--- a/1.03.txt
+++ b/1.03.txt
@@ -41,6 +41,7 @@ D2Lang.dll	Unicode_strlen	Offset	0x1055	?strlen@Unicode@@SIHPBU1@@Z	Unicode::str
 D2Lang.dll	Unicode_tolower	Offset	0x1014	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x1154		Unicode::toUpper
 D2Win.dll	DrawUnicodeText	Ordinal	10110		
+D2Win.dll	GetPopupUnicodeTextWidthAndHeight	Ordinal	10124		
 D2Win.dll	GetUnicodeTextDrawWidth	Ordinal	10114		
 D2Win.dll	GetUnicodeTextNDrawWidth	Ordinal	10115		
 D2Win.dll	LoadCelFile	Ordinal	10035		

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -41,6 +41,7 @@ D2Lang.dll	Unicode_strlen	Offset	0x1490	?strlen@Unicode@@SIHPBU1@@Z	Unicode::str
 D2Lang.dll	Unicode_tolower	Offset	0x10E0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10B0		Unicode::toUpper
 D2Win.dll	DrawUnicodeText	Ordinal	10110		
+D2Win.dll	GetPopupUnicodeTextWidthAndHeight	Ordinal	10124		
 D2Win.dll	GetUnicodeTextDrawWidth	Ordinal	10114		
 D2Win.dll	GetUnicodeTextNDrawWidth	Ordinal	10115		
 D2Win.dll	LoadCelFile	Ordinal	10035		

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -41,6 +41,7 @@ D2Lang.dll	Unicode_strlen	Offset	0x1490	?strlen@Unicode@@SIHPBU1@@Z	Unicode::str
 D2Lang.dll	Unicode_tolower	Offset	0x10E0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10B0		Unicode::toUpper
 D2Win.dll	DrawUnicodeText	Ordinal	10117		
+D2Win.dll	GetPopupUnicodeTextWidthAndHeight	Ordinal	10131		
 D2Win.dll	GetUnicodeTextDrawWidth	Ordinal	10121		
 D2Win.dll	GetUnicodeTextNDrawWidth	Ordinal	10122		
 D2Win.dll	LoadCelFile	Ordinal	10039		

--- a/1.10.txt
+++ b/1.10.txt
@@ -41,6 +41,7 @@ D2Lang.dll	Unicode_strlen	Offset	0x14C0	?strlen@Unicode@@SIHPBU1@@Z	Unicode::str
 D2Lang.dll	Unicode_tolower	Offset	0x10E0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10B0		Unicode::toUpper
 D2Win.dll	DrawUnicodeText	Ordinal	10117		
+D2Win.dll	GetPopupUnicodeTextWidthAndHeight	Ordinal	10131		
 D2Win.dll	GetUnicodeTextDrawWidth	Ordinal	10121		
 D2Win.dll	GetUnicodeTextNDrawWidth	Ordinal	10122		
 D2Win.dll	LoadCelFile	Ordinal	10039		

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -41,6 +41,7 @@ D2Lang.dll	Unicode_strlen	Offset	0xA6E0	?strlen@Unicode@@SIHPBU1@@Z	Unicode::str
 D2Lang.dll	Unicode_tolower	Offset	0x10C0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10A0		Unicode::toUpper
 D2Win.dll	DrawUnicodeText	Ordinal	10001		
+D2Win.dll	GetPopupUnicodeTextWidthAndHeight	Ordinal	10096		
 D2Win.dll	GetUnicodeTextDrawWidth	Ordinal	10132		
 D2Win.dll	GetUnicodeTextNDrawWidth	Ordinal	10041		
 D2Win.dll	LoadCelFile	Ordinal	10186		

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -43,6 +43,7 @@ D2Lang.dll	Unicode_strlen	Offset	0xB0B0	?strlen@Unicode@@SIHPBU1@@Z	Unicode::str
 D2Lang.dll	Unicode_tolower	Offset	0x10C0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10A0		Unicode::toUpper
 D2Win.dll	DrawUnicodeText	Ordinal	10150		
+D2Win.dll	GetPopupUnicodeTextWidthAndHeight	Ordinal	10177		
 D2Win.dll	GetUnicodeTextDrawWidth	Ordinal	10028		
 D2Win.dll	GetUnicodeTextNDrawWidth	Ordinal	10055		
 D2Win.dll	HasWindowFocus	Offset	0x1FBA8		

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -41,6 +41,7 @@ D2Lang.dll	Unicode_strlen	Offset	0x8C60	?strlen@Unicode@@SIHPBU1@@Z	Unicode::str
 D2Lang.dll	Unicode_tolower	Offset	0x10C0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10A0		Unicode::toUpper
 D2Win.dll	DrawUnicodeText	Ordinal	10076		
+D2Win.dll	GetPopupUnicodeTextWidthAndHeight	Ordinal	10179		
 D2Win.dll	GetUnicodeTextDrawWidth	Ordinal	10150		
 D2Win.dll	GetUnicodeTextNDrawWidth	Ordinal	10148		
 D2Win.dll	LoadCelFile	Ordinal	10023		

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -41,6 +41,7 @@ D2Lang.dll	Unicode_strlen	Offset	0x123D50	?strlen@Unicode@@SIHPBU1@@Z	Unicode::s
 D2Lang.dll	Unicode_tolower	Offset	0xADD70	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x29E40		Unicode::toUpper
 D2Win.dll	DrawUnicodeText	Offset	0xFFB70		
+D2Win.dll	GetPopupUnicodeTextWidthAndHeight	Offset	0xFFD80		
 D2Win.dll	GetUnicodeTextDrawWidth	Offset	0xFF010		
 D2Win.dll	GetUnicodeTextNDrawWidth	Offset	0xFEFD0		
 D2Win.dll	LoadCelFile	Offset	0xF7F80		

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -41,6 +41,7 @@ D2Lang.dll	Unicode_strlen	Offset	0x126800	?strlen@Unicode@@SIHPBU1@@Z	Unicode::s
 D2Lang.dll	Unicode_tolower	Offset	0xB15F3	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x2E650		Unicode::toUpper
 D2Win.dll	DrawUnicodeText	Offset	0x102320		
+D2Win.dll	GetPopupUnicodeTextWidthAndHeight	Offset	0x102520		
 D2Win.dll	GetUnicodeTextDrawWidth	Offset	0x101820		
 D2Win.dll	GetUnicodeTextNDrawWidth	Offset	0x1017D0		
 D2Win.dll	LoadCelFile	Offset	0xFA9B0		


### PR DESCRIPTION
The function determines the number of horizontal and vertical pixels required to display the specified `UnicodeChar` text with the current font, by placing the width and height into the parameters.

The function can be located by looking for the bytes `B8 93 24 49 92`, which are the byte codes for the assembly instruction `mov eax, 0x92492493`.

## Function Definition

### All Versions
```C
void D2Win_GetPopupUnicodeTextWidthAndHeight(
    const UnicodeChar* unicode_text,
    int32_t* width,
    int32_t* height
);
```
- `unicode_text` in ecx
- `width` in edx
- Remaining parameters on the stack
  - Callee cleans the stack

`unicode_text` is not modified, which permits it to be `const`.

## Screenshots
The following 1.00 screenshot shows the function parameters and calling convention.
![D2Win_GetPopupUnicodeTextWidthAndHeight_01_(1 00)](https://user-images.githubusercontent.com/26683324/65571319-2cc81f80-df19-11e9-8049-72b582eb90bc.PNG)

The following 1.00 screenshot is of the function itself, which shows the parameters and the cleanup convention.
![D2Win_GetPopupUnicodeTextWidthAndHeight_02_and_03_(1 00)](https://user-images.githubusercontent.com/26683324/65571320-2cc81f80-df19-11e9-8595-cc43b24c5961.png)
