### PR TITLE
Add D2Lang Unicode strcmp

### DIFF
--- a/1.00.txt
+++ b/1.00.txt
@@ -38,6 +38,7 @@ D2Glide.dll	DisplayWidth	Offset	0x1DD44
 D2Lang.dll	GetStringByIndex	Ordinal	10004		
 D2Lang.dll	Unicode_asciiToUnicode	Offset	0x1122		Unicode::win2Unicode
 D2Lang.dll	Unicode_strcat	Offset	0x10B4		Unicode::strcat
+D2Lang.dll	Unicode_strcmp	Offset	0x1050	?strcmp@Unicode@@SIHPBU1@0@Z	Unicode::strcmp
 D2Lang.dll	Unicode_strlen	Offset	0x1055	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x1014	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x1154		Unicode::toUpper
@@ -51,7 +52,6 @@ D2Lang.dll	UnicodeChar_IsAlpha	Offset	0x103C	?isAlpha@Unicode@@QBEHXZ	Unicode::i
 D2Lang.dll	UnicodeChar_IsNewLine	Offset	0x1073	?isNewline@Unicode@@QBEHXZ	Unicode::isNewline
 D2Lang.dll	UnicodeChar_IsPipe	Offset	0x1087	?isPipe@Unicode@@QBEHXZ	Unicode::isPipe
 D2Lang.dll	UnicodeChar_IsWhitespace	Offset	0x1032	?isWhitespace@Unicode@@QBEHXZ	Unicode::isWhitespace
-D2Lang.dll	UnicodeString_Compare	Offset	0x1050	?strcmp@Unicode@@SIHPBU1@0@Z	Unicode::strcmp
 D2Lang.dll	UnicodeString_CompareIgnoreCase	Offset	0x100A	?stricmp@Unicode@@SIHPBU1@0@Z	Unicode::stricmp
 D2Lang.dll	UnicodeString_FindChar	Offset	0x101E	?strchr@Unicode@@SIPAU1@PBU1@U1@@Z	Unicode::strchr
 D2Lang.dll	UnicodeString_Format	Offset	0x1046	?sprintf@Unicode@@SAXHPAU1@PBU1@ZZ	Unicode::sprintf

--- a/1.03.txt
+++ b/1.03.txt
@@ -38,6 +38,7 @@ D2Glide.dll	DisplayWidth	Offset	0x1DD04
 D2Lang.dll	GetStringByIndex	Ordinal	10004		
 D2Lang.dll	Unicode_asciiToUnicode	Offset	0x109B		Unicode::win2Unicode
 D2Lang.dll	Unicode_strcat	Offset	0x10B4		Unicode::strcat
+D2Lang.dll	Unicode_strcmp	Offset	0x1050	?strcmp@Unicode@@SIHPBU1@0@Z	Unicode::strcmp
 D2Lang.dll	Unicode_strlen	Offset	0x1055	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x1014	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x1154		Unicode::toUpper

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -38,6 +38,7 @@ D2Glide.dll	DisplayWidth	Offset	0x152EC
 D2Lang.dll	GetStringByIndex	Ordinal	10004		
 D2Lang.dll	Unicode_asciiToUnicode	Offset	0x1AC0		Unicode::win2Unicode
 D2Lang.dll	Unicode_strcat	Offset	0x13A0		Unicode::strcat
+D2Lang.dll	Unicode_strcmp	Offset	0x1210	?strcmp@Unicode@@SIHPBU1@0@Z	Unicode::strcmp
 D2Lang.dll	Unicode_strlen	Offset	0x1490	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10E0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10B0		Unicode::toUpper

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -38,6 +38,7 @@ D2Glide.dll	DisplayWidth	Offset	0x1530C
 D2Lang.dll	GetStringByIndex	Ordinal	10004		
 D2Lang.dll	Unicode_asciiToUnicode	Offset	0x1B10		Unicode::win2Unicode
 D2Lang.dll	Unicode_strcat	Offset	0x13A0		Unicode::strcat
+D2Lang.dll	Unicode_strcmp	Offset	0x1210	?strcmp@Unicode@@SIHPBU1@0@Z	Unicode::strcmp
 D2Lang.dll	Unicode_strlen	Offset	0x1490	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10E0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10B0		Unicode::toUpper

--- a/1.10.txt
+++ b/1.10.txt
@@ -38,6 +38,7 @@ D2Glide.dll	DisplayWidth	Offset	0x153AC
 D2Lang.dll	GetStringByIndex	Ordinal	10004		
 D2Lang.dll	Unicode_asciiToUnicode	Offset	0x1BD0	?win2Unicode@Unicode@@SIPAU1@PAU1@PBDH@Z	Unicode::win2Unicode
 D2Lang.dll	Unicode_strcat	Offset	0x13F0		Unicode::strcat
+D2Lang.dll	Unicode_strcmp	Offset	0x1210	?strcmp@Unicode@@SIHPBU1@0@Z	Unicode::strcmp
 D2Lang.dll	Unicode_strlen	Offset	0x14C0	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10E0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10B0		Unicode::toUpper

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -38,6 +38,7 @@ D2Glide.dll	DisplayWidth	Offset	0x16DF0
 D2Lang.dll	GetStringByIndex	Ordinal	10005		
 D2Lang.dll	Unicode_asciiToUnicode	Offset	0xAF10		Unicode::win2Unicode
 D2Lang.dll	Unicode_strcat	Offset	0xA610		Unicode::strcat
+D2Lang.dll	Unicode_strcmp	Offset	0xA830	?strcmp@Unicode@@SIHPBU1@0@Z	Unicode::strcmp
 D2Lang.dll	Unicode_strlen	Offset	0xA6E0	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10C0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10A0		Unicode::toUpper

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -38,6 +38,7 @@ D2Glide.dll	DisplayWidth	Offset	0x15A68
 D2Lang.dll	GetStringByIndex	Ordinal	10003		
 D2Lang.dll	Unicode_asciiToUnicode	Offset	0x8320		Unicode::win2Unicode
 D2Lang.dll	Unicode_strcat	Offset	0xAFE0		Unicode::strcat
+D2Lang.dll	Unicode_strcmp	Offset	0xB200	?strcmp@Unicode@@SIHPBU1@0@Z	Unicode::strcmp
 D2Lang.dll	Unicode_strlen	Offset	0xB0B0	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10C0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10A0		Unicode::toUpper

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -38,6 +38,7 @@ D2Glide.dll	DisplayWidth	Offset	0x15A78
 D2Lang.dll	GetStringByIndex	Ordinal	10004		
 D2Lang.dll	Unicode_asciiToUnicode	Offset	0x82E0		Unicode::win2Unicode
 D2Lang.dll	Unicode_strcat	Offset	0x8B90		Unicode::strcat
+D2Lang.dll	Unicode_strcmp	Offset	0xB200	?strcmp@Unicode@@SIHPBU1@0@Z	Unicode::strcmp
 D2Lang.dll	Unicode_strlen	Offset	0x8C60	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10C0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10A0		Unicode::toUpper

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -38,6 +38,7 @@ D2Glide.dll	DisplayWidth	Offset	0x3C01C0
 D2Lang.dll	GetStringByIndex	Offset	0x121EE0		
 D2Lang.dll	Unicode_asciiToUnicode	Offset	0x124450		Unicode::win2Unicode
 D2Lang.dll	Unicode_strcat	Offset	0x123C50		Unicode::strcat
+D2Lang.dll	Unicode_strcmp	Offset	0x123A40	?strcmp@Unicode@@SIHPBU1@0@Z	Unicode::strcmp
 D2Lang.dll	Unicode_strlen	Offset	0x123D50	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0xADD70	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x29E40		Unicode::toUpper

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -38,6 +38,7 @@ D2Glide.dll	DisplayWidth	Offset	0x3C9138
 D2Lang.dll	GetStringByIndex	Offset	0x124A30		
 D2Lang.dll	Unicode_asciiToUnicode	Offset	0x126F20		Unicode::win2Unicode
 D2Lang.dll	Unicode_strcat	Offset	0x126700		Unicode::strcat
+D2Lang.dll	Unicode_strcmp	Offset	0x1264F0	?strcmp@Unicode@@SIHPBU1@0@Z	Unicode::strcmp
 D2Lang.dll	Unicode_strlen	Offset	0x126800	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0xB15F3	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x2E650		Unicode::toUpper


### PR DESCRIPTION
The function takes two null-terminated `UnicodeChar` strings and returns a negative number if the first string lexicographically appears before the second string, a positive number if the first string lexicographically appears after the second string, or 0 if the strings have the same characters.

The function is located in versions prior to 1.14A by searching for the function `Unicode::strcmp` in `D2Lang.dll`. Otherwise, the function is located by bruteforce scanning of opcodes taken from previous versions of the function.

## Function Definition
### All Versions
```C
int32_t D2Lang_Unicode_strcmp(
    const UnicodeChar* str1,
    const UnicodeChar* str2
);
```
- `str1` in ecx
- `str2` in edx

The data in both `str1` and `str2` are not modified by the function, which makes both variables eligible for the `const` qualifier.

## Screenshots
The following 1.00 screenshot shows the entire function, which also shows its parameters, cleanup convention, and return type.
![D2Lang_Unicode_strcmp_01_(1 00)](https://user-images.githubusercontent.com/26683324/67540645-efcb8600-f69a-11e9-89e6-b058e72aa0d1.PNG)

The following 1.12A screenshot shows the entire function.
![D2Lang_Unicode_strcmp_02_(1 12A)](https://user-images.githubusercontent.com/26683324/67540646-efcb8600-f69a-11e9-8cee-4b4f22a132fb.PNG)

The following LoD 1.14D screenshot shows the entire function.
![D2Lang_Unicode_strcmp_03_(LoD 1 14D)](https://user-images.githubusercontent.com/26683324/67540647-f0641c80-f69a-11e9-9e6c-0b119c2ddd6c.PNG)
