### PR TITLE
Add D2Common GlobalInventoryTxtRecordsCount

### DIFF
--- a/1.00.txt
+++ b/1.00.txt
@@ -17,7 +17,7 @@ D2Client.dll	ScreenShiftX	N/A	N/A
 D2Client.dll	ScreenShiftY	N/A	N/A		
 D2Common.dll	GlobalBeltsTxt	Offset	0xA923C	sgptBeltInitStats	
 D2Common.dll	GlobalInventoryTxt	Offset	0xA92B0	sgptInventoryInitStats	
-D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0xA92AC		
+D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0xA92AC	sgnInventoryInitStats	
 D2Common.dll	GetBeltSlotPosition	Ordinal	10606		
 D2Common.dll	GetBeltTypeRecord	Ordinal	10605		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10036		

--- a/1.00.txt
+++ b/1.00.txt
@@ -17,6 +17,7 @@ D2Client.dll	ScreenShiftX	N/A	N/A
 D2Client.dll	ScreenShiftY	N/A	N/A		
 D2Common.dll	GlobalBeltsTxt	Offset	0xA923C	sgptBeltInitStats	
 D2Common.dll	GlobalInventoryTxt	Offset	0xA92B0	sgptInventoryInitStats	
+D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0xA92AC		
 D2Common.dll	GetBeltSlotPosition	Ordinal	10606		
 D2Common.dll	GetBeltTypeRecord	Ordinal	10605		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10036		

--- a/1.03.txt
+++ b/1.03.txt
@@ -17,7 +17,7 @@ D2Client.dll	ScreenShiftX	N/A	N/A
 D2Client.dll	ScreenShiftY	N/A	N/A		
 D2Common.dll	GlobalBeltsTxt	Offset	0xAB9F4	sgptBeltInitStats	
 D2Common.dll	GlobalInventoryTxt	Offset	0xABA68	sgptInventoryInitStats	
-D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0xABA64		
+D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0xABA64	sgnInventoryInitStats	
 D2Common.dll	GetBeltSlotPosition	Ordinal	10606		
 D2Common.dll	GetBeltTypeRecord	Ordinal	10605		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10036		

--- a/1.03.txt
+++ b/1.03.txt
@@ -17,6 +17,7 @@ D2Client.dll	ScreenShiftX	N/A	N/A
 D2Client.dll	ScreenShiftY	N/A	N/A		
 D2Common.dll	GlobalBeltsTxt	Offset	0xAB9F4	sgptBeltInitStats	
 D2Common.dll	GlobalInventoryTxt	Offset	0xABA68	sgptInventoryInitStats	
+D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0xABA64		
 D2Common.dll	GetBeltSlotPosition	Ordinal	10606		
 D2Common.dll	GetBeltTypeRecord	Ordinal	10605		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10036		

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -17,6 +17,7 @@ D2Client.dll	ScreenShiftX	N/A	N/A
 D2Client.dll	ScreenShiftY	N/A	N/A		
 D2Common.dll	GlobalBeltsTxt	Offset	0x85E70	sgptBeltInitStats	
 D2Common.dll	GlobalInventoryTxt	Offset	0x85EE0	sgptInventoryInitStats	
+D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0x85EDC		
 D2Common.dll	GetBeltSlotPosition	Ordinal	10606		
 D2Common.dll	GetBeltTypeRecord	Ordinal	10605		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10036		

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -17,7 +17,7 @@ D2Client.dll	ScreenShiftX	N/A	N/A
 D2Client.dll	ScreenShiftY	N/A	N/A		
 D2Common.dll	GlobalBeltsTxt	Offset	0x85E70	sgptBeltInitStats	
 D2Common.dll	GlobalInventoryTxt	Offset	0x85EE0	sgptInventoryInitStats	
-D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0x85EDC		
+D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0x85EDC	sgnInventoryInitStats	
 D2Common.dll	GetBeltSlotPosition	Ordinal	10606		
 D2Common.dll	GetBeltTypeRecord	Ordinal	10605		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10036		

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -17,7 +17,7 @@ D2Client.dll	ScreenShiftX	Offset	0x124954
 D2Client.dll	ScreenShiftY	Offset	0x124958		
 D2Common.dll	GlobalBeltsTxt	Offset	0xA1B94	sgptBeltInitStats	
 D2Common.dll	GlobalInventoryTxt	Offset	0xA1D38	sgptInventoryInitStats	
-D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0xA1D34		
+D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0xA1D34	sgnInventoryInitStats	
 D2Common.dll	GetBeltSlotPosition	Ordinal	10639		
 D2Common.dll	GetBeltTypeRecord	Ordinal	10638		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10036		

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -17,6 +17,7 @@ D2Client.dll	ScreenShiftX	Offset	0x124954
 D2Client.dll	ScreenShiftY	Offset	0x124958		
 D2Common.dll	GlobalBeltsTxt	Offset	0xA1B94	sgptBeltInitStats	
 D2Common.dll	GlobalInventoryTxt	Offset	0xA1D38	sgptInventoryInitStats	
+D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0xA1D34		
 D2Common.dll	GetBeltSlotPosition	Ordinal	10639		
 D2Common.dll	GetBeltTypeRecord	Ordinal	10638		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10036		

--- a/1.10.txt
+++ b/1.10.txt
@@ -17,6 +17,7 @@ D2Client.dll	ScreenShiftX	Offset	0x11A748
 D2Client.dll	ScreenShiftY	Offset	0x11A74C		
 D2Common.dll	GlobalBeltsTxt	Offset	0xA9604	sgptBeltInitStats	
 D2Common.dll	GlobalInventoryTxt	Offset	0xAA2D8	sgptInventoryInitStats	
+D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0xAA2D4		
 D2Common.dll	GetBeltSlotPosition	Ordinal	10639		
 D2Common.dll	GetBeltTypeRecord	Ordinal	10638		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10036		

--- a/1.10.txt
+++ b/1.10.txt
@@ -17,7 +17,7 @@ D2Client.dll	ScreenShiftX	Offset	0x11A748
 D2Client.dll	ScreenShiftY	Offset	0x11A74C		
 D2Common.dll	GlobalBeltsTxt	Offset	0xA9604	sgptBeltInitStats	
 D2Common.dll	GlobalInventoryTxt	Offset	0xAA2D8	sgptInventoryInitStats	
-D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0xAA2D4		
+D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0xAA2D4	sgnInventoryInitStats	
 D2Common.dll	GetBeltSlotPosition	Ordinal	10639		
 D2Common.dll	GetBeltTypeRecord	Ordinal	10638		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10036		

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -17,6 +17,7 @@ D2Client.dll	ScreenShiftX	Offset	0x11BD28
 D2Client.dll	ScreenShiftY	Offset	0x11BD2C		
 D2Common.dll	GlobalBeltsTxt	Offset	0xA0750	sgptBeltInitStats	
 D2Common.dll	GlobalInventoryTxt	Offset	0xA13F8	sgptInventoryInitStats	
+D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0xA13F4		
 D2Common.dll	GetBeltSlotPosition	Ordinal	10110		
 D2Common.dll	GetBeltTypeRecord	Ordinal	10225		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10038		

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -17,7 +17,7 @@ D2Client.dll	ScreenShiftX	Offset	0x11BD28
 D2Client.dll	ScreenShiftY	Offset	0x11BD2C		
 D2Common.dll	GlobalBeltsTxt	Offset	0xA0750	sgptBeltInitStats	
 D2Common.dll	GlobalInventoryTxt	Offset	0xA13F8	sgptInventoryInitStats	
-D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0xA13F4		
+D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0xA13F4	sgnInventoryInitStats	
 D2Common.dll	GetBeltSlotPosition	Ordinal	10110		
 D2Common.dll	GetBeltTypeRecord	Ordinal	10225		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10038		

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -17,7 +17,7 @@ D2Client.dll	ScreenShiftX	Offset	0x11B9A0
 D2Client.dll	ScreenShiftY	Offset	0x11B9A4		
 D2Common.dll	GlobalBeltsTxt	Offset	0xA13DC	sgptBeltInitStats	
 D2Common.dll	GlobalInventoryTxt	Offset	0x9FA5C	sgptInventoryInitStats	
-D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0x9FA58		
+D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0x9FA58	sgnInventoryInitStats	
 D2Common.dll	GetBeltSlotPosition	Ordinal	10333		
 D2Common.dll	GetBeltTypeRecord	Ordinal	10991		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10021		

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -17,6 +17,7 @@ D2Client.dll	ScreenShiftX	Offset	0x11B9A0
 D2Client.dll	ScreenShiftY	Offset	0x11B9A4		
 D2Common.dll	GlobalBeltsTxt	Offset	0xA13DC	sgptBeltInitStats	
 D2Common.dll	GlobalInventoryTxt	Offset	0x9FA5C	sgptInventoryInitStats	
+D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0x9FA58		
 D2Common.dll	GetBeltSlotPosition	Ordinal	10333		
 D2Common.dll	GetBeltTypeRecord	Ordinal	10991		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10021		

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -17,6 +17,7 @@ D2Client.dll	ScreenShiftX	Offset	0x11D354
 D2Client.dll	ScreenShiftY	Offset	0x11D358		
 D2Common.dll	GlobalBeltsTxt	Offset	0xA4BA0	sgptBeltInitStats	
 D2Common.dll	GlobalInventoryTxt	Offset	0xA4CB0	sgptInventoryInitStats	
+D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0xA4CAC		
 D2Common.dll	GetBeltSlotPosition	Ordinal	10689		
 D2Common.dll	GetBeltTypeRecord	Ordinal	10370		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10035		

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -17,7 +17,7 @@ D2Client.dll	ScreenShiftX	Offset	0x11D354
 D2Client.dll	ScreenShiftY	Offset	0x11D358		
 D2Common.dll	GlobalBeltsTxt	Offset	0xA4BA0	sgptBeltInitStats	
 D2Common.dll	GlobalInventoryTxt	Offset	0xA4CB0	sgptInventoryInitStats	
-D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0xA4CAC		
+D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0xA4CAC	sgnInventoryInitStats	
 D2Common.dll	GetBeltSlotPosition	Ordinal	10689		
 D2Common.dll	GetBeltTypeRecord	Ordinal	10370		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10035		

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -17,6 +17,7 @@ D2Client.dll	ScreenShiftX	Offset	0x3998E0
 D2Client.dll	ScreenShiftY	Offset	0x3998E4		
 D2Common.dll	GlobalBeltsTxt	Offset	0x564480	sgptBeltInitStats	
 D2Common.dll	GlobalInventoryTxt	Offset	0x56447C	sgptInventoryInitStats	
+D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0x564478		
 D2Common.dll	GetBeltSlotPosition	Offset	0x262FD0		
 D2Common.dll	GetBeltTypeRecord	Offset	0x262F70		
 D2CMP.dll	GetCelFromCelContext	Offset	0x200620		

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -17,7 +17,7 @@ D2Client.dll	ScreenShiftX	Offset	0x3998E0
 D2Client.dll	ScreenShiftY	Offset	0x3998E4		
 D2Common.dll	GlobalBeltsTxt	Offset	0x564480	sgptBeltInitStats	
 D2Common.dll	GlobalInventoryTxt	Offset	0x56447C	sgptInventoryInitStats	
-D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0x564478		
+D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0x564478	sgnInventoryInitStats	
 D2Common.dll	GetBeltSlotPosition	Offset	0x262FD0		
 D2Common.dll	GetBeltTypeRecord	Offset	0x262F70		
 D2CMP.dll	GetCelFromCelContext	Offset	0x200620		

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -17,7 +17,7 @@ D2Client.dll	ScreenShiftX	Offset	0x3A2858
 D2Client.dll	ScreenShiftY	Offset	0x3A285C		
 D2Common.dll	GlobalBeltsTxt	Offset	0x56D4F8	sgptBeltInitStats	
 D2Common.dll	GlobalInventoryTxt	Offset	0x56D4F4	sgptInventoryInitStats	
-D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0x56D4F0		
+D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0x56D4F0	sgnInventoryInitStats	
 D2Common.dll	GetBeltSlotPosition	Offset	0x260D10		
 D2Common.dll	GetBeltTypeRecord	Offset	0x260CB0		
 D2CMP.dll	GetCelFromCelContext	Offset	0x201840		

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -17,6 +17,7 @@ D2Client.dll	ScreenShiftX	Offset	0x3A2858
 D2Client.dll	ScreenShiftY	Offset	0x3A285C		
 D2Common.dll	GlobalBeltsTxt	Offset	0x56D4F8	sgptBeltInitStats	
 D2Common.dll	GlobalInventoryTxt	Offset	0x56D4F4	sgptInventoryInitStats	
+D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0x56D4F0		
 D2Common.dll	GetBeltSlotPosition	Offset	0x260D10		
 D2Common.dll	GetBeltTypeRecord	Offset	0x260CB0		
 D2CMP.dll	GetCelFromCelContext	Offset	0x201840		


### PR DESCRIPTION
The variable is responsible for storing the number of records in the [D2Common GlobalInventoryTxt](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/60) variable. Prior to 1.07, the number of records did not have a limit. With 1.07 and above, the limit is at 32 entries.

The variable can be located prior to 1.12A by scanning for every usage of the string `sgptInventoryInitStats`. Any one of the functions using this string is also using the target variable.

In 1.12A and above, the variable can be located by checking for code that accesses [D2Client InventoryArrangeMode](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/31). When the right inventory screen is open, one function will access `D2Client InventoryArrangeMode` every frame. The function calls other functions, which access the target variable.

## Definition
### All Versions
```C
uint32_t D2Common_GlobalInventoryTxtRecordsCount;
```

In 1.09D to 1.10 (inclusive), the variable was known internally as `sgnInventoryInitStats`.

## Screenshot
The following 1.00 screenshot shows how to locate the variable prior to 1.09D. It also shows that the variable is a `uint32_t`.
![D2Common_GlobalInventoryTxtRecordsCount_01_(1 00)](https://user-images.githubusercontent.com/26683324/69904942-6b87b500-1362-11ea-999a-69f3406136cd.PNG)

The following 1.09D screenshot shows that the variable in 1.09D and above are limited to a value of 32. Also, it shows the variable's internal debugging name.
![D2Common_GlobalInventoryTxtRecordsCount_02_(1 09D)](https://user-images.githubusercontent.com/26683324/69904943-6c204b80-1362-11ea-988c-904b048a1c82.PNG)

The following 1.12A screenshot shows how to locate the variables in 1.09D and above.
![D2Common_GlobalInventoryTxt_03_(1 12A)](https://user-images.githubusercontent.com/26683324/69905283-249bbe80-1366-11ea-9a3a-e0e827c9f05e.PNG)
