### PR TITLE
Add D2Lang Unicode asciiToUnicode

### DIFF
--- a/1.00.txt
+++ b/1.00.txt
@@ -38,7 +38,7 @@ D2Glide.dll	DisplayWidth	Offset	0x1DD44
 D2Lang.dll	ConvertUnicodeToWin				
 D2Lang.dll	GetStringByIndex	Ordinal	10004		
 D2Lang.dll	ToUnicodeString	Offset	0x1118	?toUnicode@Unicode@@SIPAU1@PAU1@PBDH@Z	Unicode::toUnicode
-D2Lang.dll	Unicode_asciiToUnicode	Offset	0x1154		Unicode::win2Unicode
+D2Lang.dll	Unicode_asciiToUnicode	Offset	0x1122		Unicode::win2Unicode
 D2Lang.dll	Unicode_strcat	Offset	0x10B4		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x1055	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x1014	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower

--- a/1.00.txt
+++ b/1.00.txt
@@ -38,6 +38,7 @@ D2Glide.dll	DisplayWidth	Offset	0x1DD44
 D2Lang.dll	ConvertUnicodeToWin				
 D2Lang.dll	GetStringByIndex	Ordinal	10004		
 D2Lang.dll	ToUnicodeString	Offset	0x1118	?toUnicode@Unicode@@SIPAU1@PAU1@PBDH@Z	Unicode::toUnicode
+D2Lang.dll	Unicode_asciiToUnicode	Offset	0x1154		Unicode::win2Unicode
 D2Lang.dll	Unicode_strcat	Offset	0x10B4		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x1055	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x1014	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower

--- a/1.03.txt
+++ b/1.03.txt
@@ -36,6 +36,7 @@ D2GFX.dll	VideoMode	Offset	0x2A988	"1 = GDI, 2 = Software, 3 = DirectDraw, 4 = G
 D2Glide.dll	DisplayHeight	Offset	0x1DDC4		
 D2Glide.dll	DisplayWidth	Offset	0x1DD04		
 D2Lang.dll	GetStringByIndex	Ordinal	10004		
+D2Lang.dll	Unicode_asciiToUnicode	Offset	0x109B		Unicode::win2Unicode
 D2Lang.dll	Unicode_strcat	Offset	0x10B4		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x1055	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x1014	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -36,6 +36,7 @@ D2GFX.dll	VideoMode	Offset	0x1D058	"1 = GDI, 2 = Software, 3 = DirectDraw, 4 = G
 D2Glide.dll	DisplayHeight	Offset	0x153AC		
 D2Glide.dll	DisplayWidth	Offset	0x152EC		
 D2Lang.dll	GetStringByIndex	Ordinal	10004		
+D2Lang.dll	Unicode_asciiToUnicode	Offset	0x1AC0		Unicode::win2Unicode
 D2Lang.dll	Unicode_strcat	Offset	0x13A0		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x1490	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10E0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -36,6 +36,7 @@ D2GFX.dll	VideoMode	Offset	0x1D208	"1 = GDI, 2 = Software, 3 = DirectDraw, 4 = G
 D2Glide.dll	DisplayHeight	Offset	0x153CC		
 D2Glide.dll	DisplayWidth	Offset	0x1530C		
 D2Lang.dll	GetStringByIndex	Ordinal	10004		
+D2Lang.dll	Unicode_asciiToUnicode	Offset	0x1B10		Unicode::win2Unicode
 D2Lang.dll	Unicode_strcat	Offset	0x13A0		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x1490	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10E0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower

--- a/1.10.txt
+++ b/1.10.txt
@@ -36,6 +36,7 @@ D2GFX.dll	VideoMode	Offset	0x1D264	"1 = GDI, 2 = Software, 3 = DirectDraw, 4 = G
 D2Glide.dll	DisplayHeight	Offset	0x15468		
 D2Glide.dll	DisplayWidth	Offset	0x153AC		
 D2Lang.dll	GetStringByIndex	Ordinal	10004		
+D2Lang.dll	Unicode_asciiToUnicode	Offset	0x1BD0	?win2Unicode@Unicode@@SIPAU1@PAU1@PBDH@Z	Unicode::win2Unicode
 D2Lang.dll	Unicode_strcat	Offset	0x13F0		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x14C0	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10E0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -36,6 +36,7 @@ D2GFX.dll	VideoMode	Offset	0x1D44C	"1 = GDI, 2 = Software, 3 = DirectDraw, 4 = G
 D2Glide.dll	DisplayHeight	Offset	0x16E8C		
 D2Glide.dll	DisplayWidth	Offset	0x16DF0		
 D2Lang.dll	GetStringByIndex	Ordinal	10005		
+D2Lang.dll	Unicode_asciiToUnicode	Offset	0xAF10		Unicode::win2Unicode
 D2Lang.dll	Unicode_strcat	Offset	0xA610		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0xA6E0	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10C0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -38,6 +38,7 @@ D2Glide.dll	DisplayWidth	Offset	0x15A68
 D2Lang.dll	CreateD2UnicodeChar	Ordinal	10000		
 D2Lang.dll	CreateD2UnicodeCharWithValue	Ordinal			
 D2Lang.dll	GetStringByIndex	Ordinal	10003		
+D2Lang.dll	Unicode_asciiToUnicode	Offset	0x8320		Unicode::win2Unicode
 D2Lang.dll	Unicode_strcat	Offset	0xAFE0		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0xB0B0	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10C0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -36,6 +36,7 @@ D2GFX.dll	VideoMode	Offset	0x14A38	"1 = GDI, 2 = Software, 3 = DirectDraw, 4 = G
 D2Glide.dll	DisplayHeight	Offset	0x15B14		
 D2Glide.dll	DisplayWidth	Offset	0x15A78		
 D2Lang.dll	GetStringByIndex	Ordinal	10004		
+D2Lang.dll	Unicode_asciiToUnicode	Offset	0x82E0		Unicode::win2Unicode
 D2Lang.dll	Unicode_strcat	Offset	0x8B90		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x8C60	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10C0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -36,6 +36,7 @@ D2GFX.dll	VideoMode	Offset	0x3BFD38	"1 = GDI, 2 = Software, 3 = DirectDraw, 4 = 
 D2Glide.dll	DisplayHeight	Offset	0x3C01C4		
 D2Glide.dll	DisplayWidth	Offset	0x3C01C0		
 D2Lang.dll	GetStringByIndex	Offset	0x121EE0		
+D2Lang.dll	Unicode_asciiToUnicode	Offset	0x124450		Unicode::win2Unicode
 D2Lang.dll	Unicode_strcat	Offset	0x123C50		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x123D50	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0xADD70	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -36,6 +36,7 @@ D2GFX.dll	VideoMode	Offset	0x3C8CB0	"1 = GDI, 2 = Software, 3 = DirectDraw, 4 = 
 D2Glide.dll	DisplayHeight	Offset	0x3C913C		
 D2Glide.dll	DisplayWidth	Offset	0x3C9138		
 D2Lang.dll	GetStringByIndex	Offset	0x124A30		
+D2Lang.dll	Unicode_asciiToUnicode	Offset	0x126F20		Unicode::win2Unicode
 D2Lang.dll	Unicode_strcat	Offset	0x126700		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x126800	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0xB15F3	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower


### PR DESCRIPTION
The function takes a string encoded with 7-bit ASCII characters, converts the characters to `UnicodeChar` format, and then stores the converted characters in a specified location. It will copy the specified number of characters minus one, and safely null-terminate the destination string. The function returns the pointer to the destination string.

The function can be located by scanning for the bytes `B9 D9 0F 00 00` which represent the x86 operation `mov ecx, 4057` in executable, non-writable regions of memory.

## Function Definition
### All Versions
```C
Unicode* D2Lang_Unicode_asciiToUnicode(
    Unicode* dest,
    const char* src,
    int32_t count
);
```
- `dest` in ecx
- `src` in edx
- Remaining parameters on the stack
  - Callee cleans the stack

The function is known as `Unicode::win2Unicode`. This name is not chosen for the API because it is unclear what "win" means, which encoding is being used, and whether the encoding CP-1252 is related. The function does a direct promotion of the individual characters into Unicode characters. No arithmetic is applied to modify the characters before storage.

The values stored at the parameter `src` are not modified by the function. It therefore qualifies for the `const` modifier.

`count` is the number of characters to store in `dest`, including the null-terminator character. A value of `INT32_MAX` will practically (but not theoretically) copy all characters from `src` into `dest`.

## Screenshots
The following 1.03 screenshot shows the entire function, the function parameters, and the cleanup convention. `count` is shown to be an `int32_t`. The values of `src` are shown not to be modified. The parameter `dest` is returned.
![D2Lang_Unicode_asciiToUnicode_01_(1 03)](https://user-images.githubusercontent.com/26683324/65827329-fd315400-e245-11e9-977b-a5369a1e895b.PNG)

The following 1.03 screenshot shows the function's calling convention and parameters.
![D2Lang_Unicode_asciiToUnicode_02_(1 03)](https://user-images.githubusercontent.com/26683324/65827330-fd315400-e245-11e9-8488-045779022b1a.PNG)

The following LoD 1.14D screenshot shows the context used to locate the function.
![D2Lang_Unicode_asciiToUnicode_03_(LoD 1 14D)](https://user-images.githubusercontent.com/26683324/65827331-fd315400-e245-11e9-84ec-28552abec4f8.PNG)
