### PR TITLE
Add D2Lang Unicode unicodeToUtf8

### DIFF
--- a/1.00.txt
+++ b/1.00.txt
@@ -35,13 +35,13 @@ D2GFX.dll	ResolutionMode	Offset	0x2A950	"0 = 640x480, 1 = Main Menu 800x600"
 D2GFX.dll	VideoMode	Offset	0x2A948	"1 = GDI, 2 = Software, 3 = DirectDraw, 4 = Glide, 5 = OpenGL, 6 = Direct3D, 7 = Rave"	
 D2Glide.dll	DisplayHeight	Offset	0x1DE04		
 D2Glide.dll	DisplayWidth	Offset	0x1DD44		
-D2Lang.dll	ConvertUnicodeToWin				
 D2Lang.dll	GetStringByIndex	Ordinal	10004		
 D2Lang.dll	Unicode_asciiToUnicode	Offset	0x1122		Unicode::win2Unicode
 D2Lang.dll	Unicode_strcat	Offset	0x10B4		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x1055	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x1014	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x1154		Unicode::toUpper
+D2Lang.dll	Unicode_unicodeToUtf8	Offset	0x1069	?toUtf@Unicode@@SIPADPADPBU1@H@Z	Unicode::toUtf
 D2Lang.dll	Unicode_utf8ToUnicode	Offset	0x1118	?toUnicode@Unicode@@SIPAU1@PAU1@PBDH@Z	Unicode::toUnicode
 D2Lang.dll	UnicodeChar_Compare	Offset	0x1019	?compare@Unicode@@SIHU1@0@Z	Unicode::compare
 D2Lang.dll	UnicodeChar_Copy	Offset	0x1136	??4Unicode@@QAEAAU0@ABU0@@Z	Unicode::operator=

--- a/1.03.txt
+++ b/1.03.txt
@@ -41,6 +41,7 @@ D2Lang.dll	Unicode_strcat	Offset	0x10B4		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x1055	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x1014	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x1154		Unicode::toUpper
+D2Lang.dll	Unicode_unicodeToUtf8	Offset	0x1069	?toUtf@Unicode@@SIPADPADPBU1@H@Z	Unicode::toUtf
 D2Lang.dll	Unicode_utf8ToUnicode	Offset	0x1118	?toUnicode@Unicode@@SIPAU1@PAU1@PBDH@Z	Unicode::toUnicode
 D2Win.dll	DrawUnicodeText	Ordinal	10110		
 D2Win.dll	GetPopupUnicodeTextWidthAndHeight	Ordinal	10124		

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -41,6 +41,7 @@ D2Lang.dll	Unicode_strcat	Offset	0x13A0		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x1490	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10E0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10B0		Unicode::toUpper
+D2Lang.dll	Unicode_unicodeToUtf8	Offset	0x2530	?toUtf@Unicode@@SIPADPADPBU1@H@Z	Unicode::toUtf
 D2Lang.dll	Unicode_utf8ToUnicode	Offset	0x23F0	?toUnicode@Unicode@@SIPAU1@PAU1@PBDH@Z	Unicode::toUnicode
 D2Win.dll	DrawUnicodeText	Ordinal	10110		
 D2Win.dll	GetPopupUnicodeTextWidthAndHeight	Ordinal	10124		

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -41,6 +41,7 @@ D2Lang.dll	Unicode_strcat	Offset	0x13A0		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x1490	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10E0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10B0		Unicode::toUpper
+D2Lang.dll	Unicode_unicodeToUtf8	Offset	0x2BE0	?toUtf@Unicode@@SIPADPADPBU1@H@Z	Unicode::toUtf
 D2Lang.dll	Unicode_utf8ToUnicode	Offset	0x2AA0	?toUnicode@Unicode@@SIPAU1@PAU1@PBDH@Z	Unicode::toUnicode
 D2Win.dll	DrawUnicodeText	Ordinal	10117		
 D2Win.dll	GetPopupUnicodeTextWidthAndHeight	Ordinal	10131		

--- a/1.10.txt
+++ b/1.10.txt
@@ -41,6 +41,7 @@ D2Lang.dll	Unicode_strcat	Offset	0x13F0		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x14C0	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10E0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10B0		Unicode::toUpper
+D2Lang.dll	Unicode_unicodeToUtf8	Offset	0x2B60	?toUtf@Unicode@@SIPADPADPBU1@H@Z	Unicode::toUtf
 D2Lang.dll	Unicode_utf8ToUnicode	Offset	0x2A40	?toUnicode@Unicode@@SIPAU1@PAU1@PBDH@Z	Unicode::toUnicode
 D2Win.dll	DrawUnicodeText	Ordinal	10117		
 D2Win.dll	GetPopupUnicodeTextWidthAndHeight	Ordinal	10131		

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -41,6 +41,7 @@ D2Lang.dll	Unicode_strcat	Offset	0xA610		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0xA6E0	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10C0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10A0		Unicode::toUpper
+D2Lang.dll	Unicode_unicodeToUtf8	Offset	0x8BB0	?toUtf@Unicode@@SIPADPADPBU1@H@Z	Unicode::toUtf
 D2Lang.dll	Unicode_utf8ToUnicode	Offset	0x8A00	?toUnicode@Unicode@@SIPAU1@PAU1@PBDH@Z	Unicode::toUnicode
 D2Win.dll	DrawUnicodeText	Ordinal	10001		
 D2Win.dll	GetPopupUnicodeTextWidthAndHeight	Ordinal	10096		

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -35,20 +35,18 @@ D2GFX.dll	ResolutionMode	Offset	0x11260	"0 = 640x480, 1 = Main Menu, 2 = 800x600
 D2GFX.dll	VideoMode	Offset	0x11258	"1 = GDI, 2 = Software, 3 = DirectDraw, 4 = Glide, 5 = OpenGL, 6 = Direct3D, 7 = Rave"	
 D2Glide.dll	DisplayHeight	Offset	0x15B04		
 D2Glide.dll	DisplayWidth	Offset	0x15A68		
-D2Lang.dll	CreateD2UnicodeChar	Ordinal	10000		
-D2Lang.dll	CreateD2UnicodeCharWithValue	Ordinal			
 D2Lang.dll	GetStringByIndex	Ordinal	10003		
 D2Lang.dll	Unicode_asciiToUnicode	Offset	0x8320		Unicode::win2Unicode
 D2Lang.dll	Unicode_strcat	Offset	0xAFE0		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0xB0B0	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10C0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10A0		Unicode::toUpper
+D2Lang.dll	Unicode_unicodeToUtf8	Offset	0x8E80	?toUtf@Unicode@@SIPADPADPBU1@H@Z	Unicode::toUtf
 D2Lang.dll	Unicode_utf8ToUnicode	Offset	0x8CD0	?toUnicode@Unicode@@SIPAU1@PAU1@PBDH@Z	Unicode::toUnicode
 D2Win.dll	DrawUnicodeText	Ordinal	10150		
 D2Win.dll	GetPopupUnicodeTextWidthAndHeight	Ordinal	10177		
 D2Win.dll	GetUnicodeTextDrawWidth	Ordinal	10028		
 D2Win.dll	GetUnicodeTextNDrawWidth	Ordinal	10055		
-D2Win.dll	HasWindowFocus	Offset	0x1FBA8		
 D2Win.dll	LoadCelFile	Ordinal	10111		
 D2Win.dll	LoadMPQ	Offset	0x7E60		
 D2Win.dll	MainMenuMousePositionX	Offset	0x21488		

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -41,6 +41,7 @@ D2Lang.dll	Unicode_strcat	Offset	0x8B90		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x8C60	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10C0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10A0		Unicode::toUpper
+D2Lang.dll	Unicode_unicodeToUtf8	Offset	0xB6D0	?toUtf@Unicode@@SIPADPADPBU1@H@Z	Unicode::toUtf
 D2Lang.dll	Unicode_utf8ToUnicode	Offset	0xB520	?toUnicode@Unicode@@SIPAU1@PAU1@PBDH@Z	Unicode::toUnicode
 D2Win.dll	DrawUnicodeText	Ordinal	10076		
 D2Win.dll	GetPopupUnicodeTextWidthAndHeight	Ordinal	10179		

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -41,6 +41,7 @@ D2Lang.dll	Unicode_strcat	Offset	0x123C50		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x123D50	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0xADD70	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x29E40		Unicode::toUpper
+D2Lang.dll	Unicode_unicodeToUtf8	Offset	0x123940	?toUtf@Unicode@@SIPADPADPBU1@H@Z	Unicode::toUtf
 D2Lang.dll	Unicode_utf8ToUnicode	Offset	0x123890	?toUnicode@Unicode@@SIPAU1@PAU1@PBDH@Z	Unicode::toUnicode
 D2Win.dll	DrawUnicodeText	Offset	0xFFB70		
 D2Win.dll	GetPopupUnicodeTextWidthAndHeight	Offset	0xFFD80		

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -41,6 +41,7 @@ D2Lang.dll	Unicode_strcat	Offset	0x126700		Unicode::strcat
 D2Lang.dll	Unicode_strlen	Offset	0x126800	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0xB15F3	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x2E650		Unicode::toUpper
+D2Lang.dll	Unicode_unicodeToUtf8	Offset	0x1263E0	?toUtf@Unicode@@SIPADPADPBU1@H@Z	Unicode::toUtf
 D2Lang.dll	Unicode_utf8ToUnicode	Offset	0x126320	?toUnicode@Unicode@@SIPAU1@PAU1@PBDH@Z	Unicode::toUnicode
 D2Win.dll	DrawUnicodeText	Offset	0x102320		
 D2Win.dll	GetPopupUnicodeTextWidthAndHeight	Offset	0x102520		


### PR DESCRIPTION
The function takes the specified Unicode (UTF-16 encoded) text, converts the characters to UTF-8 encoding, and stores the values in a specified destination. It will copy the specified number of characters (which may be larger than one code point) minus one, and safely null-terminates the destination string.

The function can be located by searching in executable non-writable regions of memory for the usages of the string `line 0 of string does not contain scroll rate`.

## Function Definition
### All Versions
```C
char* D2Lang_Unicode_unicodeToUtf8(
    char* dest,
    const Unicode* src
    int32_t count_with_null_term
);
```
- `dest` in ecx
- `src` in edx
- Remaining parameters on the stack
  - Callee cleans the stack

The function is known as `Unicode::toUtf`.

ASCII characters are compatible with UTF-8, so the `dest` type could also be `char8_t`.

`count_with_null_term` is the number of characters to store in dest, including the null-terminator character. A value of INT32_MAX will practically (but not theoretically) copy all characters from `src` into `dest`.

## Screenshots
The following 1.00 screenshot shows the calling convention of the function. In the same screenshot, there is an access to the string that is used to locate the function.
![D2Lang_Unicode_unicodeToUtf8_01_(1 00)](https://user-images.githubusercontent.com/26683324/65934106-00a11880-e3c9-11e9-8b6a-f1a71da65d05.PNG)

The following 1.10 screenshot shows some of the function code. The highlighted section shows that the parameter `count_with_null_term` is an `int32_t`. The black section indicates the arithmetic done to convert UTF-16 to UTF-8.
![D2Lang_Unicode_unicodeToUtf8_02_(1 10)](https://user-images.githubusercontent.com/26683324/65934107-00a11880-e3c9-11e9-9f68-8959533df312.PNG)
