### PR TITLE
Add D2GFX IsWindowedMode

### DIFF
--- a/1.00.txt
+++ b/1.00.txt
@@ -42,6 +42,7 @@ D2GDI.dll	CelDisplayLeft	Offset	0xBF80
 D2GDI.dll	CelDisplayRight	Offset	0xBF7C		
 D2GFX.dll	DrawCelContext	Ordinal	10076		
 D2GFX.dll	DrawRectangle	Ordinal	10059		
+D2GFX.dll	IsWindowedMode	Offset	0x2A94C		
 D2GFX.dll	ResolutionMode	Offset	0x2A950	"0 = 640x480, 1 = Main Menu 800x600"	
 D2GFX.dll	VideoMode	Offset	0x2A948	"1 = GDI, 2 = Software, 3 = DirectDraw, 4 = Glide, 5 = OpenGL, 6 = Direct3D, 7 = Rave"	
 D2Glide.dll	DisplayHeight	Offset	0x1DE04		

--- a/1.03.txt
+++ b/1.03.txt
@@ -42,6 +42,7 @@ D2GDI.dll	CelDisplayLeft	Offset	0xBF80
 D2GDI.dll	CelDisplayRight	Offset	0xBF7C		
 D2GFX.dll	DrawCelContext	Ordinal	10076		
 D2GFX.dll	DrawRectangle	Ordinal	10059		
+D2GFX.dll	IsWindowedMode	Offset	0x2A98C		
 D2GFX.dll	ResolutionMode	Offset	0x2A990	"0 = 640x480, 1 = Main Menu 800x600"	
 D2GFX.dll	VideoMode	Offset	0x2A988	"1 = GDI, 2 = Software, 3 = DirectDraw, 4 = Glide, 5 = OpenGL, 6 = Direct3D, 7 = Rave"	
 D2Glide.dll	DisplayHeight	Offset	0x1DDC4		

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -42,6 +42,7 @@ D2GDI.dll	CelDisplayLeft	Offset	0xB8EC
 D2GDI.dll	CelDisplayRight	Offset	0xB8E8		
 D2GFX.dll	DrawCelContext	Ordinal	10076		
 D2GFX.dll	DrawRectangle	Ordinal	10059		
+D2GFX.dll	IsWindowedMode	Offset	0x1D05C		
 D2GFX.dll	ResolutionMode	Offset	0x1D060	"0 = 640x480, 1 = Main Menu 800x600"	
 D2GFX.dll	VideoMode	Offset	0x1D058	"1 = GDI, 2 = Software, 3 = DirectDraw, 4 = Glide, 5 = OpenGL, 6 = Direct3D, 7 = Rave"	
 D2Glide.dll	DisplayHeight	Offset	0x153AC		

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -42,6 +42,7 @@ D2GDI.dll	CelDisplayLeft	Offset	0xC96C
 D2GDI.dll	CelDisplayRight	Offset	0xC968		
 D2GFX.dll	DrawCelContext	Ordinal	10072		
 D2GFX.dll	DrawRectangle	Ordinal	10055		
+D2GFX.dll	IsWindowedMode	Offset	0x1D20C		
 D2GFX.dll	ResolutionMode	Offset	0x1D210	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
 D2GFX.dll	VideoMode	Offset	0x1D208	"1 = GDI, 2 = Software, 3 = DirectDraw, 4 = Glide, 5 = OpenGL, 6 = Direct3D, 7 = Rave"	
 D2Glide.dll	DisplayHeight	Offset	0x153CC		

--- a/1.10.txt
+++ b/1.10.txt
@@ -42,6 +42,7 @@ D2GDI.dll	CelDisplayLeft	Offset	0xC9B4
 D2GDI.dll	CelDisplayRight	Offset	0xC9B0		
 D2GFX.dll	DrawCelContext	Ordinal	10072		
 D2GFX.dll	DrawRectangle	Ordinal	10055		
+D2GFX.dll	IsWindowedMode	Offset	0x1D268		
 D2GFX.dll	ResolutionMode	Offset	0x1D26C	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
 D2GFX.dll	VideoMode	Offset	0x1D264	"1 = GDI, 2 = Software, 3 = DirectDraw, 4 = Glide, 5 = OpenGL, 6 = Direct3D, 7 = Rave"	
 D2Glide.dll	DisplayHeight	Offset	0x15468		

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -42,6 +42,7 @@ D2GDI.dll	CelDisplayLeft	Offset	0xC040
 D2GDI.dll	CelDisplayRight	Offset	0xC044		
 D2GFX.dll	DrawCelContext	Ordinal	10024		
 D2GFX.dll	DrawRectangle	Ordinal	10062		
+D2GFX.dll	IsWindowedMode	Offset	0x1D450		
 D2GFX.dll	ResolutionMode	Offset	0x1D454	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
 D2GFX.dll	VideoMode	Offset	0x1D44C	"1 = GDI, 2 = Software, 3 = DirectDraw, 4 = Glide, 5 = OpenGL, 6 = Direct3D, 7 = Rave"	
 D2Glide.dll	DisplayHeight	Offset	0x16E8C		

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -42,6 +42,7 @@ D2GDI.dll	CelDisplayLeft	Offset	0xCA98
 D2GDI.dll	CelDisplayRight	Offset	0xCA9C		
 D2GFX.dll	DrawCelContext	Ordinal	10041		
 D2GFX.dll	DrawRectangle	Ordinal	10014		
+D2GFX.dll	IsWindowedMode	Offset	0x1125C		
 D2GFX.dll	ResolutionMode	Offset	0x11260	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
 D2GFX.dll	VideoMode	Offset	0x11258	"1 = GDI, 2 = Software, 3 = DirectDraw, 4 = Glide, 5 = OpenGL, 6 = Direct3D, 7 = Rave"	
 D2Glide.dll	DisplayHeight	Offset	0x15B04		

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -42,6 +42,7 @@ D2GDI.dll	CelDisplayLeft	Offset	0xCA94
 D2GDI.dll	CelDisplayRight	Offset	0xCA98		
 D2GFX.dll	DrawCelContext	Ordinal	10042		
 D2GFX.dll	DrawRectangle	Ordinal	10028		
+D2GFX.dll	IsWindowedMode	Offset	0x14A3C		
 D2GFX.dll	ResolutionMode	Offset	0x14A40	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
 D2GFX.dll	VideoMode	Offset	0x14A38	"1 = GDI, 2 = Software, 3 = DirectDraw, 4 = Glide, 5 = OpenGL, 6 = Direct3D, 7 = Rave"	
 D2Glide.dll	DisplayHeight	Offset	0x15B14		

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -42,6 +42,7 @@ D2GDI.dll	CelDisplayLeft	Offset	0x5810F0
 D2GDI.dll	CelDisplayRight	Offset	0x5810F4		
 D2GFX.dll	DrawCelContext	Offset	0xF3AA0		
 D2GFX.dll	DrawRectangle	Offset	0xF3910		
+D2GFX.dll	IsWindowedMode	Offset	0x3BFD3C		
 D2GFX.dll	ResolutionMode	Offset	0x3BFD40	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
 D2GFX.dll	VideoMode	Offset	0x3BFD38	"1 = GDI, 2 = Software, 3 = DirectDraw, 4 = Glide, 5 = OpenGL, 6 = Direct3D, 7 = Rave"	
 D2Glide.dll	DisplayHeight	Offset	0x3C01C4		

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -42,6 +42,7 @@ D2GDI.dll	CelDisplayLeft	Offset	0x58A168
 D2GDI.dll	CelDisplayRight	Offset	0x58A16C		
 D2GFX.dll	DrawCelContext	Offset	0xF6480		
 D2GFX.dll	DrawRectangle	Offset	0xF6300		
+D2GFX.dll	IsWindowedMode	Offset	0x3C8CB4		
 D2GFX.dll	ResolutionMode	Offset	0x3C8CB8	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
 D2GFX.dll	VideoMode	Offset	0x3C8CB0	"1 = GDI, 2 = Software, 3 = DirectDraw, 4 = Glide, 5 = OpenGL, 6 = Direct3D, 7 = Rave"	
 D2Glide.dll	DisplayHeight	Offset	0x3C913C		


### PR DESCRIPTION
The variable stores that window is in windowed mode, otherwise in fullscreen mode.

The variable can be located by scanning for code that uses the null-terminated string `Unsupported video mode - %d`. One of the functions using the string also uses the target variable.

## Definitions
### All Versions
```C
bool32 D2GFX_IsWindowedMode;
```

## Screenshots
The following 1.00 screenshot shows the variable being accessed. This shows the variable is a 32-bit value that is treated like a boolean.
![D2GFX_IsWindowedMode_01_(1 00)](https://user-images.githubusercontent.com/26683324/71635964-a3428080-2bde-11ea-90c9-000a88a6e3d2.PNG)

The following 1.00 screenshot shows how to locate the variable.
![D2GFX_IsWindowedMode_02_(1 00)](https://user-images.githubusercontent.com/26683324/71635965-a3428080-2bde-11ea-9607-6d0e0d39cd3c.PNG)
