### PR TITLE
Add D2Lang Unicode utf8ToUnicode

### DIFF
--- a/1.00.txt
+++ b/1.00.txt
@@ -37,12 +37,12 @@ D2Glide.dll	DisplayHeight	Offset	0x1DE04
 D2Glide.dll	DisplayWidth	Offset	0x1DD44		
 D2Lang.dll	ConvertUnicodeToWin				
 D2Lang.dll	GetStringByIndex	Ordinal	10004		
-D2Lang.dll	ToUnicodeString	Offset	0x1118	?toUnicode@Unicode@@SIPAU1@PAU1@PBDH@Z	Unicode::toUnicode
 D2Lang.dll	Unicode_asciiToUnicode	Offset	0x1122		Unicode::win2Unicode
 D2Lang.dll	Unicode_strcat	Offset	0x10B4		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x1055	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x1014	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x1154		Unicode::toUpper
+D2Lang.dll	Unicode_utf8ToUnicode	Offset	0x1118	?toUnicode@Unicode@@SIPAU1@PAU1@PBDH@Z	Unicode::toUnicode
 D2Lang.dll	UnicodeChar_Compare	Offset	0x1019	?compare@Unicode@@SIHU1@0@Z	Unicode::compare
 D2Lang.dll	UnicodeChar_Copy	Offset	0x1136	??4Unicode@@QAEAAU0@ABU0@@Z	Unicode::operator=
 D2Lang.dll	UnicodeChar_CreateWithNoArgs	Offset	0x10CD	??_FUnicode@@QAEXXZ	Unicode::`default constructor closure'

--- a/1.03.txt
+++ b/1.03.txt
@@ -41,6 +41,7 @@ D2Lang.dll	Unicode_strcat	Offset	0x10B4		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x1055	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x1014	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x1154		Unicode::toUpper
+D2Lang.dll	Unicode_utf8ToUnicode	Offset	0x1118	?toUnicode@Unicode@@SIPAU1@PAU1@PBDH@Z	Unicode::toUnicode
 D2Win.dll	DrawUnicodeText	Ordinal	10110		
 D2Win.dll	GetPopupUnicodeTextWidthAndHeight	Ordinal	10124		
 D2Win.dll	GetUnicodeTextDrawWidth	Ordinal	10114		

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -41,6 +41,7 @@ D2Lang.dll	Unicode_strcat	Offset	0x13A0		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x1490	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10E0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10B0		Unicode::toUpper
+D2Lang.dll	Unicode_utf8ToUnicode	Offset	0x23F0	?toUnicode@Unicode@@SIPAU1@PAU1@PBDH@Z	Unicode::toUnicode
 D2Win.dll	DrawUnicodeText	Ordinal	10110		
 D2Win.dll	GetPopupUnicodeTextWidthAndHeight	Ordinal	10124		
 D2Win.dll	GetUnicodeTextDrawWidth	Ordinal	10114		

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -41,6 +41,7 @@ D2Lang.dll	Unicode_strcat	Offset	0x13A0		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x1490	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10E0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10B0		Unicode::toUpper
+D2Lang.dll	Unicode_utf8ToUnicode	Offset	0x2AA0	?toUnicode@Unicode@@SIPAU1@PAU1@PBDH@Z	Unicode::toUnicode
 D2Win.dll	DrawUnicodeText	Ordinal	10117		
 D2Win.dll	GetPopupUnicodeTextWidthAndHeight	Ordinal	10131		
 D2Win.dll	GetUnicodeTextDrawWidth	Ordinal	10121		

--- a/1.10.txt
+++ b/1.10.txt
@@ -41,6 +41,7 @@ D2Lang.dll	Unicode_strcat	Offset	0x13F0		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x14C0	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10E0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10B0		Unicode::toUpper
+D2Lang.dll	Unicode_utf8ToUnicode	Offset	0x2A40	?toUnicode@Unicode@@SIPAU1@PAU1@PBDH@Z	Unicode::toUnicode
 D2Win.dll	DrawUnicodeText	Ordinal	10117		
 D2Win.dll	GetPopupUnicodeTextWidthAndHeight	Ordinal	10131		
 D2Win.dll	GetUnicodeTextDrawWidth	Ordinal	10121		

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -41,6 +41,7 @@ D2Lang.dll	Unicode_strcat	Offset	0xA610		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0xA6E0	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10C0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10A0		Unicode::toUpper
+D2Lang.dll	Unicode_utf8ToUnicode	Offset	0x8A00	?toUnicode@Unicode@@SIPAU1@PAU1@PBDH@Z	Unicode::toUnicode
 D2Win.dll	DrawUnicodeText	Ordinal	10001		
 D2Win.dll	GetPopupUnicodeTextWidthAndHeight	Ordinal	10096		
 D2Win.dll	GetUnicodeTextDrawWidth	Ordinal	10132		

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -43,6 +43,7 @@ D2Lang.dll	Unicode_strcat	Offset	0xAFE0		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0xB0B0	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10C0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10A0		Unicode::toUpper
+D2Lang.dll	Unicode_utf8ToUnicode	Offset	0x8CD0	?toUnicode@Unicode@@SIPAU1@PAU1@PBDH@Z	Unicode::toUnicode
 D2Win.dll	DrawUnicodeText	Ordinal	10150		
 D2Win.dll	GetPopupUnicodeTextWidthAndHeight	Ordinal	10177		
 D2Win.dll	GetUnicodeTextDrawWidth	Ordinal	10028		

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -41,6 +41,7 @@ D2Lang.dll	Unicode_strcat	Offset	0x8B90		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x8C60	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10C0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10A0		Unicode::toUpper
+D2Lang.dll	Unicode_utf8ToUnicode	Offset	0xB520	?toUnicode@Unicode@@SIPAU1@PAU1@PBDH@Z	Unicode::toUnicode
 D2Win.dll	DrawUnicodeText	Ordinal	10076		
 D2Win.dll	GetPopupUnicodeTextWidthAndHeight	Ordinal	10179		
 D2Win.dll	GetUnicodeTextDrawWidth	Ordinal	10150		

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -41,6 +41,7 @@ D2Lang.dll	Unicode_strcat	Offset	0x123C50		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x123D50	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0xADD70	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x29E40		Unicode::toUpper
+D2Lang.dll	Unicode_utf8ToUnicode	Offset	0x123890	?toUnicode@Unicode@@SIPAU1@PAU1@PBDH@Z	Unicode::toUnicode
 D2Win.dll	DrawUnicodeText	Offset	0xFFB70		
 D2Win.dll	GetPopupUnicodeTextWidthAndHeight	Offset	0xFFD80		
 D2Win.dll	GetUnicodeTextDrawWidth	Offset	0xFF010		

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -41,6 +41,7 @@ D2Lang.dll	Unicode_strcat	Offset	0x126700		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x126800	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0xB15F3	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x2E650		Unicode::toUpper
+D2Lang.dll	Unicode_utf8ToUnicode	Offset	0x126320	?toUnicode@Unicode@@SIPAU1@PAU1@PBDH@Z	Unicode::toUnicode
 D2Win.dll	DrawUnicodeText	Offset	0x102320		
 D2Win.dll	GetPopupUnicodeTextWidthAndHeight	Offset	0x102520		
 D2Win.dll	GetUnicodeTextDrawWidth	Offset	0x101820		


### PR DESCRIPTION
The function takes the specified UTF-8 encoded text, converts the characters to  `Unicode` (UTF-16) encoding, and stores the values in a specified destination. It will copy the specified number of characters (which may be larger than one code point) minus one, and safely null-terminates the destination string.

The function can be located by searching in executable non-writable regions of memory for the usages of the string `Realm: `.

## Function Definition
### All Versions
```C
Unicode* D2Lang_Unicode_utf8ToUnicode(
    Unicode* dest,
    const char* src
    int32_t count_with_null_term
);
```
- `dest` in ecx
- `src` in edx
- Remaining parameters on the stack
  - Callee cleans the stack

The function is known as `Unicode::toUnicode`. As a side note, 1.10+ introduced a function that was actually named `Unicode::utf8ToUnicode`. That function is unnecessary, especially given that this function exists.

ASCII characters are compatible with UTF-8, so the `src` type could also be `char8_t`.

`count_with_null_term` is the number of characters to store in dest, including the null-terminator character. A value of INT32_MAX will practically (but not theoretically) copy all characters from src into dest.

## Screenshots
The following 1.00 screenshot shows the function's parameters and calling convention. `src` is a pointer to a string of UTF-8 encoded characters.
![D2Lang_Unicode_utf8ToUnicode_01_(1 00)](https://user-images.githubusercontent.com/26683324/65840923-319f2180-e2d3-11e9-8ea2-ef41ceccedc3.PNG)

The following 1.10 screenshot shows the function's code. The highlighted parts show that the parameter `count_with_null_term` is an `int32_t`. The red section is primarily the conversion code. The black section indicates the arithmetic being done to convert UTF-8 to UTF-16.
![D2Lang_Unicode_utf8ToUnicode_02_(1 10)](https://user-images.githubusercontent.com/26683324/65840924-3237b800-e2d3-11e9-96d0-b78b04d2e1a7.PNG)
