### PR TITLE
Add D2Common GetGlobalBeltRecord

### DIFF
--- a/1.00.txt
+++ b/1.00.txt
@@ -16,6 +16,7 @@ D2Client.dll	ScreenOpenMode	N/A	N/A
 D2Client.dll	ScreenShiftX	N/A	N/A		
 D2Client.dll	ScreenShiftY	N/A	N/A		
 D2Common.dll	GlobalBeltsTxt	Offset	0xA923C		
+D2Common.dll	GetBeltTypeRecord	Ordinal	10605		
 D2Common.dll	GetBeltSlotPosition	Ordinal	10606		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10036		
 D2CMP.dll	CloseCelFile	Ordinal	10032		

--- a/1.03.txt
+++ b/1.03.txt
@@ -16,6 +16,7 @@ D2Client.dll	ScreenOpenMode	N/A	N/A
 D2Client.dll	ScreenShiftX	N/A	N/A		
 D2Client.dll	ScreenShiftY	N/A	N/A		
 D2Common.dll	GlobalBeltsTxt	Offset	0xAB9F4		
+D2Common.dll	GetBeltTypeRecord	Ordinal	10605		
 D2Common.dll	GetBeltSlotPosition	Ordinal	10606		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10036		
 D2CMP.dll	CloseCelFile	Ordinal	10032		

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -16,6 +16,7 @@ D2Client.dll	ScreenOpenMode	N/A	N/A
 D2Client.dll	ScreenShiftX	N/A	N/A		
 D2Client.dll	ScreenShiftY	N/A	N/A		
 D2Common.dll	GlobalBeltsTxt	Offset	0x85E70		
+D2Common.dll	GetBeltTypeRecord	Ordinal	10605		
 D2Common.dll	GetBeltSlotPosition	Ordinal	10606		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10036		
 D2CMP.dll	CloseCelFile	Ordinal	10032		

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -16,6 +16,7 @@ D2Client.dll	ScreenOpenMode	Offset	0x115C10
 D2Client.dll	ScreenShiftX	Offset	0x124954		
 D2Client.dll	ScreenShiftY	Offset	0x124958		
 D2Common.dll	GlobalBeltsTxt	Offset	0xA1B94		
+D2Common.dll	GetBeltTypeRecord	Ordinal	10638		
 D2Common.dll	GetBeltSlotPosition	Ordinal	10639		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10036		
 D2CMP.dll	CloseCelFile	Ordinal	10032		

--- a/1.10.txt
+++ b/1.10.txt
@@ -16,6 +16,7 @@ D2Client.dll	ScreenOpenMode	Offset	0x10B9C4
 D2Client.dll	ScreenShiftX	Offset	0x11A748		
 D2Client.dll	ScreenShiftY	Offset	0x11A74C		
 D2Common.dll	GlobalBeltsTxt	Offset	0xA9604		
+D2Common.dll	GetBeltTypeRecord	Ordinal	10638		
 D2Common.dll	GetBeltSlotPosition	Ordinal	10639		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10036		
 D2CMP.dll	CloseCelFile	Ordinal	10032		

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -16,6 +16,7 @@ D2Client.dll	ScreenOpenMode	Offset	0x11C1D0
 D2Client.dll	ScreenShiftX	Offset	0x11BD28		
 D2Client.dll	ScreenShiftY	Offset	0x11BD2C		
 D2Common.dll	GlobalBeltsTxt	Offset	0xA0750		
+D2Common.dll	GetBeltTypeRecord	Ordinal	10225		
 D2Common.dll	GetBeltSlotPosition	Ordinal	10110		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10038		
 D2CMP.dll	CloseCelFile	Ordinal	10106		

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -16,6 +16,7 @@ D2Client.dll	ScreenOpenMode	Offset	0x11C414
 D2Client.dll	ScreenShiftX	Offset	0x11B9A0		
 D2Client.dll	ScreenShiftY	Offset	0x11B9A4		
 D2Common.dll	GlobalBeltsTxt	Offset	0xA13DC		
+D2Common.dll	GetBeltTypeRecord	Ordinal	10991		
 D2Common.dll	GetBeltSlotPosition	Ordinal	10333		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10021		
 D2CMP.dll	CloseCelFile	Ordinal	10065		

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -16,6 +16,7 @@ D2Client.dll	ScreenOpenMode	Offset	0x11D070
 D2Client.dll	ScreenShiftX	Offset	0x11D354		
 D2Client.dll	ScreenShiftY	Offset	0x11D358		
 D2Common.dll	GlobalBeltsTxt	Offset	0xA4BA0		
+D2Common.dll	GetBeltTypeRecord	Ordinal	10370		
 D2Common.dll	GetBeltSlotPosition	Ordinal	10689		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10035		
 D2CMP.dll	CloseCelFile	Ordinal	10020		

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -16,6 +16,7 @@ D2Client.dll	ScreenOpenMode	Offset	0x39C298
 D2Client.dll	ScreenShiftX	Offset	0x3998E0		
 D2Client.dll	ScreenShiftY	Offset	0x3998E4		
 D2Common.dll	GlobalBeltsTxt	Offset	0x564480		
+D2Common.dll	GetBeltTypeRecord	Offset	0x262F70		
 D2Common.dll	GetBeltSlotPosition	Offset	0x262FD0		
 D2CMP.dll	GetCelFromCelContext	Offset	0x200620		
 D2CMP.dll	CloseCelFile	Offset	0x200820		

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -16,6 +16,7 @@ D2Client.dll	ScreenOpenMode	Offset	0x3A5210
 D2Client.dll	ScreenShiftX	Offset	0x3A2858		
 D2Client.dll	ScreenShiftY	Offset	0x3A285C		
 D2Common.dll	GlobalBeltsTxt	Offset	0x56D4F8		
+D2Common.dll	GetBeltTypeRecord	Offset	0x260CB0		
 D2Common.dll	GetBeltSlotPosition	Offset	0x260D10		
 D2CMP.dll	GetCelFromCelContext	Offset	0x201840		
 D2CMP.dll	CloseCelFile	Offset	0x201A50		


### PR DESCRIPTION
The function retrieves an entire `BeltRecord` from [D2Common GlobalBeltsTxt](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/57) and stores the values into a specified `BeltRecord`. The `BeltRecord` that is retreived is determined by the input belt type ID and (in 1.09D+) the inventory arrange mode.

The function can be located by scanning for all functions that access [D2Common GlobalBeltsTxt](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/57). One of the functions is the target function.

## Function Definitions
### 1.00 - 1.05B (inclusive)
```C
void D2Common_GetGlobalBeltRecord(
  uint32_t belt_record_index,
  BeltRecord* belt_record
);
```
- All parameters on the stack
  - Callee cleans the stack

### 1.09D - LoD 1.14D (inclusive)
```C
void D2Common_GetGlobalBeltRecord(
  uint32_t belt_record_index,
  uint32_t inventory_arrange_mode,
  BeltRecord* belt_record
);
```
- All parameters on the stack
  - Callee cleans the stack
The parameter `inventory_arrange_mode` is derived from [D2Client InventoryArrangeMode](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/31).

## Screenshots
The following 1.00 screenshot shows the decompiled function code.
![D2Common_GetBeltTypeRecord_01_(1 00)](https://user-images.githubusercontent.com/26683324/69713852-22add300-10ba-11ea-84f4-27aea010caa5.PNG)

The following 1.00 screenshot shows the function's cleanup convention. It also shows how the function parameters are used.
![D2Common_GetBeltTypeRecord_02_(1 00)](https://user-images.githubusercontent.com/26683324/69713853-22add300-10ba-11ea-921b-f599c0487e1e.PNG)

The following 1.09D screenshot shows the addition of the `inventory_arrange_mode` parameter and the function's cleanup convention.
![D2Common_GetBeltTypeRecord_03_(1 09D)](https://user-images.githubusercontent.com/26683324/69713854-23466980-10ba-11ea-85e3-63755a3b6081.PNG)
