### PR TITLE
Add BNClient GatewayIPv4Address

### DIFF
--- a/1.00.txt
+++ b/1.00.txt
@@ -1,5 +1,6 @@
 Library	Name	Locator Type	Locator Value	Comments	
 BNClient.dll	GatewayDomainName	Offset	0x21D90		
+BNClient.dll	GatewayIPv4Address	Offset	0x21EB8		
 D2Client.dll	DifficultyLevel	Offset	0x12EDDC	nDifficultyLevel	
 D2Client.dll	DrawCenteredUnicodeText	Offset	0x10EB		
 D2Client.dll	GameType	Offset	0x12EDE0	gnGameType	"0 = SP, 3 = BNet Join, 6 = OpenBNet or TCP/IP Host, 7 = OpenBNet or TCP/IP Join"

--- a/1.03.txt
+++ b/1.03.txt
@@ -1,5 +1,6 @@
 Library	Name	Locator Type	Locator Value	Comments	
 BNClient.dll	GatewayDomainName	Offset	0x21DE0		
+BNClient.dll	GatewayIPv4Address	Offset	0x21F08		
 D2Client.dll	DifficultyLevel	Offset	0x12EAC4	nDifficultyLevel	
 D2Client.dll	DrawCenteredUnicodeText	Offset	0x10E6		
 D2Client.dll	GameType	Offset	0x12EAC8	gnGameType	"0 = SP, 3 = BNet Join, 6 = OpenBNet or TCP/IP Host, 7 = OpenBNet or TCP/IP Join"

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -1,5 +1,6 @@
 Library	Name	Locator Type	Locator Value	Comments	
 BNClient.dll	GatewayDomainName	Offset	0x18138		
+BNClient.dll	GatewayIPv4Address	Offset	0x18260		
 D2Client.dll	DifficultyLevel	Offset	0xE3024	nDifficultyLevel	
 D2Client.dll	DrawCenteredUnicodeText	Offset	0x21ED0		
 D2Client.dll	GameType	Offset	0xE3028	gnGameType	"0 = SP, 3 = BNet Join, 6 = OpenBNet or TCP/IP Host, 7 = OpenBNet or TCP/IP Join"

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -1,5 +1,6 @@
 Library	Name	Locator Type	Locator Value	Comments	
 BNClient.dll	GatewayDomainName	Offset	0x1CB38		
+BNClient.dll	GatewayIPv4Address	Offset	0x1CC60		
 D2Client.dll	DifficultyLevel	Offset	0x110BBC	nDifficultyLevel	
 D2Client.dll	DrawCenteredUnicodeText	Offset	0x29760		
 D2Client.dll	GameType	Offset	0x110BC0	gnGameType	"0 = SP, 3 = BNet Join, 6 = OpenBNet Host, 7 = OpenBNet Join, 8 = TCP/IP Host, 9 = TCP/IP Join"

--- a/1.10.txt
+++ b/1.10.txt
@@ -1,5 +1,6 @@
 Library	Name	Locator Type	Locator Value	Comments	
 BNClient.dll	GatewayDomainName	Offset	0x1CE30		
+BNClient.dll	GatewayIPv4Address	Offset	0x1CF58		
 D2Client.dll	DifficultyLevel	Offset	0x10795C	nDifficultyLevel	
 D2Client.dll	DrawCenteredUnicodeText	Offset	0x2FCD0		
 D2Client.dll	GameType	Offset	0x107960	gnGameType	"0 = SP, 3 = BNet Join, 6 = OpenBNet Host, 7 = OpenBNet Join, 8 = TCP/IP Host, 9 = TCP/IP Join"

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -1,5 +1,6 @@
 Library	Name	Locator Type	Locator Value	Comments	
 BNClient.dll	GatewayDomainName	Offset	0x1F1B8		
+BNClient.dll	GatewayIPv4Address	Offset	0x1F2B8		
 D2Client.dll	DifficultyLevel	Offset	0x11BFF4	nDifficultyLevel	
 D2Client.dll	DrawCenteredUnicodeText	Offset	0x6A8C0		
 D2Client.dll	GameType	Offset	0x11BFF8	gnGameType	"0 = SP, 3 = BNet Join, 6 = OpenBNet Host, 7 = OpenBNet Join, 8 = TCP/IP Host, 9 = TCP/IP Join"

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -1,5 +1,6 @@
 Library	Name	Locator Type	Locator Value	Comments	
 BNClient.dll	GatewayDomainName	Offset	0x1F200		
+BNClient.dll	GatewayIPv4Address	Offset	0x1F300		
 D2Client.dll	DifficultyLevel	Offset	0x11C390	nDifficultyLevel	
 D2Client.dll	DrawCenteredUnicodeText	Offset	0xBC4E0		
 D2Client.dll	GameType	Offset	0x11C394	gnGameType	"0 = SP, 3 = BNet Join, 6 = OpenBNet Host, 7 = OpenBNet Join, 8 = TCP/IP Host, 9 = TCP/IP Join"

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -1,5 +1,6 @@
 Library	Name	Locator Type	Locator Value	Comments	
 BNClient.dll	GatewayDomainName	Offset	0x1EDF8		
+BNClient.dll	GatewayIPv4Address	Offset	0x1EEF8		
 D2Client.dll	DifficultyLevel	Offset	0x11D1D8	nDifficultyLevel	
 D2Client.dll	DrawCenteredUnicodeText	Offset	0xBEC80		
 D2Client.dll	GameType	Offset	0x11D1DC	gnGameType	"0 = SP, 3 = BNet Join, 6 = OpenBNet Host, 7 = OpenBNet Join, 8 = TCP/IP Host, 9 = TCP/IP Join"

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -1,5 +1,6 @@
 Library	Name	Locator Type	Locator Value	Comments	
 BNClient.dll	GatewayDomainName	Offset	0x478970		
+BNClient.dll	GatewayIPv4Address	Offset	0x478A70		
 D2Client.dll	DifficultyLevel	Offset	0x397694	nDifficultyLevel	
 D2Client.dll	DrawCenteredUnicodeText	Offset	0xA3750		
 D2Client.dll	GameType	Offset	0x397698	gnGameType	"0 = SP, 3 = BNet Join, 6 = OpenBNet Host, 7 = OpenBNet Join, 8 = TCP/IP Host, 9 = TCP/IP Join"

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -1,5 +1,6 @@
 Library	Name	Locator Type	Locator Value	Comments	
 BNClient.dll	GatewayDomainName	Offset	0x4818E8		
+BNClient.dll	GatewayIPv4Address	Offset	0x4819E8		
 D2Client.dll	DifficultyLevel	Offset	0x3A060C	nDifficultyLevel	
 D2Client.dll	DrawCenteredUnicodeText	Offset	0xA7080		
 D2Client.dll	GameType	Offset	0x3A0610	gnGameType	"0 = SP, 3 = BNet Join, 6 = OpenBNet Host, 7 = OpenBNet Join, 8 = TCP/IP Host, 9 = TCP/IP Join"


### PR DESCRIPTION
The variable stores a null-terminated string of 7-bit ASCII characters that represent the chosen Gateway's IPv4 Address.

The variable can be located by searching for the string `BNETIP` and scanning for functions that access that string. Afterwards, one of the functions will be accessing the target variable.

## Definitions
### All Versions
```C
char* BNClient_GatewayIPv4Address;
```

## Screenshots
The following 1.00 screenshot shows the variable being used and that the variable is a null-terminated string of 7-bit ASCII characters.
![BNClient_GatewayIPv4Address_01_(1 00)](https://user-images.githubusercontent.com/26683324/71316502-2e748700-2425-11ea-8635-e2f750c8f68d.PNG)
