### PR TITLE
Add D2Lang Unicode strcpy

### DIFF
--- a/1.00.txt
+++ b/1.00.txt
@@ -39,6 +39,7 @@ D2Lang.dll	GetStringByIndex	Ordinal	10004
 D2Lang.dll	Unicode_asciiToUnicode	Offset	0x1122		Unicode::win2Unicode
 D2Lang.dll	Unicode_strcat	Offset	0x10B4		Unicode::strcat
 D2Lang.dll	Unicode_strcmp	Offset	0x1050	?strcmp@Unicode@@SIHPBU1@0@Z	Unicode::strcmp
+D2Lang.dll	Unicode_strcpy	Offset	0x10D7		Unicode::strcpy
 D2Lang.dll	Unicode_strlen	Offset	0x1055	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x1014	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x1154		Unicode::toUpper

--- a/1.03.txt
+++ b/1.03.txt
@@ -39,6 +39,7 @@ D2Lang.dll	GetStringByIndex	Ordinal	10004
 D2Lang.dll	Unicode_asciiToUnicode	Offset	0x109B		Unicode::win2Unicode
 D2Lang.dll	Unicode_strcat	Offset	0x10B4		Unicode::strcat
 D2Lang.dll	Unicode_strcmp	Offset	0x1050	?strcmp@Unicode@@SIHPBU1@0@Z	Unicode::strcmp
+D2Lang.dll	Unicode_strcpy	Offset	0x10D7		Unicode::strcpy
 D2Lang.dll	Unicode_strlen	Offset	0x1055	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x1014	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x1154		Unicode::toUpper

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -39,6 +39,7 @@ D2Lang.dll	GetStringByIndex	Ordinal	10004
 D2Lang.dll	Unicode_asciiToUnicode	Offset	0x1AC0		Unicode::win2Unicode
 D2Lang.dll	Unicode_strcat	Offset	0x13A0		Unicode::strcat
 D2Lang.dll	Unicode_strcmp	Offset	0x1210	?strcmp@Unicode@@SIHPBU1@0@Z	Unicode::strcmp
+D2Lang.dll	Unicode_strcpy	Offset	0x1470		Unicode::strcpy
 D2Lang.dll	Unicode_strlen	Offset	0x1490	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10E0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10B0		Unicode::toUpper

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -39,6 +39,7 @@ D2Lang.dll	GetStringByIndex	Ordinal	10004
 D2Lang.dll	Unicode_asciiToUnicode	Offset	0x1B10		Unicode::win2Unicode
 D2Lang.dll	Unicode_strcat	Offset	0x13A0		Unicode::strcat
 D2Lang.dll	Unicode_strcmp	Offset	0x1210	?strcmp@Unicode@@SIHPBU1@0@Z	Unicode::strcmp
+D2Lang.dll	Unicode_strcpy	Offset	0x1470		Unicode::strcpy
 D2Lang.dll	Unicode_strlen	Offset	0x1490	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10E0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10B0		Unicode::toUpper

--- a/1.10.txt
+++ b/1.10.txt
@@ -39,6 +39,7 @@ D2Lang.dll	GetStringByIndex	Ordinal	10004
 D2Lang.dll	Unicode_asciiToUnicode	Offset	0x1BD0	?win2Unicode@Unicode@@SIPAU1@PAU1@PBDH@Z	Unicode::win2Unicode
 D2Lang.dll	Unicode_strcat	Offset	0x13F0		Unicode::strcat
 D2Lang.dll	Unicode_strcmp	Offset	0x1210	?strcmp@Unicode@@SIHPBU1@0@Z	Unicode::strcmp
+D2Lang.dll	Unicode_strcpy	Offset	0x14A0		Unicode::strcpy
 D2Lang.dll	Unicode_strlen	Offset	0x14C0	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10E0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10B0		Unicode::toUpper

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -39,6 +39,7 @@ D2Lang.dll	GetStringByIndex	Ordinal	10005
 D2Lang.dll	Unicode_asciiToUnicode	Offset	0xAF10		Unicode::win2Unicode
 D2Lang.dll	Unicode_strcat	Offset	0xA610		Unicode::strcat
 D2Lang.dll	Unicode_strcmp	Offset	0xA830	?strcmp@Unicode@@SIHPBU1@0@Z	Unicode::strcmp
+D2Lang.dll	Unicode_strcpy	Offset	0xA5F0		Unicode::strcpy
 D2Lang.dll	Unicode_strlen	Offset	0xA6E0	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10C0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10A0		Unicode::toUpper

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -39,6 +39,7 @@ D2Lang.dll	GetStringByIndex	Ordinal	10003
 D2Lang.dll	Unicode_asciiToUnicode	Offset	0x8320		Unicode::win2Unicode
 D2Lang.dll	Unicode_strcat	Offset	0xAFE0		Unicode::strcat
 D2Lang.dll	Unicode_strcmp	Offset	0xB200	?strcmp@Unicode@@SIHPBU1@0@Z	Unicode::strcmp
+D2Lang.dll	Unicode_strcpy	Offset	0xAFC0		Unicode::strcpy
 D2Lang.dll	Unicode_strlen	Offset	0xB0B0	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10C0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10A0		Unicode::toUpper

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -39,6 +39,7 @@ D2Lang.dll	GetStringByIndex	Ordinal	10004
 D2Lang.dll	Unicode_asciiToUnicode	Offset	0x82E0		Unicode::win2Unicode
 D2Lang.dll	Unicode_strcat	Offset	0x8B90		Unicode::strcat
 D2Lang.dll	Unicode_strcmp	Offset	0xB200	?strcmp@Unicode@@SIHPBU1@0@Z	Unicode::strcmp
+D2Lang.dll	Unicode_strcpy	Offset	0xAFC0		Unicode::strcpy
 D2Lang.dll	Unicode_strlen	Offset	0x8C60	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10C0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10A0		Unicode::toUpper

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -39,6 +39,7 @@ D2Lang.dll	GetStringByIndex	Offset	0x121EE0
 D2Lang.dll	Unicode_asciiToUnicode	Offset	0x124450		Unicode::win2Unicode
 D2Lang.dll	Unicode_strcat	Offset	0x123C50		Unicode::strcat
 D2Lang.dll	Unicode_strcmp	Offset	0x123A40	?strcmp@Unicode@@SIHPBU1@0@Z	Unicode::strcmp
+D2Lang.dll	Unicode_strcpy	Offset	0x123D30		Unicode::strcpy
 D2Lang.dll	Unicode_strlen	Offset	0x123D50	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0xADD70	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x29E40		Unicode::toUpper

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -39,6 +39,7 @@ D2Lang.dll	GetStringByIndex	Offset	0x124A30
 D2Lang.dll	Unicode_asciiToUnicode	Offset	0x126F20		Unicode::win2Unicode
 D2Lang.dll	Unicode_strcat	Offset	0x126700		Unicode::strcat
 D2Lang.dll	Unicode_strcmp	Offset	0x1264F0	?strcmp@Unicode@@SIHPBU1@0@Z	Unicode::strcmp
+D2Lang.dll	Unicode_strcpy	Offset	0x1267E0		Unicode::strcpy
 D2Lang.dll	Unicode_strlen	Offset	0x126800	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0xB15F3	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x2E650		Unicode::toUpper


### PR DESCRIPTION
The function copies every `UnicodeChar`, including the null-terminator, from a `UnicodeChar` string into a destination.

The function is located by scanning for the bytes `B9 51 10 00 00` which represents the x86 instruction `mov ecx, 4177`.

## Function Definition
### All Versions
```C
UnicodeChar* D2Lang_Unicode_strcpy(
    UnicodeChar* dest,
    const UnicodeChar* src
);
```
- `dest` in ecx
- `src` in edx

Returns `dest`. `dest` is never modified, making it eligible for the `const` qualifier.

This function prior to 1.14A was known as `Unicode::strcpy`.

## Screenshots
The following 1.00 screenshot shows the entire function, its parameters, its return type, and its cleanup convention.
![D2Lang_Unicode_strcpy_01_(1 00)](https://user-images.githubusercontent.com/26683324/67544571-d92d2b00-f6aa-11e9-8c8d-cb5c1570d194.PNG)

The following 1.00 screenshot shows how to locate the function and the function's calling convention.
![D2Lang_Unicode_strcpy_02_(1 00)](https://user-images.githubusercontent.com/26683324/67544572-d92d2b00-f6aa-11e9-8920-749dce8b6d38.PNG)
