### PR TITLE
Add D2Lang Unicode strncat

### DIFF
--- a/1.00.txt
+++ b/1.00.txt
@@ -40,6 +40,7 @@ D2Lang.dll	Unicode_asciiToUnicode	Offset	0x1122		Unicode::win2Unicode
 D2Lang.dll	Unicode_strcat	Offset	0x10B4		Unicode::strcat
 D2Lang.dll	Unicode_strcmp	Offset	0x1050	?strcmp@Unicode@@SIHPBU1@0@Z	Unicode::strcmp
 D2Lang.dll	Unicode_strcpy	Offset	0x10D7		Unicode::strcpy
+D2Lang.dll	Unicode_strncat	Offset	0x10C8		Unicode::strncat
 D2Lang.dll	Unicode_strncpy	Offset	0x114A		Unicode::strncpy
 D2Lang.dll	Unicode_strlen	Offset	0x1055	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x1014	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower

--- a/1.03.txt
+++ b/1.03.txt
@@ -40,6 +40,7 @@ D2Lang.dll	Unicode_asciiToUnicode	Offset	0x109B		Unicode::win2Unicode
 D2Lang.dll	Unicode_strcat	Offset	0x10B4		Unicode::strcat
 D2Lang.dll	Unicode_strcmp	Offset	0x1050	?strcmp@Unicode@@SIHPBU1@0@Z	Unicode::strcmp
 D2Lang.dll	Unicode_strcpy	Offset	0x10D7		Unicode::strcpy
+D2Lang.dll	Unicode_strncat	Offset	0x10C8		Unicode::strncat
 D2Lang.dll	Unicode_strncpy	Offset	0x114A		Unicode::strncpy
 D2Lang.dll	Unicode_strlen	Offset	0x1055	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x1014	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -40,6 +40,7 @@ D2Lang.dll	Unicode_asciiToUnicode	Offset	0x1AC0		Unicode::win2Unicode
 D2Lang.dll	Unicode_strcat	Offset	0x13A0		Unicode::strcat
 D2Lang.dll	Unicode_strcmp	Offset	0x1210	?strcmp@Unicode@@SIHPBU1@0@Z	Unicode::strcmp
 D2Lang.dll	Unicode_strcpy	Offset	0x1470		Unicode::strcpy
+D2Lang.dll	Unicode_strncat	Offset	0x13D0		Unicode::strncat
 D2Lang.dll	Unicode_strncpy	Offset	0x1420		Unicode::strncpy
 D2Lang.dll	Unicode_strlen	Offset	0x1490	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10E0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -40,6 +40,7 @@ D2Lang.dll	Unicode_asciiToUnicode	Offset	0x1B10		Unicode::win2Unicode
 D2Lang.dll	Unicode_strcat	Offset	0x13A0		Unicode::strcat
 D2Lang.dll	Unicode_strcmp	Offset	0x1210	?strcmp@Unicode@@SIHPBU1@0@Z	Unicode::strcmp
 D2Lang.dll	Unicode_strcpy	Offset	0x1470		Unicode::strcpy
+D2Lang.dll	Unicode_strncat	Offset	0x13D0		Unicode::strncat
 D2Lang.dll	Unicode_strncpy	Offset	0x1420		Unicode::strncpy
 D2Lang.dll	Unicode_strlen	Offset	0x1490	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10E0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower

--- a/1.10.txt
+++ b/1.10.txt
@@ -40,6 +40,7 @@ D2Lang.dll	Unicode_asciiToUnicode	Offset	0x1BD0	?win2Unicode@Unicode@@SIPAU1@PAU
 D2Lang.dll	Unicode_strcat	Offset	0x13F0		Unicode::strcat
 D2Lang.dll	Unicode_strcmp	Offset	0x1210	?strcmp@Unicode@@SIHPBU1@0@Z	Unicode::strcmp
 D2Lang.dll	Unicode_strcpy	Offset	0x14A0		Unicode::strcpy
+D2Lang.dll	Unicode_strncat	Offset	0x1420		Unicode::strncat
 D2Lang.dll	Unicode_strncpy	Offset	0x1460		Unicode::strncpy
 D2Lang.dll	Unicode_strlen	Offset	0x14C0	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10E0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -40,6 +40,7 @@ D2Lang.dll	Unicode_asciiToUnicode	Offset	0xAF10		Unicode::win2Unicode
 D2Lang.dll	Unicode_strcat	Offset	0xA610		Unicode::strcat
 D2Lang.dll	Unicode_strcmp	Offset	0xA830	?strcmp@Unicode@@SIHPBU1@0@Z	Unicode::strcmp
 D2Lang.dll	Unicode_strcpy	Offset	0xA5F0		Unicode::strcpy
+D2Lang.dll	Unicode_strncat	Offset	0xA750		Unicode::strncat
 D2Lang.dll	Unicode_strncpy	Offset	0xA700		Unicode::strncpy
 D2Lang.dll	Unicode_strlen	Offset	0xA6E0	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10C0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -40,6 +40,7 @@ D2Lang.dll	Unicode_asciiToUnicode	Offset	0x8320		Unicode::win2Unicode
 D2Lang.dll	Unicode_strcat	Offset	0xAFE0		Unicode::strcat
 D2Lang.dll	Unicode_strcmp	Offset	0xB200	?strcmp@Unicode@@SIHPBU1@0@Z	Unicode::strcmp
 D2Lang.dll	Unicode_strcpy	Offset	0xAFC0		Unicode::strcpy
+D2Lang.dll	Unicode_strncat	Offset	0xB120		Unicode::strncat
 D2Lang.dll	Unicode_strncpy	Offset	0xB0D0		Unicode::strncpy
 D2Lang.dll	Unicode_strlen	Offset	0xB0B0	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10C0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -40,6 +40,7 @@ D2Lang.dll	Unicode_asciiToUnicode	Offset	0x82E0		Unicode::win2Unicode
 D2Lang.dll	Unicode_strcat	Offset	0x8B90		Unicode::strcat
 D2Lang.dll	Unicode_strcmp	Offset	0xB200	?strcmp@Unicode@@SIHPBU1@0@Z	Unicode::strcmp
 D2Lang.dll	Unicode_strcpy	Offset	0xAFC0		Unicode::strcpy
+D2Lang.dll	Unicode_strncat	Offset	0xB120		Unicode::strncat
 D2Lang.dll	Unicode_strncpy	Offset	0xB0D0		Unicode::strncpy
 D2Lang.dll	Unicode_strlen	Offset	0x8C60	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10C0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -40,6 +40,7 @@ D2Lang.dll	Unicode_asciiToUnicode	Offset	0x124450		Unicode::win2Unicode
 D2Lang.dll	Unicode_strcat	Offset	0x123C50		Unicode::strcat
 D2Lang.dll	Unicode_strcmp	Offset	0x123A40	?strcmp@Unicode@@SIHPBU1@0@Z	Unicode::strcmp
 D2Lang.dll	Unicode_strcpy	Offset	0x123D30		Unicode::strcpy
+D2Lang.dll	Unicode_strncat	Offset	0x123C90		Unicode::strncat
 D2Lang.dll	Unicode_strncpy	Offset	0x123CE0		Unicode::strncpy
 D2Lang.dll	Unicode_strlen	Offset	0x123D50	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0xADD70	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -40,6 +40,7 @@ D2Lang.dll	Unicode_asciiToUnicode	Offset	0x126F20		Unicode::win2Unicode
 D2Lang.dll	Unicode_strcat	Offset	0x126700		Unicode::strcat
 D2Lang.dll	Unicode_strcmp	Offset	0x1264F0	?strcmp@Unicode@@SIHPBU1@0@Z	Unicode::strcmp
 D2Lang.dll	Unicode_strcpy	Offset	0x1267E0		Unicode::strcpy
+D2Lang.dll	Unicode_strncat	Offset	0x126740		Unicode::strncat
 D2Lang.dll	Unicode_strncpy	Offset	0x126790		Unicode::strncpy
 D2Lang.dll	Unicode_strlen	Offset	0x126800	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0xB15F3	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower


### PR DESCRIPTION
The function appends a specified number of `UnicodeChar` from a null-terminated `UnicodeChar` source string to the end of a null-terminated `UnicodeChar` destination string. This operation replaces the null-terminator in the destination string with the first character in the source string.

If the specified number of characters to copy is less than the number of characters in the source string, including the null-terminator character, then the destination string may not be properly null-terminated. If the specified number of characters to copy is more than the number of characters in the source string, including the null-terminator character, then all of the characters up to and including the null-terminator of the source string are copied and the remaining count of characters are not modified.

Prior to 1.14A, the function could be located with the function name `Unicode::strncat` in `D2Lang.dll`. In versions 1.14A and above, the function needs to be located by using opcodes from previous versions of this function.

## Function Definition
### All Versions
```C
UnicodeChar* D2Lang_Unicode_strncat(
    UnicodeChar* dest,
    const UnicodeChar* src,
    uint32_t count
);
```
- `dest` in ecx
- `src` in edx
- Remaining parameters on the stack
  - Callee cleans the stack

The function returns `dest`.  `src` is not modified, making it eligible for the `const` qualifier.

## Screenshots
The following 1.00 screenshot shows the entire function, along with its parameters, return type and value, and cleanup convention. `count` is shown to be a 32-bit value. Since [D2Lang Unicode strncpy](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/54) has a unsigned `count`, it has been made `uint32_t` is the function definition.
![D2Lang_Unicode_strncat_01_(1 00)](https://user-images.githubusercontent.com/26683324/67614954-77d48d00-f77a-11e9-91e8-20df2c1dfa65.PNG)

The following 1.12A screenshot shows the entire function.
![D2Lang_Unicode_strncat_02_(1 12A)](https://user-images.githubusercontent.com/26683324/67614955-77d48d00-f77a-11e9-9dc3-4cbe580f7c95.PNG)

The following LoD 1.14D screenshot shows the entire function.
![D2Lang_Unicode_strncat_03_(LoD 1 14D)](https://user-images.githubusercontent.com/26683324/67614956-77d48d00-f77a-11e9-96bf-a08929984dc6.PNG)
