### PR TITLE
Add D2Common GetGlobalEquipmentSlotLayout

### DIFF
--- a/1.00.txt
+++ b/1.00.txt
@@ -20,6 +20,7 @@ D2Common.dll	GlobalInventoryTxt	Offset	0xA92B0	sgptInventoryInitStats
 D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0xA92AC	sgnInventoryInitStats	
 D2Common.dll	GetBeltSlotPosition	Ordinal	10606		
 D2Common.dll	GetBeltTypeRecord	Ordinal	10605		
+D2Common.dll	GetEquipmentSlotLayout	Ordinal	10604		
 D2Common.dll	GetInventoryGridLayout	Ordinal	10603		
 D2Common.dll	GetInventoryPosition	Ordinal	10602		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10036		

--- a/1.03.txt
+++ b/1.03.txt
@@ -20,6 +20,7 @@ D2Common.dll	GlobalInventoryTxt	Offset	0xABA68	sgptInventoryInitStats
 D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0xABA64	sgnInventoryInitStats	
 D2Common.dll	GetBeltSlotPosition	Ordinal	10606		
 D2Common.dll	GetBeltTypeRecord	Ordinal	10605		
+D2Common.dll	GetEquipmentSlotLayout	Ordinal	10604		
 D2Common.dll	GetInventoryGridLayout	Ordinal	10603		
 D2Common.dll	GetInventoryPosition	Ordinal	10602		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10036		

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -20,6 +20,7 @@ D2Common.dll	GlobalInventoryTxt	Offset	0x85EE0	sgptInventoryInitStats
 D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0x85EDC	sgnInventoryInitStats	
 D2Common.dll	GetBeltSlotPosition	Ordinal	10606		
 D2Common.dll	GetBeltTypeRecord	Ordinal	10605		
+D2Common.dll	GetEquipmentSlotLayout	Ordinal	10604		
 D2Common.dll	GetInventoryGridLayout	Ordinal	10603		
 D2Common.dll	GetInventoryPosition	Ordinal	10602		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10036		

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -20,6 +20,7 @@ D2Common.dll	GlobalInventoryTxt	Offset	0xA1D38	sgptInventoryInitStats
 D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0xA1D34	sgnInventoryInitStats	
 D2Common.dll	GetBeltSlotPosition	Ordinal	10639		
 D2Common.dll	GetBeltTypeRecord	Ordinal	10638		
+D2Common.dll	GetEquipmentSlotLayout	Ordinal	10637		
 D2Common.dll	GetInventoryGridLayout	Ordinal	10636		
 D2Common.dll	GetInventoryPosition	Ordinal	10635		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10036		

--- a/1.10.txt
+++ b/1.10.txt
@@ -20,6 +20,7 @@ D2Common.dll	GlobalInventoryTxt	Offset	0xAA2D8	sgptInventoryInitStats
 D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0xAA2D4	sgnInventoryInitStats	
 D2Common.dll	GetBeltSlotPosition	Ordinal	10639		
 D2Common.dll	GetBeltTypeRecord	Ordinal	10638		
+D2Common.dll	GetEquipmentSlotLayout	Ordinal	10637		
 D2Common.dll	GetInventoryGridLayout	Ordinal	10636		
 D2Common.dll	GetInventoryPosition	Ordinal	10635		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10036		

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -20,6 +20,7 @@ D2Common.dll	GlobalInventoryTxt	Offset	0xA13F8	sgptInventoryInitStats
 D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0xA13F4	sgnInventoryInitStats	
 D2Common.dll	GetBeltSlotPosition	Ordinal	10110		
 D2Common.dll	GetBeltTypeRecord	Ordinal	10225		
+D2Common.dll	GetEquipmentSlotLayout	Ordinal	10030		
 D2Common.dll	GetInventoryGridLayout	Ordinal	10654		
 D2Common.dll	GetInventoryPosition	Ordinal	10279		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10038		

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -20,6 +20,7 @@ D2Common.dll	GlobalInventoryTxt	Offset	0x9FA5C	sgptInventoryInitStats
 D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0x9FA58	sgnInventoryInitStats	
 D2Common.dll	GetBeltSlotPosition	Ordinal	10333		
 D2Common.dll	GetBeltTypeRecord	Ordinal	10991		
+D2Common.dll	GetEquipmentSlotLayout	Ordinal	10701		
 D2Common.dll	GetInventoryGridLayout	Ordinal	10760		
 D2Common.dll	GetInventoryPosition	Ordinal	11012		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10021		

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -20,6 +20,7 @@ D2Common.dll	GlobalInventoryTxt	Offset	0xA4CB0	sgptInventoryInitStats
 D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0xA4CAC	sgnInventoryInitStats	
 D2Common.dll	GetBeltSlotPosition	Ordinal	10689		
 D2Common.dll	GetBeltTypeRecord	Ordinal	10370		
+D2Common.dll	GetEquipmentSlotLayout	Ordinal	10441		
 D2Common.dll	GetInventoryGridLayout	Ordinal	10964		
 D2Common.dll	GetInventoryPosition	Ordinal	10770		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10035		

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -20,6 +20,7 @@ D2Common.dll	GlobalInventoryTxt	Offset	0x56447C	sgptInventoryInitStats
 D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0x564478	sgnInventoryInitStats	
 D2Common.dll	GetBeltSlotPosition	Offset	0x262FD0		
 D2Common.dll	GetBeltTypeRecord	Offset	0x262F70		
+D2Common.dll	GetEquipmentSlotLayout	Offset	0x25E370		
 D2Common.dll	GetInventoryGridLayout	Offset	0x25E2F0		
 D2Common.dll	GetInventoryPosition	Offset	0x25E280		
 D2CMP.dll	GetCelFromCelContext	Offset	0x200620		

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -20,6 +20,7 @@ D2Common.dll	GlobalInventoryTxt	Offset	0x56D4F4	sgptInventoryInitStats
 D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0x56D4F0	sgnInventoryInitStats	
 D2Common.dll	GetBeltSlotPosition	Offset	0x260D10		
 D2Common.dll	GetBeltTypeRecord	Offset	0x260CB0		
+D2Common.dll	GetEquipmentSlotLayout	Offset	0x25C270		
 D2Common.dll	GetInventoryGridLayout	Offset	0x25C1F0		
 D2Common.dll	GetInventoryPosition	Offset	0x25C180		
 D2CMP.dll	GetCelFromCelContext	Offset	0x201840		


### PR DESCRIPTION
The function looks into [D2Common GlobalInventoryTxt](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/60) and writes to a specified memory location the `EquipmentSlotLayout` from an inventory record with the specified inventory index, equipment slot index, and (in 1.09D and above) the specified inventory arrange mode.

Prior to 1.12A, the function can be located by scanning for every usage of the string `sgptInventoryInitStats`. One of the functions using this string is the target function.

In 1,12A and above, the function can be located by scanning for the usage of the variable [D2Client InventoryArrangeMode](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/31). One of the functions that uses this variable also calls the target function.

## Definition
### 1.00 to 1.05B (inclusive)
```C
void D2Common_GetGlobalEquipmentSlotLayout(
  uint32_t inventory_type_index,
  EquipmentSlotLayout* out_equipment_slot_layout,
  uint32_t equipment_slot_index
);
```
- All parameters on the stack
  - Callee cleans the stack

### 1.09D and Above
```C
void D2Common_GetGlobalEquipmentSlotLayout(
  uint32_t inventory_type_index,
  uint32_t inventory_arrange_mode,
  EquipmentSlotLayout* out_equipment_slot_layout,
  uint32_t equipment_slot_index
);
```
- All parameters on the stack
  - Callee cleans the stack

## Screenshots
The following 1.00 screenshot shows the decompiled function's parameters and its cleanup convention.
![D2Common_GetEquipmentSlotLayout_01_(1 00)](https://user-images.githubusercontent.com/26683324/69907234-0e9df600-1386-11ea-9f8d-0e9a4ad6a637.PNG)

The following 1.00 screenshot shows that the parameter `inventory_type_index` is a `uint32_t`.
![D2Common_GetEquipmentSlotLayout_02_(1 00)](https://user-images.githubusercontent.com/26683324/69907236-13fb4080-1386-11ea-9fc9-d4d04f8d9645.PNG)

The following 1.09D screenshot shows the decompiled function's parameters and its cleanup convention.
![D2Common_GetEquipmentSlotLayout_03_(1 09D)](https://user-images.githubusercontent.com/26683324/69907242-237a8980-1386-11ea-96fd-60ec90e49aac.PNG)

The following 1.00 screenshot shows how to locate the function and what to look out for.
![D2Common_GetEquipmentSlotLayout_05_(1 00)](https://user-images.githubusercontent.com/26683324/69907245-28d7d400-1386-11ea-82ce-e80cf82b30b4.PNG)

The following 1.12A screenshot shows how to locate the function and what to look out for.
![D2Common_GetEquipmentSlotLayout_04_(1 12A)](https://user-images.githubusercontent.com/26683324/69907247-2c6b5b00-1386-11ea-8dde-b50656ab7f03.PNG)
