### PR TITLE
Add D2Client GameType

### DIFF
--- a/1.00.txt
+++ b/1.00.txt
@@ -1,6 +1,7 @@
 Library	Name	Locator Type	Locator Value	Comments	
 D2Client.dll	DifficultyLevel	Offset	0x12EDDC	nDifficultyLevel	
 D2Client.dll	DrawCenteredUnicodeText	Offset	0x10EB		
+D2Client.dll	GameType	Offset	0x12EDE0	gnGameType	"0 = SP, 3 = BNet Join, 6 = OpenBNet or TCP/IP Host, 7 = OpenBNet or TCP/IP Join"
 D2Client.dll	GeneralDisplayHeight	Offset	0x1681A4		
 D2Client.dll	GeneralDisplayWidth	Offset	0x1681A8		
 D2Client.dll	GeneralPlayAreaCameraShiftX	Offset	0x1348AC		

--- a/1.03.txt
+++ b/1.03.txt
@@ -1,6 +1,7 @@
 Library	Name	Locator Type	Locator Value	Comments	
 D2Client.dll	DifficultyLevel	Offset	0x12EAC4	nDifficultyLevel	
 D2Client.dll	DrawCenteredUnicodeText	Offset	0x10E6		
+D2Client.dll	GameType	Offset	0x12EAC8	gnGameType	"0 = SP, 3 = BNet Join, 6 = OpenBNet or TCP/IP Host, 7 = OpenBNet or TCP/IP Join"
 D2Client.dll	GeneralDisplayHeight	Offset	0x1680AC		
 D2Client.dll	GeneralDisplayWidth	Offset	0x1680B0		
 D2Client.dll	GeneralPlayAreaCameraShiftX	Offset	0x134594		

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -1,6 +1,7 @@
 Library	Name	Locator Type	Locator Value	Comments	
 D2Client.dll	DifficultyLevel	Offset	0xE3024	nDifficultyLevel	
 D2Client.dll	DrawCenteredUnicodeText	Offset	0x21ED0		
+D2Client.dll	GameType	Offset	0xE3028	gnGameType	"0 = SP, 3 = BNet Join, 6 = OpenBNet or TCP/IP Host, 7 = OpenBNet or TCP/IP Join"
 D2Client.dll	GeneralDisplayHeight	Offset	0xFB594		
 D2Client.dll	GeneralDisplayWidth	Offset	0xFB598		
 D2Client.dll	GeneralPlayAreaCameraShiftX	Offset	0xE7B4C		

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -1,6 +1,7 @@
 Library	Name	Locator Type	Locator Value	Comments	
 D2Client.dll	DifficultyLevel	Offset	0x110BBC	nDifficultyLevel	
 D2Client.dll	DrawCenteredUnicodeText	Offset	0x29760		
+D2Client.dll	GameType	Offset	0x110BC0	gnGameType	"0 = SP, 3 = BNet Join, 6 = OpenBNet Host, 7 = OpenBNet Join, 8 = TCP/IP Host, 9 = TCP/IP Join"
 D2Client.dll	GeneralDisplayHeight	Offset	0xD40E0		
 D2Client.dll	GeneralDisplayWidth	Offset	0xD40DC		
 D2Client.dll	GeneralPlayAreaCameraShiftX	Offset	0x115C14		

--- a/1.10.txt
+++ b/1.10.txt
@@ -1,6 +1,7 @@
 Library	Name	Locator Type	Locator Value	Comments	
 D2Client.dll	DifficultyLevel	Offset	0x10795C	nDifficultyLevel	
 D2Client.dll	DrawCenteredUnicodeText	Offset	0x2FCD0		
+D2Client.dll	GameType	Offset	0x107960	gnGameType	"0 = SP, 3 = BNet Join, 6 = OpenBNet Host, 7 = OpenBNet Join, 8 = TCP/IP Host, 9 = TCP/IP Join"
 D2Client.dll	GeneralDisplayHeight	Offset	0xD40F0		
 D2Client.dll	GeneralDisplayWidth	Offset	0xD40EC		
 D2Client.dll	GeneralPlayAreaCameraShiftX	Offset	0x10B9C8		

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -1,6 +1,7 @@
 Library	Name	Locator Type	Locator Value	Comments	
 D2Client.dll	DifficultyLevel	Offset	0x11BFF4	nDifficultyLevel	
 D2Client.dll	DrawCenteredUnicodeText	Offset	0x6A8C0		
+D2Client.dll	GameType	Offset	0x11BFF8	gnGameType	"0 = SP, 3 = BNet Join, 6 = OpenBNet Host, 7 = OpenBNet Join, 8 = TCP/IP Host, 9 = TCP/IP Join"
 D2Client.dll	GeneralDisplayHeight	Offset	0xDC6E4		
 D2Client.dll	GeneralDisplayWidth	Offset	0xDC6E0		
 D2Client.dll	GeneralPlayAreaCameraShiftX	Offset	0x11C1D4		

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -1,6 +1,7 @@
 Library	Name	Locator Type	Locator Value	Comments	
 D2Client.dll	DifficultyLevel	Offset	0x11C390	nDifficultyLevel	
 D2Client.dll	DrawCenteredUnicodeText	Offset	0xBC4E0		
+D2Client.dll	GameType	Offset	0x11C394	gnGameType	"0 = SP, 3 = BNet Join, 6 = OpenBNet Host, 7 = OpenBNet Join, 8 = TCP/IP Host, 9 = TCP/IP Join"
 D2Client.dll	GeneralDisplayHeight	Offset	0xDBC4C		
 D2Client.dll	GeneralDisplayWidth	Offset	0xDBC48		
 D2Client.dll	GeneralPlayAreaCameraShiftX	Offset	0x11C418		

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -1,6 +1,7 @@
 Library	Name	Locator Type	Locator Value	Comments	
 D2Client.dll	DifficultyLevel	Offset	0x11D1D8	nDifficultyLevel	
 D2Client.dll	DrawCenteredUnicodeText	Offset	0xBEC80		
+D2Client.dll	GameType	Offset	0x11D1DC	gnGameType	"0 = SP, 3 = BNet Join, 6 = OpenBNet Host, 7 = OpenBNet Join, 8 = TCP/IP Host, 9 = TCP/IP Join"
 D2Client.dll	GeneralDisplayHeight	Offset	0xF7038		
 D2Client.dll	GeneralDisplayWidth	Offset	0xF7034		
 D2Client.dll	GeneralPlayAreaCameraShiftX	Offset	0x11D074		

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -1,6 +1,7 @@
 Library	Name	Locator Type	Locator Value	Comments	
 D2Client.dll	DifficultyLevel	Offset	0x397694	nDifficultyLevel	
 D2Client.dll	DrawCenteredUnicodeText	Offset	0xA3750		
+D2Client.dll	GameType	Offset	0x397698	gnGameType	"0 = SP, 3 = BNet Join, 6 = OpenBNet Host, 7 = OpenBNet Join, 8 = TCP/IP Host, 9 = TCP/IP Join"
 D2Client.dll	GeneralDisplayHeight	Offset	0x30FF4C		
 D2Client.dll	GeneralDisplayWidth	Offset	0x30FF48		
 D2Client.dll	GeneralPlayAreaCameraShiftX	Offset	0x39C29C		

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -1,6 +1,7 @@
 Library	Name	Locator Type	Locator Value	Comments	
 D2Client.dll	DifficultyLevel	Offset	0x3A060C	nDifficultyLevel	
 D2Client.dll	DrawCenteredUnicodeText	Offset	0xA7080		
+D2Client.dll	GameType	Offset	0x3A0610	gnGameType	"0 = SP, 3 = BNet Join, 6 = OpenBNet Host, 7 = OpenBNet Join, 8 = TCP/IP Host, 9 = TCP/IP Join"
 D2Client.dll	GeneralDisplayHeight	Offset	0x311470		
 D2Client.dll	GeneralDisplayWidth	Offset	0x31146C		
 D2Client.dll	GeneralPlayAreaCameraShiftX	Offset	0x3A5214		


### PR DESCRIPTION
This variable is used to store the client's game type (e.g. singleplayer, Battle.net, hosting TCP/IP).

The variable can be located by scanning for the values that corresponds to what state they would be at when switching between these game modes. 

## Definition
### 1.00 to 1.05B (inclusive)
```C
uint32_t D2Client_GameType;

/*
0 = Single Player,
3 = Battle.net Join,
6 = Open Battle.net or TCP/IP Host,
7 = Open Battle.net or TCP/IP Join
*/
```

### 1.07 to LoD 1.14D (inclusive)
```C
uint32_t D2Client_GameType;

/*
0 = Single Player,
3 = Battle.net Join,
6 = Open Battle.net Host,
7 = Open Battle.net Join,
8 = TCP/IP Host,
9 = TCP/IP Join
*/
```

## Screenshots
The following screenshot 1.00 shows that the variable is named `gnGameType` and is a 32-bit variable. It is being compared for the value 0, which represents Single Player.
![D2Client_GameType_01_(1 00)](https://user-images.githubusercontent.com/26683324/71315767-8e653080-2419-11ea-8d2f-d9a51c08262c.PNG)
