### PR TITLE
Rename unicode conversion functions

### DIFF
--- a/1.00.txt
+++ b/1.00.txt
@@ -49,7 +49,9 @@ D2GFX.dll	WindowHandle	Offset	0x2A954	gtGfxSystem.hWnd
 D2Glide.dll	DisplayHeight	Offset	0x1DE04		
 D2Glide.dll	DisplayWidth	Offset	0x1DD44		
 D2Lang.dll	GetStringByIndex	Ordinal	10004		
-D2Lang.dll	Unicode_asciiToUnicode	Offset	0x1122		Unicode::win2Unicode
+D2Lang.dll	Unicode_AsciiToUnicode	Offset	0x1122		Unicode::win2Unicode
+D2Lang.dll	Unicode_UnicodeToUtf8	Offset	0x1069	?toUtf@Unicode@@SIPADPADPBU1@H@Z	Unicode::toUtf
+D2Lang.dll	Unicode_Utf8ToUnicode	Offset	0x1118	?toUnicode@Unicode@@SIPAU1@PAU1@PBDH@Z	Unicode::toUnicode
 D2Lang.dll	Unicode_strcat	Offset	0x10B4		Unicode::strcat
 D2Lang.dll	Unicode_strcmp	Offset	0x1050	?strcmp@Unicode@@SIHPBU1@0@Z	Unicode::strcmp
 D2Lang.dll	Unicode_strcpy	Offset	0x10D7		Unicode::strcpy
@@ -59,8 +61,6 @@ D2Lang.dll	Unicode_strncpy	Offset	0x114A		Unicode::strncpy
 D2Lang.dll	Unicode_strlen	Offset	0x1055	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x1014	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x1154		Unicode::toUpper
-D2Lang.dll	Unicode_unicodeToUtf8	Offset	0x1069	?toUtf@Unicode@@SIPADPADPBU1@H@Z	Unicode::toUtf
-D2Lang.dll	Unicode_utf8ToUnicode	Offset	0x1118	?toUnicode@Unicode@@SIPAU1@PAU1@PBDH@Z	Unicode::toUnicode
 D2Lang.dll	UnicodeChar_Compare	Offset	0x1019	?compare@Unicode@@SIHU1@0@Z	Unicode::compare
 D2Lang.dll	UnicodeChar_Copy	Offset	0x1136	??4Unicode@@QAEAAU0@ABU0@@Z	Unicode::operator=
 D2Lang.dll	UnicodeChar_CreateWithNoArgs	Offset	0x10CD	??_FUnicode@@QAEXXZ	Unicode::`default constructor closure'

--- a/1.03.txt
+++ b/1.03.txt
@@ -49,7 +49,9 @@ D2GFX.dll	WindowHandle	Offset	0x2A994	gtGfxSystem.hWnd
 D2Glide.dll	DisplayHeight	Offset	0x1DDC4		
 D2Glide.dll	DisplayWidth	Offset	0x1DD04		
 D2Lang.dll	GetStringByIndex	Ordinal	10004		
-D2Lang.dll	Unicode_asciiToUnicode	Offset	0x109B		Unicode::win2Unicode
+D2Lang.dll	Unicode_AsciiToUnicode	Offset	0x109B		Unicode::win2Unicode
+D2Lang.dll	Unicode_UnicodeToUtf8	Offset	0x1069	?toUtf@Unicode@@SIPADPADPBU1@H@Z	Unicode::toUtf
+D2Lang.dll	Unicode_Utf8ToUnicode	Offset	0x1118	?toUnicode@Unicode@@SIPAU1@PAU1@PBDH@Z	Unicode::toUnicode
 D2Lang.dll	Unicode_strcat	Offset	0x10B4		Unicode::strcat
 D2Lang.dll	Unicode_strcmp	Offset	0x1050	?strcmp@Unicode@@SIHPBU1@0@Z	Unicode::strcmp
 D2Lang.dll	Unicode_strcpy	Offset	0x10D7		Unicode::strcpy
@@ -59,8 +61,6 @@ D2Lang.dll	Unicode_strncpy	Offset	0x114A		Unicode::strncpy
 D2Lang.dll	Unicode_strlen	Offset	0x1055	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x1014	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x1154		Unicode::toUpper
-D2Lang.dll	Unicode_unicodeToUtf8	Offset	0x1069	?toUtf@Unicode@@SIPADPADPBU1@H@Z	Unicode::toUtf
-D2Lang.dll	Unicode_utf8ToUnicode	Offset	0x1118	?toUnicode@Unicode@@SIPAU1@PAU1@PBDH@Z	Unicode::toUnicode
 D2Win.dll	DrawUnicodeText	Ordinal	10110		
 D2Win.dll	GetPopupUnicodeTextWidthAndHeight	Ordinal	10124		
 D2Win.dll	GetUnicodeTextDrawWidth	Ordinal	10114		

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -49,7 +49,9 @@ D2GFX.dll	WindowHandle	Offset	0x1D064	gtGfxSystem.hWnd
 D2Glide.dll	DisplayHeight	Offset	0x153AC		
 D2Glide.dll	DisplayWidth	Offset	0x152EC		
 D2Lang.dll	GetStringByIndex	Ordinal	10004		
-D2Lang.dll	Unicode_asciiToUnicode	Offset	0x1AC0		Unicode::win2Unicode
+D2Lang.dll	Unicode_AsciiToUnicode	Offset	0x1AC0		Unicode::win2Unicode
+D2Lang.dll	Unicode_UnicodeToUtf8	Offset	0x2530	?toUtf@Unicode@@SIPADPADPBU1@H@Z	Unicode::toUtf
+D2Lang.dll	Unicode_Utf8ToUnicode	Offset	0x23F0	?toUnicode@Unicode@@SIPAU1@PAU1@PBDH@Z	Unicode::toUnicode
 D2Lang.dll	Unicode_strcat	Offset	0x13A0		Unicode::strcat
 D2Lang.dll	Unicode_strcmp	Offset	0x1210	?strcmp@Unicode@@SIHPBU1@0@Z	Unicode::strcmp
 D2Lang.dll	Unicode_strcpy	Offset	0x1470		Unicode::strcpy
@@ -59,8 +61,6 @@ D2Lang.dll	Unicode_strncpy	Offset	0x1420		Unicode::strncpy
 D2Lang.dll	Unicode_strlen	Offset	0x1490	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10E0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10B0		Unicode::toUpper
-D2Lang.dll	Unicode_unicodeToUtf8	Offset	0x2530	?toUtf@Unicode@@SIPADPADPBU1@H@Z	Unicode::toUtf
-D2Lang.dll	Unicode_utf8ToUnicode	Offset	0x23F0	?toUnicode@Unicode@@SIPAU1@PAU1@PBDH@Z	Unicode::toUnicode
 D2Win.dll	DrawUnicodeText	Ordinal	10110		
 D2Win.dll	GetPopupUnicodeTextWidthAndHeight	Ordinal	10124		
 D2Win.dll	GetUnicodeTextDrawWidth	Ordinal	10114		

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -49,7 +49,9 @@ D2GFX.dll	WindowHandle	Offset	0x1D214	gtGfxSystem.hWnd
 D2Glide.dll	DisplayHeight	Offset	0x153CC		
 D2Glide.dll	DisplayWidth	Offset	0x1530C		
 D2Lang.dll	GetStringByIndex	Ordinal	10004		
-D2Lang.dll	Unicode_asciiToUnicode	Offset	0x1B10		Unicode::win2Unicode
+D2Lang.dll	Unicode_AsciiToUnicode	Offset	0x1B10		Unicode::win2Unicode
+D2Lang.dll	Unicode_UnicodeToUtf8	Offset	0x2BE0	?toUtf@Unicode@@SIPADPADPBU1@H@Z	Unicode::toUtf
+D2Lang.dll	Unicode_Utf8ToUnicode	Offset	0x2AA0	?toUnicode@Unicode@@SIPAU1@PAU1@PBDH@Z	Unicode::toUnicode
 D2Lang.dll	Unicode_strcat	Offset	0x13A0		Unicode::strcat
 D2Lang.dll	Unicode_strcmp	Offset	0x1210	?strcmp@Unicode@@SIHPBU1@0@Z	Unicode::strcmp
 D2Lang.dll	Unicode_strcpy	Offset	0x1470		Unicode::strcpy
@@ -59,8 +61,6 @@ D2Lang.dll	Unicode_strncpy	Offset	0x1420		Unicode::strncpy
 D2Lang.dll	Unicode_strlen	Offset	0x1490	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10E0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10B0		Unicode::toUpper
-D2Lang.dll	Unicode_unicodeToUtf8	Offset	0x2BE0	?toUtf@Unicode@@SIPADPADPBU1@H@Z	Unicode::toUtf
-D2Lang.dll	Unicode_utf8ToUnicode	Offset	0x2AA0	?toUnicode@Unicode@@SIPAU1@PAU1@PBDH@Z	Unicode::toUnicode
 D2Win.dll	DrawUnicodeText	Ordinal	10117		
 D2Win.dll	GetPopupUnicodeTextWidthAndHeight	Ordinal	10131		
 D2Win.dll	GetUnicodeTextDrawWidth	Ordinal	10121		

--- a/1.10.txt
+++ b/1.10.txt
@@ -49,7 +49,9 @@ D2GFX.dll	WindowHandle	Offset	0x1D270	gtGfxSystem.hWnd
 D2Glide.dll	DisplayHeight	Offset	0x15468		
 D2Glide.dll	DisplayWidth	Offset	0x153AC		
 D2Lang.dll	GetStringByIndex	Ordinal	10004		
-D2Lang.dll	Unicode_asciiToUnicode	Offset	0x1BD0	?win2Unicode@Unicode@@SIPAU1@PAU1@PBDH@Z	Unicode::win2Unicode
+D2Lang.dll	Unicode_AsciiToUnicode	Offset	0x1BD0	?win2Unicode@Unicode@@SIPAU1@PAU1@PBDH@Z	Unicode::win2Unicode
+D2Lang.dll	Unicode_UnicodeToUtf8	Offset	0x2B60	?toUtf@Unicode@@SIPADPADPBU1@H@Z	Unicode::toUtf
+D2Lang.dll	Unicode_Utf8ToUnicode	Offset	0x2A40	?toUnicode@Unicode@@SIPAU1@PAU1@PBDH@Z	Unicode::toUnicode
 D2Lang.dll	Unicode_strcat	Offset	0x13F0		Unicode::strcat
 D2Lang.dll	Unicode_strcmp	Offset	0x1210	?strcmp@Unicode@@SIHPBU1@0@Z	Unicode::strcmp
 D2Lang.dll	Unicode_strcpy	Offset	0x14A0		Unicode::strcpy
@@ -59,8 +61,6 @@ D2Lang.dll	Unicode_strncpy	Offset	0x1460		Unicode::strncpy
 D2Lang.dll	Unicode_strlen	Offset	0x14C0	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10E0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10B0		Unicode::toUpper
-D2Lang.dll	Unicode_unicodeToUtf8	Offset	0x2B60	?toUtf@Unicode@@SIPADPADPBU1@H@Z	Unicode::toUtf
-D2Lang.dll	Unicode_utf8ToUnicode	Offset	0x2A40	?toUnicode@Unicode@@SIPAU1@PAU1@PBDH@Z	Unicode::toUnicode
 D2Win.dll	DrawUnicodeText	Ordinal	10117		
 D2Win.dll	GetPopupUnicodeTextWidthAndHeight	Ordinal	10131		
 D2Win.dll	GetUnicodeTextDrawWidth	Ordinal	10121		

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -49,7 +49,9 @@ D2GFX.dll	WindowHandle	Offset	0x1D458	gtGfxSystem.hWnd
 D2Glide.dll	DisplayHeight	Offset	0x16E8C		
 D2Glide.dll	DisplayWidth	Offset	0x16DF0		
 D2Lang.dll	GetStringByIndex	Ordinal	10005		
-D2Lang.dll	Unicode_asciiToUnicode	Offset	0xAF10		Unicode::win2Unicode
+D2Lang.dll	Unicode_AsciiToUnicode	Offset	0xAF10		Unicode::win2Unicode
+D2Lang.dll	Unicode_UnicodeToUtf8	Offset	0x8BB0	?toUtf@Unicode@@SIPADPADPBU1@H@Z	Unicode::toUtf
+D2Lang.dll	Unicode_Utf8ToUnicode	Offset	0x8A00	?toUnicode@Unicode@@SIPAU1@PAU1@PBDH@Z	Unicode::toUnicode
 D2Lang.dll	Unicode_strcat	Offset	0xA610		Unicode::strcat
 D2Lang.dll	Unicode_strcmp	Offset	0xA830	?strcmp@Unicode@@SIHPBU1@0@Z	Unicode::strcmp
 D2Lang.dll	Unicode_strcpy	Offset	0xA5F0		Unicode::strcpy
@@ -59,8 +61,6 @@ D2Lang.dll	Unicode_strncpy	Offset	0xA700		Unicode::strncpy
 D2Lang.dll	Unicode_strlen	Offset	0xA6E0	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10C0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10A0		Unicode::toUpper
-D2Lang.dll	Unicode_unicodeToUtf8	Offset	0x8BB0	?toUtf@Unicode@@SIPADPADPBU1@H@Z	Unicode::toUtf
-D2Lang.dll	Unicode_utf8ToUnicode	Offset	0x8A00	?toUnicode@Unicode@@SIPAU1@PAU1@PBDH@Z	Unicode::toUnicode
 D2Win.dll	DrawUnicodeText	Ordinal	10001		
 D2Win.dll	GetPopupUnicodeTextWidthAndHeight	Ordinal	10096		
 D2Win.dll	GetUnicodeTextDrawWidth	Ordinal	10132		

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -49,7 +49,9 @@ D2GFX.dll	WindowHandle	Offset	0x11264	gtGfxSystem.hWnd
 D2Glide.dll	DisplayHeight	Offset	0x15B04		
 D2Glide.dll	DisplayWidth	Offset	0x15A68		
 D2Lang.dll	GetStringByIndex	Ordinal	10003		
-D2Lang.dll	Unicode_asciiToUnicode	Offset	0x8320		Unicode::win2Unicode
+D2Lang.dll	Unicode_AsciiToUnicode	Offset	0x8320		Unicode::win2Unicode
+D2Lang.dll	Unicode_UnicodeToUtf8	Offset	0x8E80	?toUtf@Unicode@@SIPADPADPBU1@H@Z	Unicode::toUtf
+D2Lang.dll	Unicode_Utf8ToUnicode	Offset	0x8CD0	?toUnicode@Unicode@@SIPAU1@PAU1@PBDH@Z	Unicode::toUnicode
 D2Lang.dll	Unicode_strcat	Offset	0xAFE0		Unicode::strcat
 D2Lang.dll	Unicode_strcmp	Offset	0xB200	?strcmp@Unicode@@SIHPBU1@0@Z	Unicode::strcmp
 D2Lang.dll	Unicode_strcpy	Offset	0xAFC0		Unicode::strcpy
@@ -59,8 +61,6 @@ D2Lang.dll	Unicode_strncpy	Offset	0xB0D0		Unicode::strncpy
 D2Lang.dll	Unicode_strlen	Offset	0xB0B0	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10C0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10A0		Unicode::toUpper
-D2Lang.dll	Unicode_unicodeToUtf8	Offset	0x8E80	?toUtf@Unicode@@SIPADPADPBU1@H@Z	Unicode::toUtf
-D2Lang.dll	Unicode_utf8ToUnicode	Offset	0x8CD0	?toUnicode@Unicode@@SIPAU1@PAU1@PBDH@Z	Unicode::toUnicode
 D2Win.dll	DrawUnicodeText	Ordinal	10150		
 D2Win.dll	GetPopupUnicodeTextWidthAndHeight	Ordinal	10177		
 D2Win.dll	GetUnicodeTextDrawWidth	Ordinal	10028		

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -49,7 +49,9 @@ D2GFX.dll	WindowHandle	Offset	0x14A44	gtGfxSystem.hWnd
 D2Glide.dll	DisplayHeight	Offset	0x15B14		
 D2Glide.dll	DisplayWidth	Offset	0x15A78		
 D2Lang.dll	GetStringByIndex	Ordinal	10004		
-D2Lang.dll	Unicode_asciiToUnicode	Offset	0x82E0		Unicode::win2Unicode
+D2Lang.dll	Unicode_AsciiToUnicode	Offset	0x82E0		Unicode::win2Unicode
+D2Lang.dll	Unicode_UnicodeToUtf8	Offset	0xB6D0	?toUtf@Unicode@@SIPADPADPBU1@H@Z	Unicode::toUtf
+D2Lang.dll	Unicode_Utf8ToUnicode	Offset	0xB520	?toUnicode@Unicode@@SIPAU1@PAU1@PBDH@Z	Unicode::toUnicode
 D2Lang.dll	Unicode_strcat	Offset	0x8B90		Unicode::strcat
 D2Lang.dll	Unicode_strcmp	Offset	0xB200	?strcmp@Unicode@@SIHPBU1@0@Z	Unicode::strcmp
 D2Lang.dll	Unicode_strcpy	Offset	0xAFC0		Unicode::strcpy
@@ -59,8 +61,6 @@ D2Lang.dll	Unicode_strncpy	Offset	0xB0D0		Unicode::strncpy
 D2Lang.dll	Unicode_strlen	Offset	0x8C60	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0x10C0	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x10A0		Unicode::toUpper
-D2Lang.dll	Unicode_unicodeToUtf8	Offset	0xB6D0	?toUtf@Unicode@@SIPADPADPBU1@H@Z	Unicode::toUtf
-D2Lang.dll	Unicode_utf8ToUnicode	Offset	0xB520	?toUnicode@Unicode@@SIPAU1@PAU1@PBDH@Z	Unicode::toUnicode
 D2Win.dll	DrawUnicodeText	Ordinal	10076		
 D2Win.dll	GetPopupUnicodeTextWidthAndHeight	Ordinal	10179		
 D2Win.dll	GetUnicodeTextDrawWidth	Ordinal	10150		

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -49,7 +49,9 @@ D2GFX.dll	WindowHandle	Offset	0x3BFD44	gtGfxSystem.hWnd
 D2Glide.dll	DisplayHeight	Offset	0x3C01C4		
 D2Glide.dll	DisplayWidth	Offset	0x3C01C0		
 D2Lang.dll	GetStringByIndex	Offset	0x121EE0		
-D2Lang.dll	Unicode_asciiToUnicode	Offset	0x124450		Unicode::win2Unicode
+D2Lang.dll	Unicode_AsciiToUnicode	Offset	0x124450		Unicode::win2Unicode
+D2Lang.dll	Unicode_UnicodeToUtf8	Offset	0x123940	?toUtf@Unicode@@SIPADPADPBU1@H@Z	Unicode::toUtf
+D2Lang.dll	Unicode_Utf8ToUnicode	Offset	0x123890	?toUnicode@Unicode@@SIPAU1@PAU1@PBDH@Z	Unicode::toUnicode
 D2Lang.dll	Unicode_strcat	Offset	0x123C50		Unicode::strcat
 D2Lang.dll	Unicode_strcmp	Offset	0x123A40	?strcmp@Unicode@@SIHPBU1@0@Z	Unicode::strcmp
 D2Lang.dll	Unicode_strcpy	Offset	0x123D30		Unicode::strcpy
@@ -59,8 +61,6 @@ D2Lang.dll	Unicode_strncpy	Offset	0x123CE0		Unicode::strncpy
 D2Lang.dll	Unicode_strlen	Offset	0x123D50	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0xADD70	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x29E40		Unicode::toUpper
-D2Lang.dll	Unicode_unicodeToUtf8	Offset	0x123940	?toUtf@Unicode@@SIPADPADPBU1@H@Z	Unicode::toUtf
-D2Lang.dll	Unicode_utf8ToUnicode	Offset	0x123890	?toUnicode@Unicode@@SIPAU1@PAU1@PBDH@Z	Unicode::toUnicode
 D2Win.dll	DrawUnicodeText	Offset	0xFFB70		
 D2Win.dll	GetPopupUnicodeTextWidthAndHeight	Offset	0xFFD80		
 D2Win.dll	GetUnicodeTextDrawWidth	Offset	0xFF010		

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -49,7 +49,9 @@ D2GFX.dll	WindowHandle	Offset	0x3C8CBC	gtGfxSystem.hWnd
 D2Glide.dll	DisplayHeight	Offset	0x3C913C		
 D2Glide.dll	DisplayWidth	Offset	0x3C9138		
 D2Lang.dll	GetStringByIndex	Offset	0x124A30		
-D2Lang.dll	Unicode_asciiToUnicode	Offset	0x126F20		Unicode::win2Unicode
+D2Lang.dll	Unicode_AsciiToUnicode	Offset	0x126F20		Unicode::win2Unicode
+D2Lang.dll	Unicode_UnicodeToUtf8	Offset	0x1263E0	?toUtf@Unicode@@SIPADPADPBU1@H@Z	Unicode::toUtf
+D2Lang.dll	Unicode_Utf8ToUnicode	Offset	0x126320	?toUnicode@Unicode@@SIPAU1@PAU1@PBDH@Z	Unicode::toUnicode
 D2Lang.dll	Unicode_strcat	Offset	0x126700		Unicode::strcat
 D2Lang.dll	Unicode_strcmp	Offset	0x1264F0	?strcmp@Unicode@@SIHPBU1@0@Z	Unicode::strcmp
 D2Lang.dll	Unicode_strcpy	Offset	0x1267E0		Unicode::strcpy
@@ -59,8 +61,6 @@ D2Lang.dll	Unicode_strncpy	Offset	0x126790		Unicode::strncpy
 D2Lang.dll	Unicode_strlen	Offset	0x126800	?strlen@Unicode@@SIHPBU1@@Z	Unicode::strlen
 D2Lang.dll	Unicode_tolower	Offset	0xB15F3	?toLower@Unicode@@QBE?AU1@XZ	Unicode::toLower
 D2Lang.dll	Unicode_toupper	Offset	0x2E650		Unicode::toUpper
-D2Lang.dll	Unicode_unicodeToUtf8	Offset	0x1263E0	?toUtf@Unicode@@SIPADPADPBU1@H@Z	Unicode::toUtf
-D2Lang.dll	Unicode_utf8ToUnicode	Offset	0x126320	?toUnicode@Unicode@@SIPAU1@PAU1@PBDH@Z	Unicode::toUnicode
 D2Win.dll	DrawUnicodeText	Offset	0x102320		
 D2Win.dll	GetPopupUnicodeTextWidthAndHeight	Offset	0x102520		
 D2Win.dll	GetUnicodeTextDrawWidth	Offset	0x101820		


### PR DESCRIPTION
The function names do not resemble standard library names, and therefore should have the first letter of the "function name" capitalized.