### PR TITLE
Add D2Lang Unicode strncmp

### DIFF
--- a/1.00.txt
+++ b/1.00.txt
@@ -41,6 +41,7 @@ D2Lang.dll	Unicode_strcat	Offset	0x10B4		Unicode::strcat
 D2Lang.dll	Unicode_strcmp	Offset	0x1050	?strcmp@Unicode@@SIHPBU1@0@Z	Unicode::strcmp
 D2Lang.dll	Unicode_strcpy	Offset	0x10D7		Unicode::strcpy
 D2Lang.dll	Unicode_strncat	Offset	0x10C8		Unicode::strncat
+D2Lang.dll	Unicode_strncmp	N/A	N/A		Unicode::strncmp
 D2Lang.dll	Unicode_strncpy	Offset	0x114A		Unicode::strncpy
 D2Lang.dll	Unicode_strlen	Offset	0x1055	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x1014	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower

--- a/1.03.txt
+++ b/1.03.txt
@@ -41,6 +41,7 @@ D2Lang.dll	Unicode_strcat	Offset	0x10B4		Unicode::strcat
 D2Lang.dll	Unicode_strcmp	Offset	0x1050	?strcmp@Unicode@@SIHPBU1@0@Z	Unicode::strcmp
 D2Lang.dll	Unicode_strcpy	Offset	0x10D7		Unicode::strcpy
 D2Lang.dll	Unicode_strncat	Offset	0x10C8		Unicode::strncat
+D2Lang.dll	Unicode_strncmp	N/A	N/A		Unicode::strncmp
 D2Lang.dll	Unicode_strncpy	Offset	0x114A		Unicode::strncpy
 D2Lang.dll	Unicode_strlen	Offset	0x1055	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x1014	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -41,6 +41,7 @@ D2Lang.dll	Unicode_strcat	Offset	0x13A0		Unicode::strcat
 D2Lang.dll	Unicode_strcmp	Offset	0x1210	?strcmp@Unicode@@SIHPBU1@0@Z	Unicode::strcmp
 D2Lang.dll	Unicode_strcpy	Offset	0x1470		Unicode::strcpy
 D2Lang.dll	Unicode_strncat	Offset	0x13D0		Unicode::strncat
+D2Lang.dll	Unicode_strncmp	N/A	N/A		Unicode::strncmp
 D2Lang.dll	Unicode_strncpy	Offset	0x1420		Unicode::strncpy
 D2Lang.dll	Unicode_strlen	Offset	0x1490	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10E0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -41,6 +41,7 @@ D2Lang.dll	Unicode_strcat	Offset	0x13A0		Unicode::strcat
 D2Lang.dll	Unicode_strcmp	Offset	0x1210	?strcmp@Unicode@@SIHPBU1@0@Z	Unicode::strcmp
 D2Lang.dll	Unicode_strcpy	Offset	0x1470		Unicode::strcpy
 D2Lang.dll	Unicode_strncat	Offset	0x13D0		Unicode::strncat
+D2Lang.dll	Unicode_strncmp	N/A	N/A		Unicode::strncmp
 D2Lang.dll	Unicode_strncpy	Offset	0x1420		Unicode::strncpy
 D2Lang.dll	Unicode_strlen	Offset	0x1490	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10E0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower

--- a/1.10.txt
+++ b/1.10.txt
@@ -41,6 +41,7 @@ D2Lang.dll	Unicode_strcat	Offset	0x13F0		Unicode::strcat
 D2Lang.dll	Unicode_strcmp	Offset	0x1210	?strcmp@Unicode@@SIHPBU1@0@Z	Unicode::strcmp
 D2Lang.dll	Unicode_strcpy	Offset	0x14A0		Unicode::strcpy
 D2Lang.dll	Unicode_strncat	Offset	0x1420		Unicode::strncat
+D2Lang.dll	Unicode_strncmp	Offset	0x1250		Unicode::strncmp
 D2Lang.dll	Unicode_strncpy	Offset	0x1460		Unicode::strncpy
 D2Lang.dll	Unicode_strlen	Offset	0x14C0	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10E0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -41,6 +41,7 @@ D2Lang.dll	Unicode_strcat	Offset	0xA610		Unicode::strcat
 D2Lang.dll	Unicode_strcmp	Offset	0xA830	?strcmp@Unicode@@SIHPBU1@0@Z	Unicode::strcmp
 D2Lang.dll	Unicode_strcpy	Offset	0xA5F0		Unicode::strcpy
 D2Lang.dll	Unicode_strncat	Offset	0xA750		Unicode::strncat
+D2Lang.dll	Unicode_strncmp	Offset	0xA7E0		Unicode::strncmp
 D2Lang.dll	Unicode_strncpy	Offset	0xA700		Unicode::strncpy
 D2Lang.dll	Unicode_strlen	Offset	0xA6E0	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10C0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -41,6 +41,7 @@ D2Lang.dll	Unicode_strcat	Offset	0xAFE0		Unicode::strcat
 D2Lang.dll	Unicode_strcmp	Offset	0xB200	?strcmp@Unicode@@SIHPBU1@0@Z	Unicode::strcmp
 D2Lang.dll	Unicode_strcpy	Offset	0xAFC0		Unicode::strcpy
 D2Lang.dll	Unicode_strncat	Offset	0xB120		Unicode::strncat
+D2Lang.dll	Unicode_strncmp	Offset	0xB1B0		Unicode::strncmp
 D2Lang.dll	Unicode_strncpy	Offset	0xB0D0		Unicode::strncpy
 D2Lang.dll	Unicode_strlen	Offset	0xB0B0	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10C0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -41,6 +41,7 @@ D2Lang.dll	Unicode_strcat	Offset	0x8B90		Unicode::strcat
 D2Lang.dll	Unicode_strcmp	Offset	0xB200	?strcmp@Unicode@@SIHPBU1@0@Z	Unicode::strcmp
 D2Lang.dll	Unicode_strcpy	Offset	0xAFC0		Unicode::strcpy
 D2Lang.dll	Unicode_strncat	Offset	0xB120		Unicode::strncat
+D2Lang.dll	Unicode_strncmp	Offset	0x8D60		Unicode::strncmp
 D2Lang.dll	Unicode_strncpy	Offset	0xB0D0		Unicode::strncpy
 D2Lang.dll	Unicode_strlen	Offset	0x8C60	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10C0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -41,6 +41,7 @@ D2Lang.dll	Unicode_strcat	Offset	0x123C50		Unicode::strcat
 D2Lang.dll	Unicode_strcmp	Offset	0x123A40	?strcmp@Unicode@@SIHPBU1@0@Z	Unicode::strcmp
 D2Lang.dll	Unicode_strcpy	Offset	0x123D30		Unicode::strcpy
 D2Lang.dll	Unicode_strncat	Offset	0x123C90		Unicode::strncat
+D2Lang.dll	Unicode_strncmp	Offset	0x123A90		Unicode::strncmp
 D2Lang.dll	Unicode_strncpy	Offset	0x123CE0		Unicode::strncpy
 D2Lang.dll	Unicode_strlen	Offset	0x123D50	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0xADD70	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -41,6 +41,7 @@ D2Lang.dll	Unicode_strcat	Offset	0x126700		Unicode::strcat
 D2Lang.dll	Unicode_strcmp	Offset	0x1264F0	?strcmp@Unicode@@SIHPBU1@0@Z	Unicode::strcmp
 D2Lang.dll	Unicode_strcpy	Offset	0x1267E0		Unicode::strcpy
 D2Lang.dll	Unicode_strncat	Offset	0x126740		Unicode::strncat
+D2Lang.dll	Unicode_strncmp	Offset	0x126540		Unicode::strncmp
 D2Lang.dll	Unicode_strncpy	Offset	0x126790		Unicode::strncpy
 D2Lang.dll	Unicode_strlen	Offset	0x126800	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0xB15F3	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower


### PR DESCRIPTION
The function compares a specified number of `UnicodeChar` in two null-terminated `UnicodeChar` strings. The function returns a negative value if the compared characters from the first string lexicographically appears before the second string, a positive value if the compared characters from the first string lexicographically appears before the second string, and 0 if the compared characters are the same.

Prior to 1.14A, the function is located with the name `Unicode::strncmp` from `D2Lang.dll`. In 1.14A and above, the function is located by scanning for bytes taken from the opcodes of previous versions of the function.

## Function Definitions
### All Version
```C
int32_t D2Lang_Unicode_strncmp(
    const UnicodeChar* str1,
    const UnicodeChar* str2,
    uint32_t count
);
```
- `str1` in ecx
- `str2` in edx
- Remaining parameters on the stack
  - Callee cleans the stack

The function did not exist prior to 1.10.

## Screenshots
The following 1.10 screenshot shows the entire function. Also shown are the function's parameters, return type and value, and cleanup convention. Other functions, such as [D2Lang Unicode strncmp](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/55), has `count` as a  `uint32_t`, so this type was chosen for consistency.
![D2Lang_Unicode_strncmp_01_(1 10)](https://user-images.githubusercontent.com/26683324/67630323-2e03a980-f843-11e9-9c02-ba6679024e8b.PNG)

The following 1.12A screenshot shows the entire function.
![D2Lang_Unicode_strncmp_02_(1 12A)](https://user-images.githubusercontent.com/26683324/67630324-2e03a980-f843-11e9-96cb-99de7acc3161.PNG)

The following LoD 1.14D screenshot shows the entire function.
![D2Lang_Unicode_strncmp_03_(LoD 1 14D)](https://user-images.githubusercontent.com/26683324/67630325-2e03a980-f843-11e9-8598-d14588fa04aa.PNG)