### PR TITLE
Add D2GFX WindowHandle

### DIFF
--- a/1.00.txt
+++ b/1.00.txt
@@ -45,6 +45,7 @@ D2GFX.dll	DrawRectangle	Ordinal	10059
 D2GFX.dll	IsWindowedMode	Offset	0x2A94C		
 D2GFX.dll	ResolutionMode	Offset	0x2A950	"0 = 640x480, 1 = Main Menu 800x600"	
 D2GFX.dll	VideoMode	Offset	0x2A948	"1 = GDI, 2 = Software, 3 = DirectDraw, 4 = Glide, 5 = OpenGL, 6 = Direct3D, 7 = Rave"	
+D2GFX.dll	WindowHandle	Offset	0x2A954	gtGfxSystem.hWnd	
 D2Glide.dll	DisplayHeight	Offset	0x1DE04		
 D2Glide.dll	DisplayWidth	Offset	0x1DD44		
 D2Lang.dll	GetStringByIndex	Ordinal	10004		

--- a/1.03.txt
+++ b/1.03.txt
@@ -45,6 +45,7 @@ D2GFX.dll	DrawRectangle	Ordinal	10059
 D2GFX.dll	IsWindowedMode	Offset	0x2A98C		
 D2GFX.dll	ResolutionMode	Offset	0x2A990	"0 = 640x480, 1 = Main Menu 800x600"	
 D2GFX.dll	VideoMode	Offset	0x2A988	"1 = GDI, 2 = Software, 3 = DirectDraw, 4 = Glide, 5 = OpenGL, 6 = Direct3D, 7 = Rave"	
+D2GFX.dll	WindowHandle	Offset	0x2A994	gtGfxSystem.hWnd	
 D2Glide.dll	DisplayHeight	Offset	0x1DDC4		
 D2Glide.dll	DisplayWidth	Offset	0x1DD04		
 D2Lang.dll	GetStringByIndex	Ordinal	10004		

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -45,6 +45,7 @@ D2GFX.dll	DrawRectangle	Ordinal	10059
 D2GFX.dll	IsWindowedMode	Offset	0x1D05C		
 D2GFX.dll	ResolutionMode	Offset	0x1D060	"0 = 640x480, 1 = Main Menu 800x600"	
 D2GFX.dll	VideoMode	Offset	0x1D058	"1 = GDI, 2 = Software, 3 = DirectDraw, 4 = Glide, 5 = OpenGL, 6 = Direct3D, 7 = Rave"	
+D2GFX.dll	WindowHandle	Offset	0x1D064	gtGfxSystem.hWnd	
 D2Glide.dll	DisplayHeight	Offset	0x153AC		
 D2Glide.dll	DisplayWidth	Offset	0x152EC		
 D2Lang.dll	GetStringByIndex	Ordinal	10004		

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -45,6 +45,7 @@ D2GFX.dll	DrawRectangle	Ordinal	10055
 D2GFX.dll	IsWindowedMode	Offset	0x1D20C		
 D2GFX.dll	ResolutionMode	Offset	0x1D210	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
 D2GFX.dll	VideoMode	Offset	0x1D208	"1 = GDI, 2 = Software, 3 = DirectDraw, 4 = Glide, 5 = OpenGL, 6 = Direct3D, 7 = Rave"	
+D2GFX.dll	WindowHandle	Offset	0x1D214	gtGfxSystem.hWnd	
 D2Glide.dll	DisplayHeight	Offset	0x153CC		
 D2Glide.dll	DisplayWidth	Offset	0x1530C		
 D2Lang.dll	GetStringByIndex	Ordinal	10004		

--- a/1.10.txt
+++ b/1.10.txt
@@ -45,6 +45,7 @@ D2GFX.dll	DrawRectangle	Ordinal	10055
 D2GFX.dll	IsWindowedMode	Offset	0x1D268		
 D2GFX.dll	ResolutionMode	Offset	0x1D26C	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
 D2GFX.dll	VideoMode	Offset	0x1D264	"1 = GDI, 2 = Software, 3 = DirectDraw, 4 = Glide, 5 = OpenGL, 6 = Direct3D, 7 = Rave"	
+D2GFX.dll	WindowHandle	Offset	0x1D270	gtGfxSystem.hWnd	
 D2Glide.dll	DisplayHeight	Offset	0x15468		
 D2Glide.dll	DisplayWidth	Offset	0x153AC		
 D2Lang.dll	GetStringByIndex	Ordinal	10004		

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -45,6 +45,7 @@ D2GFX.dll	DrawRectangle	Ordinal	10062
 D2GFX.dll	IsWindowedMode	Offset	0x1D450		
 D2GFX.dll	ResolutionMode	Offset	0x1D454	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
 D2GFX.dll	VideoMode	Offset	0x1D44C	"1 = GDI, 2 = Software, 3 = DirectDraw, 4 = Glide, 5 = OpenGL, 6 = Direct3D, 7 = Rave"	
+D2GFX.dll	WindowHandle	Offset	0x1D458	gtGfxSystem.hWnd	
 D2Glide.dll	DisplayHeight	Offset	0x16E8C		
 D2Glide.dll	DisplayWidth	Offset	0x16DF0		
 D2Lang.dll	GetStringByIndex	Ordinal	10005		

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -45,6 +45,7 @@ D2GFX.dll	DrawRectangle	Ordinal	10014
 D2GFX.dll	IsWindowedMode	Offset	0x1125C		
 D2GFX.dll	ResolutionMode	Offset	0x11260	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
 D2GFX.dll	VideoMode	Offset	0x11258	"1 = GDI, 2 = Software, 3 = DirectDraw, 4 = Glide, 5 = OpenGL, 6 = Direct3D, 7 = Rave"	
+D2GFX.dll	WindowHandle	Offset	0x11264	gtGfxSystem.hWnd	
 D2Glide.dll	DisplayHeight	Offset	0x15B04		
 D2Glide.dll	DisplayWidth	Offset	0x15A68		
 D2Lang.dll	GetStringByIndex	Ordinal	10003		

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -45,6 +45,7 @@ D2GFX.dll	DrawRectangle	Ordinal	10028
 D2GFX.dll	IsWindowedMode	Offset	0x14A3C		
 D2GFX.dll	ResolutionMode	Offset	0x14A40	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
 D2GFX.dll	VideoMode	Offset	0x14A38	"1 = GDI, 2 = Software, 3 = DirectDraw, 4 = Glide, 5 = OpenGL, 6 = Direct3D, 7 = Rave"	
+D2GFX.dll	WindowHandle	Offset	0x14A44	gtGfxSystem.hWnd	
 D2Glide.dll	DisplayHeight	Offset	0x15B14		
 D2Glide.dll	DisplayWidth	Offset	0x15A78		
 D2Lang.dll	GetStringByIndex	Ordinal	10004		

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -45,6 +45,7 @@ D2GFX.dll	DrawRectangle	Offset	0xF3910
 D2GFX.dll	IsWindowedMode	Offset	0x3BFD3C		
 D2GFX.dll	ResolutionMode	Offset	0x3BFD40	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
 D2GFX.dll	VideoMode	Offset	0x3BFD38	"1 = GDI, 2 = Software, 3 = DirectDraw, 4 = Glide, 5 = OpenGL, 6 = Direct3D, 7 = Rave"	
+D2GFX.dll	WindowHandle	Offset	0x3BFD44	gtGfxSystem.hWnd	
 D2Glide.dll	DisplayHeight	Offset	0x3C01C4		
 D2Glide.dll	DisplayWidth	Offset	0x3C01C0		
 D2Lang.dll	GetStringByIndex	Offset	0x121EE0		

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -45,6 +45,7 @@ D2GFX.dll	DrawRectangle	Offset	0xF6300
 D2GFX.dll	IsWindowedMode	Offset	0x3C8CB4		
 D2GFX.dll	ResolutionMode	Offset	0x3C8CB8	"0 = 640x480, 1 = Main Menu, 2 = 800x600, 3 = 1344x700"	
 D2GFX.dll	VideoMode	Offset	0x3C8CB0	"1 = GDI, 2 = Software, 3 = DirectDraw, 4 = Glide, 5 = OpenGL, 6 = Direct3D, 7 = Rave"	
+D2GFX.dll	WindowHandle	Offset	0x3C8CBC	gtGfxSystem.hWnd	
 D2Glide.dll	DisplayHeight	Offset	0x3C913C		
 D2Glide.dll	DisplayWidth	Offset	0x3C9138		
 D2Lang.dll	GetStringByIndex	Offset	0x124A30		


### PR DESCRIPTION
The variable stores the window handle of the game window.

The variable can be located by looking for a function that accesses the string `Only one copy of Diablo II may run at a time.` where that function accesses the target variable.

## Definitions
### All Versions
```C
HWND D2GFX_WindowHandle;
```

In the game code, the variable's internal name is `gtGfxSystem.hWnd`.

## Screenshots
The following 1.00 screenshot shows that the variable is a [HWND](https://docs.microsoft.com/en-us/windows/win32/winprog/windows-data-types).
![D2GFX_WindowHandle_03_(1 00)](https://user-images.githubusercontent.com/26683324/71637964-5aeb8880-2c07-11ea-9a07-ad6adb3d1f2a.PNG)

The following 1.00 screenshot shows how to locate the variable. It also shows the variable's internal name.
![D2GFX_WindowHandle_01_(1 00)](https://user-images.githubusercontent.com/26683324/71637967-81112880-2c07-11ea-820a-de41f949c025.PNG)

The following 1.13D screenshot shows how to locate the variable, without the assistance of the other indicators.
![D2GFX_WindowHandle_02_(1 13D)](https://user-images.githubusercontent.com/26683324/71637968-81112880-2c07-11ea-95f9-70ee64dc0ae1.PNG)
