### PR TITLE
Add D2Common GetGlobalBeltSlotPosition

### DIFF
--- a/1.00.txt
+++ b/1.00.txt
@@ -16,6 +16,7 @@ D2Client.dll	ScreenOpenMode	N/A	N/A
 D2Client.dll	ScreenShiftX	N/A	N/A		
 D2Client.dll	ScreenShiftY	N/A	N/A		
 D2Common.dll	GlobalBeltsTxt	Offset	0xA923C		
+D2Common.dll	GetBeltSlotPosition	Ordinal	10606		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10036		
 D2CMP.dll	CloseCelFile	Ordinal	10032		
 D2DDraw.dll	BitBlockHeight	Offset	0x194E4		

--- a/1.03.txt
+++ b/1.03.txt
@@ -16,6 +16,7 @@ D2Client.dll	ScreenOpenMode	N/A	N/A
 D2Client.dll	ScreenShiftX	N/A	N/A		
 D2Client.dll	ScreenShiftY	N/A	N/A		
 D2Common.dll	GlobalBeltsTxt	Offset	0xAB9F4		
+D2Common.dll	GetBeltSlotPosition	Ordinal	10606		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10036		
 D2CMP.dll	CloseCelFile	Ordinal	10032		
 D2DDraw.dll	BitBlockHeight	Offset	0x194E4		

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -16,6 +16,7 @@ D2Client.dll	ScreenOpenMode	N/A	N/A
 D2Client.dll	ScreenShiftX	N/A	N/A		
 D2Client.dll	ScreenShiftY	N/A	N/A		
 D2Common.dll	GlobalBeltsTxt	Offset	0x85E70		
+D2Common.dll	GetBeltSlotPosition	Ordinal	10606		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10036		
 D2CMP.dll	CloseCelFile	Ordinal	10032		
 D2DDraw.dll	BitBlockHeight	Offset	0x11B0C		

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -16,6 +16,7 @@ D2Client.dll	ScreenOpenMode	Offset	0x115C10
 D2Client.dll	ScreenShiftX	Offset	0x124954		
 D2Client.dll	ScreenShiftY	Offset	0x124958		
 D2Common.dll	GlobalBeltsTxt	Offset	0xA1B94		
+D2Common.dll	GetBeltSlotPosition	Ordinal	10639		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10036		
 D2CMP.dll	CloseCelFile	Ordinal	10032		
 D2DDraw.dll	BitBlockHeight	Offset	0x11B7C		

--- a/1.10.txt
+++ b/1.10.txt
@@ -16,6 +16,7 @@ D2Client.dll	ScreenOpenMode	Offset	0x10B9C4
 D2Client.dll	ScreenShiftX	Offset	0x11A748		
 D2Client.dll	ScreenShiftY	Offset	0x11A74C		
 D2Common.dll	GlobalBeltsTxt	Offset	0xA9604		
+D2Common.dll	GetBeltSlotPosition	Ordinal	10639		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10036		
 D2CMP.dll	CloseCelFile	Ordinal	10032		
 D2DDraw.dll	BitBlockHeight	Offset	0x11BBC		

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -16,6 +16,7 @@ D2Client.dll	ScreenOpenMode	Offset	0x11C1D0
 D2Client.dll	ScreenShiftX	Offset	0x11BD28		
 D2Client.dll	ScreenShiftY	Offset	0x11BD2C		
 D2Common.dll	GlobalBeltsTxt	Offset	0xA0750		
+D2Common.dll	GetBeltSlotPosition	Ordinal	10110		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10038		
 D2CMP.dll	CloseCelFile	Ordinal	10106		
 D2DDraw.dll	BitBlockHeight	Offset	0xFDD8		

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -16,6 +16,7 @@ D2Client.dll	ScreenOpenMode	Offset	0x11C414
 D2Client.dll	ScreenShiftX	Offset	0x11B9A0		
 D2Client.dll	ScreenShiftY	Offset	0x11B9A4		
 D2Common.dll	GlobalBeltsTxt	Offset	0xA13DC		
+D2Common.dll	GetBeltSlotPosition	Ordinal	10333		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10021		
 D2CMP.dll	CloseCelFile	Ordinal	10065		
 D2DDraw.dll	BitBlockHeight	Offset	0x101D8		

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -16,6 +16,7 @@ D2Client.dll	ScreenOpenMode	Offset	0x11D070
 D2Client.dll	ScreenShiftX	Offset	0x11D354		
 D2Client.dll	ScreenShiftY	Offset	0x11D358		
 D2Common.dll	GlobalBeltsTxt	Offset	0xA4BA0		
+D2Common.dll	GetBeltSlotPosition	Ordinal	10689		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10035		
 D2CMP.dll	CloseCelFile	Ordinal	10020		
 D2DDraw.dll	BitBlockHeight	Offset	0x100E8		

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -16,6 +16,7 @@ D2Client.dll	ScreenOpenMode	Offset	0x39C298
 D2Client.dll	ScreenShiftX	Offset	0x3998E0		
 D2Client.dll	ScreenShiftY	Offset	0x3998E4		
 D2Common.dll	GlobalBeltsTxt	Offset	0x564480		
+D2Common.dll	GetBeltSlotPosition	Offset	0x262FD0		
 D2CMP.dll	GetCelFromCelContext	Offset	0x200620		
 D2CMP.dll	CloseCelFile	Offset	0x200820		
 D2DDraw.dll	BitBlockHeight	Offset	0x3C01C4		

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -16,6 +16,7 @@ D2Client.dll	ScreenOpenMode	Offset	0x3A5210
 D2Client.dll	ScreenShiftX	Offset	0x3A2858		
 D2Client.dll	ScreenShiftY	Offset	0x3A285C		
 D2Common.dll	GlobalBeltsTxt	Offset	0x56D4F8		
+D2Common.dll	GetBeltSlotPosition	Offset	0x260D10		
 D2CMP.dll	GetCelFromCelContext	Offset	0x201840		
 D2CMP.dll	CloseCelFile	Offset	0x201A50		
 D2DDraw.dll	BitBlockHeight	Offset	0x3C913C		


### PR DESCRIPTION
The function looks into [D2Common GlobalBeltsTxt](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/57) and fills the specified `InventorySlotPosition` with the information pertaining to that slot. The `InventorySlotPosition` that is selected is dependent on the input belt record index, slot index, and (in 1.09D+) the inventory mode.

The variable can be located by scanning for the bytes `6A 00 68 80000000 68 80000000` which are the x86 opcodes for:
```ASM
push 0
push 128
push 128
```
From there, a function call to [D2Common GetBeltSlotPosition](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/58) can be found.

## Function Definitions
### 1.00 - 1.05B (inclusive)
```C
void D2Common_GetGlobalBeltSlotPositon(
  uint32_t belt_record_index,
  PositionalRectangle* slot_position,
  uint32_t slot_index
);
```
- All parameters on the stack
  - Callee cleans the stack

### 1.09D - LoD 1.14D (inclusive)
```C
void D2Common_GetGlobalBeltSlotPositon(
  uint32_t belt_record_index,
  uint32_t inventory_arrange_mode,
  PositionalRectangle* slot_position,
  uint32_t slot_index
);
```
- All parameters on the stack
  - Callee cleans the stack

The parameter `inventory_arrange_mode` is the derived from [D2Client InventoryArrangeMode](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/31).

## Screenshots
The following 1.00 screenshot shows the decompiled function.
![D2Common_GetBeltSlotPosition_01_(1 00)](https://user-images.githubusercontent.com/26683324/69711410-df516580-10b5-11ea-94cc-9348a6155f7d.PNG)

The following 1.00 screenshot shows the function's cleanup convention.
![D2Common_GetBeltSlotPosition_02_(1 00)](https://user-images.githubusercontent.com/26683324/69711411-dfe9fc00-10b5-11ea-8869-d5c5c1fe824d.PNG)

The following 1.09D screenshot shows the addition of the `inventory_arrange_mode` parameter and the function cleanup convention.
![D2Common_GetBeltSlotPosition_03_(1 09D)](https://user-images.githubusercontent.com/26683324/69711413-dfe9fc00-10b5-11ea-8d2c-fb1a07dab2ea.PNG)

The following 1.00 screenshot shows how to locate the target function.
![D2Common_GetBeltBoxPosition_04_(1 00)](https://user-images.githubusercontent.com/26683324/69714834-09a62180-10bc-11ea-9ae3-4c66e25bda86.PNG)