### PR TITLE
Add D2Common GetGlobalInventoryGridLayout

### DIFF
--- a/1.00.txt
+++ b/1.00.txt
@@ -20,6 +20,7 @@ D2Common.dll	GlobalInventoryTxt	Offset	0xA92B0	sgptInventoryInitStats
 D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0xA92AC	sgnInventoryInitStats	
 D2Common.dll	GetBeltSlotPosition	Ordinal	10606		
 D2Common.dll	GetBeltTypeRecord	Ordinal	10605		
+D2Common.dll	GetInventoryGridLayout	Ordinal	10603		
 D2Common.dll	GetInventoryPosition	Ordinal	10602		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10036		
 D2CMP.dll	CloseCelFile	Ordinal	10032		

--- a/1.03.txt
+++ b/1.03.txt
@@ -20,6 +20,7 @@ D2Common.dll	GlobalInventoryTxt	Offset	0xABA68	sgptInventoryInitStats
 D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0xABA64	sgnInventoryInitStats	
 D2Common.dll	GetBeltSlotPosition	Ordinal	10606		
 D2Common.dll	GetBeltTypeRecord	Ordinal	10605		
+D2Common.dll	GetInventoryGridLayout	Ordinal	10603		
 D2Common.dll	GetInventoryPosition	Ordinal	10602		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10036		
 D2CMP.dll	CloseCelFile	Ordinal	10032		

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -20,6 +20,7 @@ D2Common.dll	GlobalInventoryTxt	Offset	0x85EE0	sgptInventoryInitStats
 D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0x85EDC	sgnInventoryInitStats	
 D2Common.dll	GetBeltSlotPosition	Ordinal	10606		
 D2Common.dll	GetBeltTypeRecord	Ordinal	10605		
+D2Common.dll	GetInventoryGridLayout	Ordinal	10603		
 D2Common.dll	GetInventoryPosition	Ordinal	10602		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10036		
 D2CMP.dll	CloseCelFile	Ordinal	10032		

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -20,6 +20,7 @@ D2Common.dll	GlobalInventoryTxt	Offset	0xA1D38	sgptInventoryInitStats
 D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0xA1D34	sgnInventoryInitStats	
 D2Common.dll	GetBeltSlotPosition	Ordinal	10639		
 D2Common.dll	GetBeltTypeRecord	Ordinal	10638		
+D2Common.dll	GetInventoryGridLayout	Ordinal	10636		
 D2Common.dll	GetInventoryPosition	Ordinal	10635		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10036		
 D2CMP.dll	CloseCelFile	Ordinal	10032		

--- a/1.10.txt
+++ b/1.10.txt
@@ -20,6 +20,7 @@ D2Common.dll	GlobalInventoryTxt	Offset	0xAA2D8	sgptInventoryInitStats
 D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0xAA2D4	sgnInventoryInitStats	
 D2Common.dll	GetBeltSlotPosition	Ordinal	10639		
 D2Common.dll	GetBeltTypeRecord	Ordinal	10638		
+D2Common.dll	GetInventoryGridLayout	Ordinal	10636		
 D2Common.dll	GetInventoryPosition	Ordinal	10635		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10036		
 D2CMP.dll	CloseCelFile	Ordinal	10032		

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -20,6 +20,7 @@ D2Common.dll	GlobalInventoryTxt	Offset	0xA13F8	sgptInventoryInitStats
 D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0xA13F4	sgnInventoryInitStats	
 D2Common.dll	GetBeltSlotPosition	Ordinal	10110		
 D2Common.dll	GetBeltTypeRecord	Ordinal	10225		
+D2Common.dll	GetInventoryGridLayout	Ordinal	10654		
 D2Common.dll	GetInventoryPosition	Ordinal	10279		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10038		
 D2CMP.dll	CloseCelFile	Ordinal	10106		

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -20,6 +20,7 @@ D2Common.dll	GlobalInventoryTxt	Offset	0x9FA5C	sgptInventoryInitStats
 D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0x9FA58	sgnInventoryInitStats	
 D2Common.dll	GetBeltSlotPosition	Ordinal	10333		
 D2Common.dll	GetBeltTypeRecord	Ordinal	10991		
+D2Common.dll	GetInventoryGridLayout	Ordinal	10760		
 D2Common.dll	GetInventoryPosition	Ordinal	11012		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10021		
 D2CMP.dll	CloseCelFile	Ordinal	10065		

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -20,6 +20,7 @@ D2Common.dll	GlobalInventoryTxt	Offset	0xA4CB0	sgptInventoryInitStats
 D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0xA4CAC	sgnInventoryInitStats	
 D2Common.dll	GetBeltSlotPosition	Ordinal	10689		
 D2Common.dll	GetBeltTypeRecord	Ordinal	10370		
+D2Common.dll	GetInventoryGridLayout	Ordinal	10964		
 D2Common.dll	GetInventoryPosition	Ordinal	10770		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10035		
 D2CMP.dll	CloseCelFile	Ordinal	10020		

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -20,6 +20,7 @@ D2Common.dll	GlobalInventoryTxt	Offset	0x56447C	sgptInventoryInitStats
 D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0x564478	sgnInventoryInitStats	
 D2Common.dll	GetBeltSlotPosition	Offset	0x262FD0		
 D2Common.dll	GetBeltTypeRecord	Offset	0x262F70		
+D2Common.dll	GetInventoryGridLayout	Offset	0x25E2F0		
 D2Common.dll	GetInventoryPosition	Offset	0x25E280		
 D2CMP.dll	GetCelFromCelContext	Offset	0x200620		
 D2CMP.dll	CloseCelFile	Offset	0x200820		

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -20,6 +20,7 @@ D2Common.dll	GlobalInventoryTxt	Offset	0x56D4F4	sgptInventoryInitStats
 D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0x56D4F0	sgnInventoryInitStats	
 D2Common.dll	GetBeltSlotPosition	Offset	0x260D10		
 D2Common.dll	GetBeltTypeRecord	Offset	0x260CB0		
+D2Common.dll	GetInventoryGridLayout	Offset	0x25C1F0		
 D2Common.dll	GetInventoryPosition	Offset	0x25C180		
 D2CMP.dll	GetCelFromCelContext	Offset	0x201840		
 D2CMP.dll	CloseCelFile	Offset	0x201A50		


### PR DESCRIPTION
The function looks into [D2Common GlobalInventoryTxt](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/60) and writes to a specified memory location the `GridLayout` from an inventory record with the specified inventory index and (in 1.09D and above) the specified inventory arrange mode.

Prior to 1.12A, the function can be located by scanning for every usage of the string `sgptInventoryInitStats`. One of the functions using this string is the target function.

In 1,12A and above, the function can be located by scanning for the usage of the variable [D2Client InventoryArrangeMode](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/31). One of the functions that uses this variable also calls the target function.

## Definition
### 1.00 to 1.05B (inclusive)
```C
void D2Common_GetGlobalInventoryGridLayout(
  uint32_t inventory_type_index,
  GridLayout* out_grid_layout
);
```
- All parameters on the stack
  - Callee cleans the stack

### 1.09D and Above
```C
void D2Common_GetGlobalInventoryGridLayout(
  uint32_t inventory_type_index,
  uint32_t inventory_arrange_mode,
  GridLayout* out_grid_layout
);
```
- All parameters on the stack
  - Callee cleans the stack

## Screenshots
The following 1.00 screenshot shows the decompiled function's parameters and its cleanup convention.
![D2Common_GetInventoryGridLayout_01_(1 00)](https://user-images.githubusercontent.com/26683324/69907125-3d1ad180-1384-11ea-9f86-e3b896866717.PNG)

The following 1.00 screenshot shows that the parameter `inventory_type_index` is a `uint32_t`.
![D2Common_GetInventoryGridLayout_02_(1 00)](https://user-images.githubusercontent.com/26683324/69907130-63d90800-1384-11ea-87c0-a72ffdc32a62.PNG)

The following 1.09D screenshot shows the decompiled function's parameters and its cleanup convention.
![D2Common_GetInventoryGridLayout_03_(1 09D)](https://user-images.githubusercontent.com/26683324/69907135-89661180-1384-11ea-81e2-aef5e0e8fc74.PNG)

The following 1.00 screenshot shows how to locate the function and what to look out for.
![D2Common_GetInventoryGridLayout_05_(1 00)](https://user-images.githubusercontent.com/26683324/69907169-ff6a7880-1384-11ea-8d8c-08e4f1e1ab75.PNG)

The following 1.12A screenshot shows how to locate the function and what to look out for.
![D2Common_GetInventoryGridLayout_04_(1 12A)](https://user-images.githubusercontent.com/26683324/69907152-a995d080-1384-11ea-9a94-5d77e266ae79.PNG)
