### PR TITLE
Add D2Common GetGlobalInventoryPosition

### DIFF
--- a/1.00.txt
+++ b/1.00.txt
@@ -20,6 +20,7 @@ D2Common.dll	GlobalInventoryTxt	Offset	0xA92B0	sgptInventoryInitStats
 D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0xA92AC	sgnInventoryInitStats	
 D2Common.dll	GetBeltSlotPosition	Ordinal	10606		
 D2Common.dll	GetBeltTypeRecord	Ordinal	10605		
+D2Common.dll	GetInventoryPosition	Ordinal	10602		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10036		
 D2CMP.dll	CloseCelFile	Ordinal	10032		
 D2DDraw.dll	BitBlockHeight	Offset	0x194E4		

--- a/1.03.txt
+++ b/1.03.txt
@@ -20,6 +20,7 @@ D2Common.dll	GlobalInventoryTxt	Offset	0xABA68	sgptInventoryInitStats
 D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0xABA64	sgnInventoryInitStats	
 D2Common.dll	GetBeltSlotPosition	Ordinal	10606		
 D2Common.dll	GetBeltTypeRecord	Ordinal	10605		
+D2Common.dll	GetInventoryPosition	Ordinal	10602		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10036		
 D2CMP.dll	CloseCelFile	Ordinal	10032		
 D2DDraw.dll	BitBlockHeight	Offset	0x194E4		

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -20,6 +20,7 @@ D2Common.dll	GlobalInventoryTxt	Offset	0x85EE0	sgptInventoryInitStats
 D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0x85EDC	sgnInventoryInitStats	
 D2Common.dll	GetBeltSlotPosition	Ordinal	10606		
 D2Common.dll	GetBeltTypeRecord	Ordinal	10605		
+D2Common.dll	GetInventoryPosition	Ordinal	10602		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10036		
 D2CMP.dll	CloseCelFile	Ordinal	10032		
 D2DDraw.dll	BitBlockHeight	Offset	0x11B0C		

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -20,6 +20,7 @@ D2Common.dll	GlobalInventoryTxt	Offset	0xA1D38	sgptInventoryInitStats
 D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0xA1D34	sgnInventoryInitStats	
 D2Common.dll	GetBeltSlotPosition	Ordinal	10639		
 D2Common.dll	GetBeltTypeRecord	Ordinal	10638		
+D2Common.dll	GetInventoryPosition	Ordinal	10635		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10036		
 D2CMP.dll	CloseCelFile	Ordinal	10032		
 D2DDraw.dll	BitBlockHeight	Offset	0x11B7C		

--- a/1.10.txt
+++ b/1.10.txt
@@ -20,6 +20,7 @@ D2Common.dll	GlobalInventoryTxt	Offset	0xAA2D8	sgptInventoryInitStats
 D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0xAA2D4	sgnInventoryInitStats	
 D2Common.dll	GetBeltSlotPosition	Ordinal	10639		
 D2Common.dll	GetBeltTypeRecord	Ordinal	10638		
+D2Common.dll	GetInventoryPosition	Ordinal	10635		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10036		
 D2CMP.dll	CloseCelFile	Ordinal	10032		
 D2DDraw.dll	BitBlockHeight	Offset	0x11BBC		

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -20,6 +20,7 @@ D2Common.dll	GlobalInventoryTxt	Offset	0xA13F8	sgptInventoryInitStats
 D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0xA13F4	sgnInventoryInitStats	
 D2Common.dll	GetBeltSlotPosition	Ordinal	10110		
 D2Common.dll	GetBeltTypeRecord	Ordinal	10225		
+D2Common.dll	GetInventoryPosition	Ordinal	10279		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10038		
 D2CMP.dll	CloseCelFile	Ordinal	10106		
 D2DDraw.dll	BitBlockHeight	Offset	0xFDD8		

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -20,6 +20,7 @@ D2Common.dll	GlobalInventoryTxt	Offset	0x9FA5C	sgptInventoryInitStats
 D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0x9FA58	sgnInventoryInitStats	
 D2Common.dll	GetBeltSlotPosition	Ordinal	10333		
 D2Common.dll	GetBeltTypeRecord	Ordinal	10991		
+D2Common.dll	GetInventoryPosition	Ordinal	11012		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10021		
 D2CMP.dll	CloseCelFile	Ordinal	10065		
 D2DDraw.dll	BitBlockHeight	Offset	0x101D8		

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -20,6 +20,7 @@ D2Common.dll	GlobalInventoryTxt	Offset	0xA4CB0	sgptInventoryInitStats
 D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0xA4CAC	sgnInventoryInitStats	
 D2Common.dll	GetBeltSlotPosition	Ordinal	10689		
 D2Common.dll	GetBeltTypeRecord	Ordinal	10370		
+D2Common.dll	GetInventoryPosition	Ordinal	10770		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10035		
 D2CMP.dll	CloseCelFile	Ordinal	10020		
 D2DDraw.dll	BitBlockHeight	Offset	0x100E8		

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -20,6 +20,7 @@ D2Common.dll	GlobalInventoryTxt	Offset	0x56447C	sgptInventoryInitStats
 D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0x564478	sgnInventoryInitStats	
 D2Common.dll	GetBeltSlotPosition	Offset	0x262FD0		
 D2Common.dll	GetBeltTypeRecord	Offset	0x262F70		
+D2Common.dll	GetInventoryPosition	Offset	0x25E280		
 D2CMP.dll	GetCelFromCelContext	Offset	0x200620		
 D2CMP.dll	CloseCelFile	Offset	0x200820		
 D2DDraw.dll	BitBlockHeight	Offset	0x3C01C4		

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -20,6 +20,7 @@ D2Common.dll	GlobalInventoryTxt	Offset	0x56D4F4	sgptInventoryInitStats
 D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0x56D4F0	sgnInventoryInitStats	
 D2Common.dll	GetBeltSlotPosition	Offset	0x260D10		
 D2Common.dll	GetBeltTypeRecord	Offset	0x260CB0		
+D2Common.dll	GetInventoryPosition	Offset	0x25C180		
 D2CMP.dll	GetCelFromCelContext	Offset	0x201840		
 D2CMP.dll	CloseCelFile	Offset	0x201A50		
 D2DDraw.dll	BitBlockHeight	Offset	0x3C913C		


### PR DESCRIPTION
The function looks into [D2Common GlobalInventoryTxt](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/60) and writes to a specified memory location the position of an inventory with the specified index and (in 1.09D and above) the specified inventory arrange mode.

Prior to 1.12A, the function can be located by scanning for every usage of the string `sgptInventoryInitStats`. One of the functions using this string is the target function.

In 1,12A and above, the function can be located by scanning for the usage of the variable [D2Client InventoryArrangeMode](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/31). One of the functions that uses this variable also calls the target function.

## Definition
### 1.00 to 1.05B (inclusive)
```C
void D2Common_GetGlobalInventoryPosition(
  uint32_t inventory_type_index,
  PositionalRectangle* out_position
);
```
- All parameters on the stack
  - Callee cleans the stack

### 1.09D and Above
```C
void D2Common_GetGlobalInventoryPosition(
  uint32_t inventory_type_index,
  uint32_t inventory_arrange_mode,
  PositionalRectangle* out_position
);
```
- All parameters on the stack
  - Callee cleans the stack

The value of `inventory_arrange_mode` is derived from [D2Client InventoryArrangeMode](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/31).

## Screenshot
The following 1.00 screenshot shows the decompiled function's parameters and cleanup convention.
![D2Common_GetInventoryPosition_01_(1 00)](https://user-images.githubusercontent.com/26683324/69906250-7dbf1e80-1375-11ea-844d-7f75b1a5a390.PNG)

The following 1.00 screenshot shows that the parameter `inventory_type_index` is a `uint32_t`.
![D2Common_GetInventoryPosition_02_(1 00)](https://user-images.githubusercontent.com/26683324/69906345-ff637c00-1376-11ea-8d79-25c7b1a9c754.PNG)

The following 1.09D screenshot shows the decompiled function's parameters and cleanup convention.
![D2Common_GetInventoryPosition_03_(1 09D)](https://user-images.githubusercontent.com/26683324/69906349-0c806b00-1377-11ea-9f4b-049f759b0c69.PNG)

The following 1.00 screenshot shows how to locate the function and what to look out for.
![D2Common_GetInventoryPosition_05_(1 00)](https://user-images.githubusercontent.com/26683324/69906403-94ff0b80-1377-11ea-8e03-740de7389a17.PNG)

The following 1.12A screenshot shows how to locate the function.
![D2Common_GetInventoryPosition_04_(1 12A)](https://user-images.githubusercontent.com/26683324/69906368-320d7480-1377-11ea-84ff-b3268b2e2df7.PNG)
