### PR TITLE
Add D2Lang Unicode strncpy

### DIFF
--- a/1.00.txt
+++ b/1.00.txt
@@ -40,6 +40,7 @@ D2Lang.dll	Unicode_asciiToUnicode	Offset	0x1122		Unicode::win2Unicode
 D2Lang.dll	Unicode_strcat	Offset	0x10B4		Unicode::strcat
 D2Lang.dll	Unicode_strcmp	Offset	0x1050	?strcmp@Unicode@@SIHPBU1@0@Z	Unicode::strcmp
 D2Lang.dll	Unicode_strcpy	Offset	0x10D7		Unicode::strcpy
+D2Lang.dll	Unicode_strncpy	Offset	0x114A		Unicode::strncpy
 D2Lang.dll	Unicode_strlen	Offset	0x1055	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x1014	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x1154		Unicode::toUpper

--- a/1.03.txt
+++ b/1.03.txt
@@ -40,6 +40,7 @@ D2Lang.dll	Unicode_asciiToUnicode	Offset	0x109B		Unicode::win2Unicode
 D2Lang.dll	Unicode_strcat	Offset	0x10B4		Unicode::strcat
 D2Lang.dll	Unicode_strcmp	Offset	0x1050	?strcmp@Unicode@@SIHPBU1@0@Z	Unicode::strcmp
 D2Lang.dll	Unicode_strcpy	Offset	0x10D7		Unicode::strcpy
+D2Lang.dll	Unicode_strncpy	Offset	0x114A		Unicode::strncpy
 D2Lang.dll	Unicode_strlen	Offset	0x1055	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x1014	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x1154		Unicode::toUpper

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -40,6 +40,7 @@ D2Lang.dll	Unicode_asciiToUnicode	Offset	0x1AC0		Unicode::win2Unicode
 D2Lang.dll	Unicode_strcat	Offset	0x13A0		Unicode::strcat
 D2Lang.dll	Unicode_strcmp	Offset	0x1210	?strcmp@Unicode@@SIHPBU1@0@Z	Unicode::strcmp
 D2Lang.dll	Unicode_strcpy	Offset	0x1470		Unicode::strcpy
+D2Lang.dll	Unicode_strncpy	Offset	0x1420		Unicode::strncpy
 D2Lang.dll	Unicode_strlen	Offset	0x1490	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10E0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10B0		Unicode::toUpper

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -40,6 +40,7 @@ D2Lang.dll	Unicode_asciiToUnicode	Offset	0x1B10		Unicode::win2Unicode
 D2Lang.dll	Unicode_strcat	Offset	0x13A0		Unicode::strcat
 D2Lang.dll	Unicode_strcmp	Offset	0x1210	?strcmp@Unicode@@SIHPBU1@0@Z	Unicode::strcmp
 D2Lang.dll	Unicode_strcpy	Offset	0x1470		Unicode::strcpy
+D2Lang.dll	Unicode_strncpy	Offset	0x1420		Unicode::strncpy
 D2Lang.dll	Unicode_strlen	Offset	0x1490	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10E0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10B0		Unicode::toUpper

--- a/1.10.txt
+++ b/1.10.txt
@@ -40,6 +40,7 @@ D2Lang.dll	Unicode_asciiToUnicode	Offset	0x1BD0	?win2Unicode@Unicode@@SIPAU1@PAU
 D2Lang.dll	Unicode_strcat	Offset	0x13F0		Unicode::strcat
 D2Lang.dll	Unicode_strcmp	Offset	0x1210	?strcmp@Unicode@@SIHPBU1@0@Z	Unicode::strcmp
 D2Lang.dll	Unicode_strcpy	Offset	0x14A0		Unicode::strcpy
+D2Lang.dll	Unicode_strncpy	Offset	0x1460		Unicode::strncpy
 D2Lang.dll	Unicode_strlen	Offset	0x14C0	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10E0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10B0		Unicode::toUpper

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -40,6 +40,7 @@ D2Lang.dll	Unicode_asciiToUnicode	Offset	0xAF10		Unicode::win2Unicode
 D2Lang.dll	Unicode_strcat	Offset	0xA610		Unicode::strcat
 D2Lang.dll	Unicode_strcmp	Offset	0xA830	?strcmp@Unicode@@SIHPBU1@0@Z	Unicode::strcmp
 D2Lang.dll	Unicode_strcpy	Offset	0xA5F0		Unicode::strcpy
+D2Lang.dll	Unicode_strncpy	Offset	0xA700		Unicode::strncpy
 D2Lang.dll	Unicode_strlen	Offset	0xA6E0	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10C0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10A0		Unicode::toUpper

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -40,6 +40,7 @@ D2Lang.dll	Unicode_asciiToUnicode	Offset	0x8320		Unicode::win2Unicode
 D2Lang.dll	Unicode_strcat	Offset	0xAFE0		Unicode::strcat
 D2Lang.dll	Unicode_strcmp	Offset	0xB200	?strcmp@Unicode@@SIHPBU1@0@Z	Unicode::strcmp
 D2Lang.dll	Unicode_strcpy	Offset	0xAFC0		Unicode::strcpy
+D2Lang.dll	Unicode_strncpy	Offset	0xB0D0		Unicode::strncpy
 D2Lang.dll	Unicode_strlen	Offset	0xB0B0	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10C0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10A0		Unicode::toUpper

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -40,6 +40,7 @@ D2Lang.dll	Unicode_asciiToUnicode	Offset	0x82E0		Unicode::win2Unicode
 D2Lang.dll	Unicode_strcat	Offset	0x8B90		Unicode::strcat
 D2Lang.dll	Unicode_strcmp	Offset	0xB200	?strcmp@Unicode@@SIHPBU1@0@Z	Unicode::strcmp
 D2Lang.dll	Unicode_strcpy	Offset	0xAFC0		Unicode::strcpy
+D2Lang.dll	Unicode_strncpy	Offset	0xB0D0		Unicode::strncpy
 D2Lang.dll	Unicode_strlen	Offset	0x8C60	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10C0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10A0		Unicode::toUpper

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -40,6 +40,7 @@ D2Lang.dll	Unicode_asciiToUnicode	Offset	0x124450		Unicode::win2Unicode
 D2Lang.dll	Unicode_strcat	Offset	0x123C50		Unicode::strcat
 D2Lang.dll	Unicode_strcmp	Offset	0x123A40	?strcmp@Unicode@@SIHPBU1@0@Z	Unicode::strcmp
 D2Lang.dll	Unicode_strcpy	Offset	0x123D30		Unicode::strcpy
+D2Lang.dll	Unicode_strncpy	Offset	0x123CE0		Unicode::strncpy
 D2Lang.dll	Unicode_strlen	Offset	0x123D50	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0xADD70	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x29E40		Unicode::toUpper

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -40,6 +40,7 @@ D2Lang.dll	Unicode_asciiToUnicode	Offset	0x126F20		Unicode::win2Unicode
 D2Lang.dll	Unicode_strcat	Offset	0x126700		Unicode::strcat
 D2Lang.dll	Unicode_strcmp	Offset	0x1264F0	?strcmp@Unicode@@SIHPBU1@0@Z	Unicode::strcmp
 D2Lang.dll	Unicode_strcpy	Offset	0x1267E0		Unicode::strcpy
+D2Lang.dll	Unicode_strncpy	Offset	0x126790		Unicode::strncpy
 D2Lang.dll	Unicode_strlen	Offset	0x126800	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0xB15F3	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x2E650		Unicode::toUpper


### PR DESCRIPTION
The function copies the specified number of `UnicodeChar` from a null-terminated `UnicodeChar` string into a destination.  If the specified number is less than the number of `UnicodeChar` in the source string, then the string will copy only that number of characters, but will not include a null-terminator.  Otherwise, if the number is larger than the number of `UnicodeChar` in the source string, then the remaining characters in the destination will be filled with the null-terminating character.

The function can be located in versions prior to 1.14A by searching for the function `Unicode::strncpy` in `D2Lang.dll`. In 1.14A and above, it can be located by scanning for the bytes `B9 94 0C 00 00`, which represent the x86 instruction `mov ecx, 3220`.

## Function Definition
### All Versions
```C
UnicodeChar* D2Lang_Unicode_strncpy(
    UnicodeChar* dest,
    const UnicodeChar* src,
    uint32_t count
);
```
- `dest` in ecx
- `src` in edx
- Remaining parameters on the stack
  - Callee cleans the stack

Returns `dest`.

The data stored in `src` is not modified, making it eligible for the `const` qualifier.

## Screenshots
The following 1.00 screenshot shows the function. Its return type and value, parameters, and cleanup convention are all shown. The `shr` instruction is used on `count`, indicating that it is a `uint32_t`. 
![D2Lang_Unicode_strncpy_02_(1 00)](https://user-images.githubusercontent.com/26683324/67584158-dd386780-f701-11e9-85cc-beab326c5383.PNG)

The following 1.00 screenshot shows another function calling this function. The calling convention is shown. The bytes used to locate this function are also shown.
![D2Lang_Unicode_strncpy_03_(1 00)](https://user-images.githubusercontent.com/26683324/67584176-e6293900-f701-11e9-8ccd-ce69b4c9b15d.PNG)
