### PR TITLE
Rename D2Common Functions

### DIFF
--- a/1.00.txt
+++ b/1.00.txt
@@ -18,11 +18,11 @@ D2Client.dll	ScreenShiftY	N/A	N/A
 D2Common.dll	GlobalBeltsTxt	Offset	0xA923C	sgptBeltInitStats	
 D2Common.dll	GlobalInventoryTxt	Offset	0xA92B0	sgptInventoryInitStats	
 D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0xA92AC	sgnInventoryInitStats	
-D2Common.dll	GetBeltSlotPosition	Ordinal	10606		
-D2Common.dll	GetBeltTypeRecord	Ordinal	10605		
-D2Common.dll	GetEquipmentSlotLayout	Ordinal	10604		
-D2Common.dll	GetInventoryGridLayout	Ordinal	10603		
-D2Common.dll	GetInventoryPosition	Ordinal	10602		
+D2Common.dll	GetGlobalBeltRecord	Ordinal	10605		
+D2Common.dll	GetGlobalBeltSlotPosition	Ordinal	10606		
+D2Common.dll	GetGlobalEquipmentSlotLayout	Ordinal	10604		
+D2Common.dll	GetGlobalInventoryGridLayout	Ordinal	10603		
+D2Common.dll	GetGlobalInventoryPosition	Ordinal	10602		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10036		
 D2CMP.dll	CloseCelFile	Ordinal	10032		
 D2DDraw.dll	BitBlockHeight	Offset	0x194E4		

--- a/1.03.txt
+++ b/1.03.txt
@@ -18,11 +18,11 @@ D2Client.dll	ScreenShiftY	N/A	N/A
 D2Common.dll	GlobalBeltsTxt	Offset	0xAB9F4	sgptBeltInitStats	
 D2Common.dll	GlobalInventoryTxt	Offset	0xABA68	sgptInventoryInitStats	
 D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0xABA64	sgnInventoryInitStats	
-D2Common.dll	GetBeltSlotPosition	Ordinal	10606		
-D2Common.dll	GetBeltTypeRecord	Ordinal	10605		
-D2Common.dll	GetEquipmentSlotLayout	Ordinal	10604		
-D2Common.dll	GetInventoryGridLayout	Ordinal	10603		
-D2Common.dll	GetInventoryPosition	Ordinal	10602		
+D2Common.dll	GetGlobalBeltRecord	Ordinal	10605		
+D2Common.dll	GetGlobalBeltSlotPosition	Ordinal	10606		
+D2Common.dll	GetGlobalEquipmentSlotLayout	Ordinal	10604		
+D2Common.dll	GetGlobalInventoryGridLayout	Ordinal	10603		
+D2Common.dll	GetGlobalInventoryPosition	Ordinal	10602		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10036		
 D2CMP.dll	CloseCelFile	Ordinal	10032		
 D2DDraw.dll	BitBlockHeight	Offset	0x194E4		

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -18,11 +18,11 @@ D2Client.dll	ScreenShiftY	N/A	N/A
 D2Common.dll	GlobalBeltsTxt	Offset	0x85E70	sgptBeltInitStats	
 D2Common.dll	GlobalInventoryTxt	Offset	0x85EE0	sgptInventoryInitStats	
 D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0x85EDC	sgnInventoryInitStats	
-D2Common.dll	GetBeltSlotPosition	Ordinal	10606		
-D2Common.dll	GetBeltTypeRecord	Ordinal	10605		
-D2Common.dll	GetEquipmentSlotLayout	Ordinal	10604		
-D2Common.dll	GetInventoryGridLayout	Ordinal	10603		
-D2Common.dll	GetInventoryPosition	Ordinal	10602		
+D2Common.dll	GetGlobalBeltRecord	Ordinal	10605		
+D2Common.dll	GetGlobalBeltSlotPosition	Ordinal	10606		
+D2Common.dll	GetGlobalEquipmentSlotLayout	Ordinal	10604		
+D2Common.dll	GetGlobalInventoryGridLayout	Ordinal	10603		
+D2Common.dll	GetGlobalInventoryPosition	Ordinal	10602		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10036		
 D2CMP.dll	CloseCelFile	Ordinal	10032		
 D2DDraw.dll	BitBlockHeight	Offset	0x11B0C		

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -18,11 +18,11 @@ D2Client.dll	ScreenShiftY	Offset	0x124958
 D2Common.dll	GlobalBeltsTxt	Offset	0xA1B94	sgptBeltInitStats	
 D2Common.dll	GlobalInventoryTxt	Offset	0xA1D38	sgptInventoryInitStats	
 D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0xA1D34	sgnInventoryInitStats	
-D2Common.dll	GetBeltSlotPosition	Ordinal	10639		
-D2Common.dll	GetBeltTypeRecord	Ordinal	10638		
-D2Common.dll	GetEquipmentSlotLayout	Ordinal	10637		
-D2Common.dll	GetInventoryGridLayout	Ordinal	10636		
-D2Common.dll	GetInventoryPosition	Ordinal	10635		
+D2Common.dll	GetGlobalBeltRecord	Ordinal	10638		
+D2Common.dll	GetGlobalBeltSlotPosition	Ordinal	10639		
+D2Common.dll	GetGlobalEquipmentSlotLayout	Ordinal	10637		
+D2Common.dll	GetGlobalInventoryGridLayout	Ordinal	10636		
+D2Common.dll	GetGlobalInventoryPosition	Ordinal	10635		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10036		
 D2CMP.dll	CloseCelFile	Ordinal	10032		
 D2DDraw.dll	BitBlockHeight	Offset	0x11B7C		

--- a/1.10.txt
+++ b/1.10.txt
@@ -18,11 +18,11 @@ D2Client.dll	ScreenShiftY	Offset	0x11A74C
 D2Common.dll	GlobalBeltsTxt	Offset	0xA9604	sgptBeltInitStats	
 D2Common.dll	GlobalInventoryTxt	Offset	0xAA2D8	sgptInventoryInitStats	
 D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0xAA2D4	sgnInventoryInitStats	
-D2Common.dll	GetBeltSlotPosition	Ordinal	10639		
-D2Common.dll	GetBeltTypeRecord	Ordinal	10638		
-D2Common.dll	GetEquipmentSlotLayout	Ordinal	10637		
-D2Common.dll	GetInventoryGridLayout	Ordinal	10636		
-D2Common.dll	GetInventoryPosition	Ordinal	10635		
+D2Common.dll	GetGlobalBeltRecord	Ordinal	10638		
+D2Common.dll	GetGlobalBeltSlotPosition	Ordinal	10639		
+D2Common.dll	GetGlobalEquipmentSlotLayout	Ordinal	10637		
+D2Common.dll	GetGlobalInventoryGridLayout	Ordinal	10636		
+D2Common.dll	GetGlobalInventoryPosition	Ordinal	10635		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10036		
 D2CMP.dll	CloseCelFile	Ordinal	10032		
 D2DDraw.dll	BitBlockHeight	Offset	0x11BBC		

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -18,11 +18,11 @@ D2Client.dll	ScreenShiftY	Offset	0x11BD2C
 D2Common.dll	GlobalBeltsTxt	Offset	0xA0750	sgptBeltInitStats	
 D2Common.dll	GlobalInventoryTxt	Offset	0xA13F8	sgptInventoryInitStats	
 D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0xA13F4	sgnInventoryInitStats	
-D2Common.dll	GetBeltSlotPosition	Ordinal	10110		
-D2Common.dll	GetBeltTypeRecord	Ordinal	10225		
-D2Common.dll	GetEquipmentSlotLayout	Ordinal	10030		
-D2Common.dll	GetInventoryGridLayout	Ordinal	10654		
-D2Common.dll	GetInventoryPosition	Ordinal	10279		
+D2Common.dll	GetGlobalBeltRecord	Ordinal	10225		
+D2Common.dll	GetGlobalBeltSlotPosition	Ordinal	10110		
+D2Common.dll	GetGlobalEquipmentSlotLayout	Ordinal	10030		
+D2Common.dll	GetGlobalInventoryGridLayout	Ordinal	10654		
+D2Common.dll	GetGlobalInventoryPosition	Ordinal	10279		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10038		
 D2CMP.dll	CloseCelFile	Ordinal	10106		
 D2DDraw.dll	BitBlockHeight	Offset	0xFDD8		

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -18,11 +18,11 @@ D2Client.dll	ScreenShiftY	Offset	0x11B9A4
 D2Common.dll	GlobalBeltsTxt	Offset	0xA13DC	sgptBeltInitStats	
 D2Common.dll	GlobalInventoryTxt	Offset	0x9FA5C	sgptInventoryInitStats	
 D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0x9FA58	sgnInventoryInitStats	
-D2Common.dll	GetBeltSlotPosition	Ordinal	10333		
-D2Common.dll	GetBeltTypeRecord	Ordinal	10991		
-D2Common.dll	GetEquipmentSlotLayout	Ordinal	10701		
-D2Common.dll	GetInventoryGridLayout	Ordinal	10760		
-D2Common.dll	GetInventoryPosition	Ordinal	11012		
+D2Common.dll	GetGlobalBeltRecord	Ordinal	10991		
+D2Common.dll	GetGlobalBeltSlotPosition	Ordinal	10333		
+D2Common.dll	GetGlobalEquipmentSlotLayout	Ordinal	10701		
+D2Common.dll	GetGlobalInventoryGridLayout	Ordinal	10760		
+D2Common.dll	GetGlobalInventoryPosition	Ordinal	11012		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10021		
 D2CMP.dll	CloseCelFile	Ordinal	10065		
 D2DDraw.dll	BitBlockHeight	Offset	0x101D8		

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -18,11 +18,11 @@ D2Client.dll	ScreenShiftY	Offset	0x11D358
 D2Common.dll	GlobalBeltsTxt	Offset	0xA4BA0	sgptBeltInitStats	
 D2Common.dll	GlobalInventoryTxt	Offset	0xA4CB0	sgptInventoryInitStats	
 D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0xA4CAC	sgnInventoryInitStats	
-D2Common.dll	GetBeltSlotPosition	Ordinal	10689		
-D2Common.dll	GetBeltTypeRecord	Ordinal	10370		
-D2Common.dll	GetEquipmentSlotLayout	Ordinal	10441		
-D2Common.dll	GetInventoryGridLayout	Ordinal	10964		
-D2Common.dll	GetInventoryPosition	Ordinal	10770		
+D2Common.dll	GetGlobalBeltRecord	Ordinal	10370		
+D2Common.dll	GetGlobalBeltSlotPosition	Ordinal	10689		
+D2Common.dll	GetGlobalEquipmentSlotLayout	Ordinal	10441		
+D2Common.dll	GetGlobalInventoryGridLayout	Ordinal	10964		
+D2Common.dll	GetGlobalInventoryPosition	Ordinal	10770		
 D2CMP.dll	GetCelFromCelContext	Ordinal	10035		
 D2CMP.dll	CloseCelFile	Ordinal	10020		
 D2DDraw.dll	BitBlockHeight	Offset	0x100E8		

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -18,11 +18,11 @@ D2Client.dll	ScreenShiftY	Offset	0x3998E4
 D2Common.dll	GlobalBeltsTxt	Offset	0x564480	sgptBeltInitStats	
 D2Common.dll	GlobalInventoryTxt	Offset	0x56447C	sgptInventoryInitStats	
 D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0x564478	sgnInventoryInitStats	
-D2Common.dll	GetBeltSlotPosition	Offset	0x262FD0		
-D2Common.dll	GetBeltTypeRecord	Offset	0x262F70		
-D2Common.dll	GetEquipmentSlotLayout	Offset	0x25E370		
-D2Common.dll	GetInventoryGridLayout	Offset	0x25E2F0		
-D2Common.dll	GetInventoryPosition	Offset	0x25E280		
+D2Common.dll	GetGlobalBeltRecord	Offset	0x262F70		
+D2Common.dll	GetGlobalBeltSlotPosition	Offset	0x262FD0		
+D2Common.dll	GetGlobalEquipmentSlotLayout	Offset	0x25E370		
+D2Common.dll	GetGlobalInventoryGridLayout	Offset	0x25E2F0		
+D2Common.dll	GetGlobalInventoryPosition	Offset	0x25E280		
 D2CMP.dll	GetCelFromCelContext	Offset	0x200620		
 D2CMP.dll	CloseCelFile	Offset	0x200820		
 D2DDraw.dll	BitBlockHeight	Offset	0x3C01C4		

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -18,11 +18,11 @@ D2Client.dll	ScreenShiftY	Offset	0x3A285C
 D2Common.dll	GlobalBeltsTxt	Offset	0x56D4F8	sgptBeltInitStats	
 D2Common.dll	GlobalInventoryTxt	Offset	0x56D4F4	sgptInventoryInitStats	
 D2Common.dll	GlobalInventoryTxtRecordsCount	Offset	0x56D4F0	sgnInventoryInitStats	
-D2Common.dll	GetBeltSlotPosition	Offset	0x260D10		
-D2Common.dll	GetBeltTypeRecord	Offset	0x260CB0		
-D2Common.dll	GetEquipmentSlotLayout	Offset	0x25C270		
-D2Common.dll	GetInventoryGridLayout	Offset	0x25C1F0		
-D2Common.dll	GetInventoryPosition	Offset	0x25C180		
+D2Common.dll	GetGlobalBeltRecord	Offset	0x260CB0		
+D2Common.dll	GetGlobalBeltSlotPosition	Offset	0x260D10		
+D2Common.dll	GetGlobalEquipmentSlotLayout	Offset	0x25C270		
+D2Common.dll	GetGlobalInventoryGridLayout	Offset	0x25C1F0		
+D2Common.dll	GetGlobalInventoryPosition	Offset	0x25C180		
 D2CMP.dll	GetCelFromCelContext	Offset	0x201840		
 D2CMP.dll	CloseCelFile	Offset	0x201A50		
 D2DDraw.dll	BitBlockHeight	Offset	0x3C913C		


### PR DESCRIPTION
These functions are getters that access a global table.

- [GetBeltTypeRecord -> GetGlobalBeltRecord](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/59)
- [GetBeltSlotPosition -> GetGlobalBeltSlotPosition](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/58)
- [GetEquipmentSlotLayout -> GetGlobalEquipmentSlotLayout](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/64)
- [GetInventoryGridLayout -> GetGlobalInventoryGridLayout](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/63)
- [GetInventoryPosition -> GetGlobalInventoryPosition](https://github.com/mir-diablo-ii-tools/Diablo-II-Address-Table/pull/62)