### PR TITLE
Add D2Common GlobalBeltsTxt

### DIFF
--- a/1.00.txt
+++ b/1.00.txt
@@ -15,6 +15,7 @@ D2Client.dll	IsNewStatsButtonPressed	Offset	0x13DDF4
 D2Client.dll	ScreenOpenMode	N/A	N/A		
 D2Client.dll	ScreenShiftX	N/A	N/A		
 D2Client.dll	ScreenShiftY	N/A	N/A		
+D2Common.dll	GlobalBeltsTxt	Offset	0xA923C		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10036		
 D2CMP.dll	CloseCelFile	Ordinal	10032		
 D2DDraw.dll	BitBlockHeight	Offset	0x194E4		

--- a/1.03.txt
+++ b/1.03.txt
@@ -15,6 +15,7 @@ D2Client.dll	IsNewStatsButtonPressed	Offset	0x13DB2C
 D2Client.dll	ScreenOpenMode	N/A	N/A		
 D2Client.dll	ScreenShiftX	N/A	N/A		
 D2Client.dll	ScreenShiftY	N/A	N/A		
+D2Common.dll	GlobalBeltsTxt	Offset	0xAB9F4		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10036		
 D2CMP.dll	CloseCelFile	Ordinal	10032		
 D2DDraw.dll	BitBlockHeight	Offset	0x194E4		

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -15,6 +15,7 @@ D2Client.dll	IsNewStatsButtonPressed	Offset	0xF01F4
 D2Client.dll	ScreenOpenMode	N/A	N/A		
 D2Client.dll	ScreenShiftX	N/A	N/A		
 D2Client.dll	ScreenShiftY	N/A	N/A		
+D2Common.dll	GlobalBeltsTxt	Offset	0x85E70		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10036		
 D2CMP.dll	CloseCelFile	Ordinal	10032		
 D2DDraw.dll	BitBlockHeight	Offset	0x11B0C		

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -15,6 +15,7 @@ D2Client.dll	IsNewStatsButtonPressed	Offset	0x11FE84
 D2Client.dll	ScreenOpenMode	Offset	0x115C10		
 D2Client.dll	ScreenShiftX	Offset	0x124954		
 D2Client.dll	ScreenShiftY	Offset	0x124958		
+D2Common.dll	GlobalBeltsTxt	Offset	0xA1B94		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10036		
 D2CMP.dll	CloseCelFile	Ordinal	10032		
 D2DDraw.dll	BitBlockHeight	Offset	0x11B7C		

--- a/1.10.txt
+++ b/1.10.txt
@@ -15,6 +15,7 @@ D2Client.dll	IsNewStatsButtonPressed	Offset	0x115BBC
 D2Client.dll	ScreenOpenMode	Offset	0x10B9C4		
 D2Client.dll	ScreenShiftX	Offset	0x11A748		
 D2Client.dll	ScreenShiftY	Offset	0x11A74C		
+D2Common.dll	GlobalBeltsTxt	Offset	0xA9604		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10036		
 D2CMP.dll	CloseCelFile	Ordinal	10032		
 D2DDraw.dll	BitBlockHeight	Offset	0x11BBC		

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -15,6 +15,7 @@ D2Client.dll	IsNewStatsButtonPressed	Offset	0x11C344
 D2Client.dll	ScreenOpenMode	Offset	0x11C1D0		
 D2Client.dll	ScreenShiftX	Offset	0x11BD28		
 D2Client.dll	ScreenShiftY	Offset	0x11BD2C		
+D2Common.dll	GlobalBeltsTxt	Offset	0xA0750		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10038		
 D2CMP.dll	CloseCelFile	Ordinal	10106		
 D2DDraw.dll	BitBlockHeight	Offset	0xFDD8		

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -15,6 +15,7 @@ D2Client.dll	IsNewStatsButtonPressed	Offset	0x11C308
 D2Client.dll	ScreenOpenMode	Offset	0x11C414		
 D2Client.dll	ScreenShiftX	Offset	0x11B9A0		
 D2Client.dll	ScreenShiftY	Offset	0x11B9A4		
+D2Common.dll	GlobalBeltsTxt	Offset	0xA13DC		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10021		
 D2CMP.dll	CloseCelFile	Ordinal	10065		
 D2DDraw.dll	BitBlockHeight	Offset	0x101D8		

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -15,6 +15,7 @@ D2Client.dll	IsNewStatsButtonPressed	Offset	0x11D318
 D2Client.dll	ScreenOpenMode	Offset	0x11D070		
 D2Client.dll	ScreenShiftX	Offset	0x11D354		
 D2Client.dll	ScreenShiftY	Offset	0x11D358		
+D2Common.dll	GlobalBeltsTxt	Offset	0xA4BA0		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10035		
 D2CMP.dll	CloseCelFile	Ordinal	10020		
 D2DDraw.dll	BitBlockHeight	Offset	0x100E8		

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -15,6 +15,7 @@ D2Client.dll	IsNewStatsButtonPressed	Offset	0x3B736C
 D2Client.dll	ScreenOpenMode	Offset	0x39C298		
 D2Client.dll	ScreenShiftX	Offset	0x3998E0		
 D2Client.dll	ScreenShiftY	Offset	0x3998E4		
+D2Common.dll	GlobalBeltsTxt	Offset	0x564480		
 D2CMP.dll	GetCelFromCelContext	Offset	0x200620		
 D2CMP.dll	CloseCelFile	Offset	0x200820		
 D2DDraw.dll	BitBlockHeight	Offset	0x3C01C4		

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -15,6 +15,7 @@ D2Client.dll	IsNewStatsButtonPressed	Offset	0x3C02E4
 D2Client.dll	ScreenOpenMode	Offset	0x3A5210		
 D2Client.dll	ScreenShiftX	Offset	0x3A2858		
 D2Client.dll	ScreenShiftY	Offset	0x3A285C		
+D2Common.dll	GlobalBeltsTxt	Offset	0x56D4F8		
 D2CMP.dll	GetCelFromCelContext	Offset	0x201840		
 D2CMP.dll	CloseCelFile	Offset	0x201A50		
 D2DDraw.dll	BitBlockHeight	Offset	0x3C913C		


### PR DESCRIPTION
The variable stores the memory location of the parsed belts.txt records. Each record contains the number of belt slots for each belt type, along with the left and right, along with the top and bottom positions.

The variable can be located by scanning for the bytes `6A 00 68 80000000 68 80000000` which are the x86 opcodes for:
```ASM
push 0
push 128
push 128
```
From there, a function call to [D2Common GetBeltSlotPosition](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/58) can be found. In that function, the target variable is accessed.

## Definition
```C
struct PositionalRectangle {
  int32_t left;
  int32_t right;
  int32_t top;
  int32_t bottom;
};

struct BeltRecord {
  undefined_byte unknown_0x00[4];
  uint8_t num_slots;
  uint8_t unused_0x05[3];
  PositionalRectangle slot_positions[16];
};

BeltRecord* D2Common_GlobalBeltsTxt;
```

Each of these values have been previously discovered by [PhrozenKeep](
https://web.archive.org/web/20191127053750/https://d2mods.info/forum/viewtopic.php?f=8&t=61189) and further elaborated by [D2Ex2](https://github.com/jankowskib/D2Ex2/blob/master/Constants.h). These definitions have been tested for signed and size correctness.

The `PositionalRectangle` members can be tested by setting their values to negative.  Negative values cause the inventory slots to appear beyond the left boundaries of the screen.

`BeltRecord.num_slots` is a `uint8_t`, which can be tested by setting the highest order bit in the byte. Doing so will cause the game to treat the belt as if it had many more slots instead of none. Setting the bits in `unused_0x05` does nothing.

## Screenshots
The following 1.00 screenshot shows the usage of the variable.
![D2Common_GlobalBeltsTxt_01_(1 00)](https://user-images.githubusercontent.com/26683324/69711358-cba5ff00-10b5-11ea-9faa-0e6565c3accd.PNG)

The following 1.00 screenshot shows how to locate the function that accesses the variable.
![D2Common_GetBeltBoxPosition_04_(1 00)](https://user-images.githubusercontent.com/26683324/69714724-d06db180-10bb-11ea-8997-23355c9d2c1e.PNG)

The following 1.00 screenshot shows the `BeltRecord` struct. 
![BeltRecord_01_(1 00)](https://user-images.githubusercontent.com/26683324/69696970-2af41700-1096-11ea-8935-100fdce56af3.PNG)

The following 1.00 screenshot shows the `PositionalRectangle` struct.
![InventorySlot_01_(1 00)](https://user-images.githubusercontent.com/26683324/69696969-2af41700-1096-11ea-8f6a-f748c0727b94.PNG)

The following screenshot of a page from the Diablo II manual justifies the use of `Slot` in the name `BeltRecord.slot_positions`, rather than `boxes`.
![BeltSlot_02](https://user-images.githubusercontent.com/26683324/69706042-b9bf5e80-10ab-11ea-837c-98241033d544.PNG)
