### PR TITLE
Add D2Common GlobalInventoryTxt

### DIFF
--- a/1.00.txt
+++ b/1.00.txt
@@ -15,9 +15,10 @@ D2Client.dll	IsNewStatsButtonPressed	Offset	0x13DDF4
 D2Client.dll	ScreenOpenMode	N/A	N/A		
 D2Client.dll	ScreenShiftX	N/A	N/A		
 D2Client.dll	ScreenShiftY	N/A	N/A		
-D2Common.dll	GlobalBeltsTxt	Offset	0xA923C		
-D2Common.dll	GetBeltTypeRecord	Ordinal	10605		
+D2Common.dll	GlobalBeltsTxt	Offset	0xA923C	sgptBeltInitStats	
+D2Common.dll	GlobalInventoryTxt	Offset	0xA92B0	sgptInventoryInitStats	
 D2Common.dll	GetBeltSlotPosition	Ordinal	10606		
+D2Common.dll	GetBeltTypeRecord	Ordinal	10605		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10036		
 D2CMP.dll	CloseCelFile	Ordinal	10032		
 D2DDraw.dll	BitBlockHeight	Offset	0x194E4		

--- a/1.03.txt
+++ b/1.03.txt
@@ -15,9 +15,10 @@ D2Client.dll	IsNewStatsButtonPressed	Offset	0x13DB2C
 D2Client.dll	ScreenOpenMode	N/A	N/A		
 D2Client.dll	ScreenShiftX	N/A	N/A		
 D2Client.dll	ScreenShiftY	N/A	N/A		
-D2Common.dll	GlobalBeltsTxt	Offset	0xAB9F4		
-D2Common.dll	GetBeltTypeRecord	Ordinal	10605		
+D2Common.dll	GlobalBeltsTxt	Offset	0xAB9F4	sgptBeltInitStats	
+D2Common.dll	GlobalInventoryTxt	Offset	0xABA68	sgptInventoryInitStats	
 D2Common.dll	GetBeltSlotPosition	Ordinal	10606		
+D2Common.dll	GetBeltTypeRecord	Ordinal	10605		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10036		
 D2CMP.dll	CloseCelFile	Ordinal	10032		
 D2DDraw.dll	BitBlockHeight	Offset	0x194E4		

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -15,9 +15,10 @@ D2Client.dll	IsNewStatsButtonPressed	Offset	0xF01F4
 D2Client.dll	ScreenOpenMode	N/A	N/A		
 D2Client.dll	ScreenShiftX	N/A	N/A		
 D2Client.dll	ScreenShiftY	N/A	N/A		
-D2Common.dll	GlobalBeltsTxt	Offset	0x85E70		
-D2Common.dll	GetBeltTypeRecord	Ordinal	10605		
+D2Common.dll	GlobalBeltsTxt	Offset	0x85E70	sgptBeltInitStats	
+D2Common.dll	GlobalInventoryTxt	Offset	0x85EE0	sgptInventoryInitStats	
 D2Common.dll	GetBeltSlotPosition	Ordinal	10606		
+D2Common.dll	GetBeltTypeRecord	Ordinal	10605		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10036		
 D2CMP.dll	CloseCelFile	Ordinal	10032		
 D2DDraw.dll	BitBlockHeight	Offset	0x11B0C		

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -15,9 +15,10 @@ D2Client.dll	IsNewStatsButtonPressed	Offset	0x11FE84
 D2Client.dll	ScreenOpenMode	Offset	0x115C10		
 D2Client.dll	ScreenShiftX	Offset	0x124954		
 D2Client.dll	ScreenShiftY	Offset	0x124958		
-D2Common.dll	GlobalBeltsTxt	Offset	0xA1B94		
-D2Common.dll	GetBeltTypeRecord	Ordinal	10638		
+D2Common.dll	GlobalBeltsTxt	Offset	0xA1B94	sgptBeltInitStats	
+D2Common.dll	GlobalInventoryTxt	Offset	0xA1D38	sgptInventoryInitStats	
 D2Common.dll	GetBeltSlotPosition	Ordinal	10639		
+D2Common.dll	GetBeltTypeRecord	Ordinal	10638		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10036		
 D2CMP.dll	CloseCelFile	Ordinal	10032		
 D2DDraw.dll	BitBlockHeight	Offset	0x11B7C		

--- a/1.10.txt
+++ b/1.10.txt
@@ -15,9 +15,10 @@ D2Client.dll	IsNewStatsButtonPressed	Offset	0x115BBC
 D2Client.dll	ScreenOpenMode	Offset	0x10B9C4		
 D2Client.dll	ScreenShiftX	Offset	0x11A748		
 D2Client.dll	ScreenShiftY	Offset	0x11A74C		
-D2Common.dll	GlobalBeltsTxt	Offset	0xA9604		
-D2Common.dll	GetBeltTypeRecord	Ordinal	10638		
+D2Common.dll	GlobalBeltsTxt	Offset	0xA9604	sgptBeltInitStats	
+D2Common.dll	GlobalInventoryTxt	Offset	0xAA2D8	sgptInventoryInitStats	
 D2Common.dll	GetBeltSlotPosition	Ordinal	10639		
+D2Common.dll	GetBeltTypeRecord	Ordinal	10638		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10036		
 D2CMP.dll	CloseCelFile	Ordinal	10032		
 D2DDraw.dll	BitBlockHeight	Offset	0x11BBC		

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -15,9 +15,10 @@ D2Client.dll	IsNewStatsButtonPressed	Offset	0x11C344
 D2Client.dll	ScreenOpenMode	Offset	0x11C1D0		
 D2Client.dll	ScreenShiftX	Offset	0x11BD28		
 D2Client.dll	ScreenShiftY	Offset	0x11BD2C		
-D2Common.dll	GlobalBeltsTxt	Offset	0xA0750		
-D2Common.dll	GetBeltTypeRecord	Ordinal	10225		
+D2Common.dll	GlobalBeltsTxt	Offset	0xA0750	sgptBeltInitStats	
+D2Common.dll	GlobalInventoryTxt	Offset	0xA13F8	sgptInventoryInitStats	
 D2Common.dll	GetBeltSlotPosition	Ordinal	10110		
+D2Common.dll	GetBeltTypeRecord	Ordinal	10225		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10038		
 D2CMP.dll	CloseCelFile	Ordinal	10106		
 D2DDraw.dll	BitBlockHeight	Offset	0xFDD8		

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -15,9 +15,10 @@ D2Client.dll	IsNewStatsButtonPressed	Offset	0x11C308
 D2Client.dll	ScreenOpenMode	Offset	0x11C414		
 D2Client.dll	ScreenShiftX	Offset	0x11B9A0		
 D2Client.dll	ScreenShiftY	Offset	0x11B9A4		
-D2Common.dll	GlobalBeltsTxt	Offset	0xA13DC		
-D2Common.dll	GetBeltTypeRecord	Ordinal	10991		
+D2Common.dll	GlobalBeltsTxt	Offset	0xA13DC	sgptBeltInitStats	
+D2Common.dll	GlobalInventoryTxt	Offset	0x9FA5C	sgptInventoryInitStats	
 D2Common.dll	GetBeltSlotPosition	Ordinal	10333		
+D2Common.dll	GetBeltTypeRecord	Ordinal	10991		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10021		
 D2CMP.dll	CloseCelFile	Ordinal	10065		
 D2DDraw.dll	BitBlockHeight	Offset	0x101D8		

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -15,9 +15,10 @@ D2Client.dll	IsNewStatsButtonPressed	Offset	0x11D318
 D2Client.dll	ScreenOpenMode	Offset	0x11D070		
 D2Client.dll	ScreenShiftX	Offset	0x11D354		
 D2Client.dll	ScreenShiftY	Offset	0x11D358		
-D2Common.dll	GlobalBeltsTxt	Offset	0xA4BA0		
-D2Common.dll	GetBeltTypeRecord	Ordinal	10370		
+D2Common.dll	GlobalBeltsTxt	Offset	0xA4BA0	sgptBeltInitStats	
+D2Common.dll	GlobalInventoryTxt	Offset	0xA4CB0	sgptInventoryInitStats	
 D2Common.dll	GetBeltSlotPosition	Ordinal	10689		
+D2Common.dll	GetBeltTypeRecord	Ordinal	10370		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10035		
 D2CMP.dll	CloseCelFile	Ordinal	10020		
 D2DDraw.dll	BitBlockHeight	Offset	0x100E8		

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -15,9 +15,10 @@ D2Client.dll	IsNewStatsButtonPressed	Offset	0x3B736C
 D2Client.dll	ScreenOpenMode	Offset	0x39C298		
 D2Client.dll	ScreenShiftX	Offset	0x3998E0		
 D2Client.dll	ScreenShiftY	Offset	0x3998E4		
-D2Common.dll	GlobalBeltsTxt	Offset	0x564480		
-D2Common.dll	GetBeltTypeRecord	Offset	0x262F70		
+D2Common.dll	GlobalBeltsTxt	Offset	0x564480	sgptBeltInitStats	
+D2Common.dll	GlobalInventoryTxt	Offset	0x56447C	sgptInventoryInitStats	
 D2Common.dll	GetBeltSlotPosition	Offset	0x262FD0		
+D2Common.dll	GetBeltTypeRecord	Offset	0x262F70		
 D2CMP.dll	GetCelFromCelContext	Offset	0x200620		
 D2CMP.dll	CloseCelFile	Offset	0x200820		
 D2DDraw.dll	BitBlockHeight	Offset	0x3C01C4		

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -15,9 +15,10 @@ D2Client.dll	IsNewStatsButtonPressed	Offset	0x3C02E4
 D2Client.dll	ScreenOpenMode	Offset	0x3A5210		
 D2Client.dll	ScreenShiftX	Offset	0x3A2858		
 D2Client.dll	ScreenShiftY	Offset	0x3A285C		
-D2Common.dll	GlobalBeltsTxt	Offset	0x56D4F8		
-D2Common.dll	GetBeltTypeRecord	Offset	0x260CB0		
+D2Common.dll	GlobalBeltsTxt	Offset	0x56D4F8	sgptBeltInitStats	
+D2Common.dll	GlobalInventoryTxt	Offset	0x56D4F4	sgptInventoryInitStats	
 D2Common.dll	GetBeltSlotPosition	Offset	0x260D10		
+D2Common.dll	GetBeltTypeRecord	Offset	0x260CB0		
 D2CMP.dll	GetCelFromCelContext	Offset	0x201840		
 D2CMP.dll	CloseCelFile	Offset	0x201A50		
 D2DDraw.dll	BitBlockHeight	Offset	0x3C913C		


### PR DESCRIPTION
The variable is stores the memory location of the parsed `inventory.txt` file. Each inventory contains the position, the grid (which is either the character backpack **grid** or the vendor **grid**), and the equipment slots (if they apply).

The variable can be located prior to 1.12A by scanning for every usage of the string `sgptInventoryInitStats`. Any one of the functions using this string is also using the target variable.

In 1.12A and above, the variable can be located by checking for code that accesses [D2Client InventoryArrangeMode](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/31). When the right inventory screen is open, one function will access `D2Client InventoryArrangeMode` every frame. The function calls other functions, which access the target variable.

## Definition
### All Versions
```C
struct PositionalRectangle {
  int32_t left;
  int32_t right;
  int32_t top;
  int32_t bottom;
};

struct GridLayout {
  uint8_t num_columns;
  uint8_t num_rows;
  unused_byte unused__for_align_0x02[2];
  PositionalRectangle position;
  uint8_t width;
  uint8_t height;
  unused_byte unused__for_align_0x16[2];
};

struct EquipmentSlotLayout {
  PositionalRectangle position;
  uint8_t width;
  uint8_t height;
  unused_byte unused__for_align_0x12[2];
};

struct InventoryRecord {
  PositionalRectangle position;
  GridLayout grid_layout;
  EquipmentSlotLayout equipment_slots[10];
};

InventoryRecord* D2Common_GlobalInventoryTxt;
```

Each of these values have been previously discovered by [PhrozenKeep](
https://web.archive.org/web/20191127053750/https://d2mods.info/forum/viewtopic.php?f=8&t=61189) and further elaborated by [D2Ex2](https://github.com/jankowskib/D2Ex2/blob/master/Constants.h). These definitions have been tested for signed and size correctness. Further development includes correctly aligning the `GridLayout` struct.

The `PositionalRectangle` members can be tested by setting their values to negative.  Negative values cause the inventory slots to appear beyond the left boundaries of the screen.

For the `uint8_t` members of the defined structs, they can be tested by setting the highest order bit in the byte. Doing so will cause the game to treat the belt as if it had many more slots instead of none. Setting the bits in `unused__for_align` does nothing.

## Screenshots
The following 1.00 screenshots show the reverse engineered structs.
![PositionalRectangle_01_(1 00)](https://user-images.githubusercontent.com/26683324/69897416-ba9cfe00-1300-11ea-95ab-4747e39645fc.PNG)
![GridLayout_01_(1 00)](https://user-images.githubusercontent.com/26683324/69897419-c092df00-1300-11ea-8a02-5a03b8fc39dd.PNG)
![EquipmentSlotLayout_01_(1 00)](https://user-images.githubusercontent.com/26683324/69897420-c2f53900-1300-11ea-973b-7c8a40dd6c14.PNG)
![InventoryRecord_01_(1 00)](https://user-images.githubusercontent.com/26683324/69897424-c5f02980-1300-11ea-9706-ac48f52111d9.PNG)

The following 1.00 screenshot shows how the variable is used.
![D2Common_GlobalInventoryTxt_01_(1 00)](https://user-images.githubusercontent.com/26683324/69897445-123b6980-1301-11ea-93d8-548574c345d4.PNG)

The following 1.00 screenshot shows how to locate the variable in versions prior to 1.12A.
![D2Common_GlobalInventoryTxt_02_(1 00)](https://user-images.githubusercontent.com/26683324/69897432-de604400-1300-11ea-8a5c-bd5406469fad.PNG)

The following 1.12A screenshot shows how to locate the variable in versions 1.12A and above.
![D2Common_GlobalInventoryTxt_03_(1 12A)](https://user-images.githubusercontent.com/26683324/69897442-fdf76c80-1300-11ea-9279-8d6848b4558c.PNG)

The following screenshot from the Diablo II manual justifies naming the GridLayout struct using the word **Grid**. Since the struct is also used in vendor inventories, it would make sense to not name it with the word **backpack**.
![GridLayout_02](https://user-images.githubusercontent.com/26683324/69897493-b02f3400-1301-11ea-95c3-d4ee14e49eb9.PNG)
