### PR TITLE
Rename addresses for capitalization

### DIFF
--- a/1.00.txt
+++ b/1.00.txt
@@ -79,7 +79,7 @@ D2Win.dll	GetPopupUnicodeTextWidthAndHeight	Ordinal	10124
 D2Win.dll	GetUnicodeTextDrawWidth	Ordinal	10114		
 D2Win.dll	GetUnicodeTextNDrawWidth	Ordinal	10115		
 D2Win.dll	LoadCelFile	Ordinal	10035		
-D2Win.dll	LoadMPQ	Offset	0x1458A		
+D2Win.dll	LoadMpq	Offset	0x1458A		
 D2Win.dll	MainMenuMousePositionX	Offset	0x72A90		
 D2Win.dll	MainMenuMousePositionY	Offset	0x72A94		
 D2Win.dll	SetTextFont	Ordinal	10120		

--- a/1.00.txt
+++ b/1.00.txt
@@ -85,7 +85,7 @@ D2Win.dll	MainMenuMousePositionY	Offset	0x72A94
 D2Win.dll	SetTextFont	Ordinal	10120		
 D2Win.dll	SetPopUpUnicodeText	Ordinal	10122		
 D2Win.dll	UnloadCelFile	Ordinal	10037		
-D2Win.dll	UnloadMPQ	Offset	0x14729		
+D2Win.dll	UnloadMpq	Offset	0x14729		
 Fog.dll	AllocClientMemory	Ordinal	10033		
 Fog.dll	FreeClientMemory	Ordinal	10034		
 Storm.dll	SFileCloseArchive	Ordinal	252		

--- a/1.00.txt
+++ b/1.00.txt
@@ -1,6 +1,6 @@
 Library	Name	Locator Type	Locator Value	Comments	
 BNClient.dll	GatewayDomainName	Offset	0x21D90		
-BNClient.dll	GatewayIPv4Address	Offset	0x21EB8		
+BNClient.dll	GatewayIpV4Address	Offset	0x21EB8		
 D2Client.dll	DifficultyLevel	Offset	0x12EDDC	nDifficultyLevel	
 D2Client.dll	DrawCenteredUnicodeText	Offset	0x10EB		
 D2Client.dll	GameType	Offset	0x12EDE0	gnGameType	"0 = SP, 3 = BNet Join, 6 = OpenBNet or TCP/IP Host, 7 = OpenBNet or TCP/IP Join"

--- a/1.03.txt
+++ b/1.03.txt
@@ -66,7 +66,7 @@ D2Win.dll	GetPopupUnicodeTextWidthAndHeight	Ordinal	10124
 D2Win.dll	GetUnicodeTextDrawWidth	Ordinal	10114		
 D2Win.dll	GetUnicodeTextNDrawWidth	Ordinal	10115		
 D2Win.dll	LoadCelFile	Ordinal	10035		
-D2Win.dll	LoadMPQ	Offset	0x146FA		
+D2Win.dll	LoadMpq	Offset	0x146FA		
 D2Win.dll	MainMenuMousePositionX	Offset	0x72A98		
 D2Win.dll	MainMenuMousePositionY	Offset	0x72A9C		
 D2Win.dll	SetTextFont	Ordinal	10120		

--- a/1.03.txt
+++ b/1.03.txt
@@ -72,7 +72,7 @@ D2Win.dll	MainMenuMousePositionY	Offset	0x72A9C
 D2Win.dll	SetTextFont	Ordinal	10120		
 D2Win.dll	SetPopUpUnicodeText	Ordinal	10122		
 D2Win.dll	UnloadCelFile	Ordinal	10037		
-D2Win.dll	UnloadMPQ	Offset	0x148A7		
+D2Win.dll	UnloadMpq	Offset	0x148A7		
 Fog.dll	AllocClientMemory	Ordinal	10033		
 Fog.dll	FreeClientMemory	Ordinal	10034		
 Storm.dll	SFileCloseArchive	Ordinal	252		

--- a/1.03.txt
+++ b/1.03.txt
@@ -1,6 +1,6 @@
 Library	Name	Locator Type	Locator Value	Comments	
 BNClient.dll	GatewayDomainName	Offset	0x21DE0		
-BNClient.dll	GatewayIPv4Address	Offset	0x21F08		
+BNClient.dll	GatewayIpV4Address	Offset	0x21F08		
 D2Client.dll	DifficultyLevel	Offset	0x12EAC4	nDifficultyLevel	
 D2Client.dll	DrawCenteredUnicodeText	Offset	0x10E6		
 D2Client.dll	GameType	Offset	0x12EAC8	gnGameType	"0 = SP, 3 = BNet Join, 6 = OpenBNet or TCP/IP Host, 7 = OpenBNet or TCP/IP Join"

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -1,6 +1,6 @@
 Library	Name	Locator Type	Locator Value	Comments	
 BNClient.dll	GatewayDomainName	Offset	0x18138		
-BNClient.dll	GatewayIPv4Address	Offset	0x18260		
+BNClient.dll	GatewayIpV4Address	Offset	0x18260		
 D2Client.dll	DifficultyLevel	Offset	0xE3024	nDifficultyLevel	
 D2Client.dll	DrawCenteredUnicodeText	Offset	0x21ED0		
 D2Client.dll	GameType	Offset	0xE3028	gnGameType	"0 = SP, 3 = BNet Join, 6 = OpenBNet or TCP/IP Host, 7 = OpenBNet or TCP/IP Join"

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -72,7 +72,7 @@ D2Win.dll	MainMenuMousePositionY	Offset	0x5BCBC
 D2Win.dll	SetTextFont	Ordinal	10120		
 D2Win.dll	SetPopUpUnicodeText	Ordinal	10122		
 D2Win.dll	UnloadCelFile	Ordinal	10037		
-D2Win.dll	UnloadMPQ	Offset	0x10742		
+D2Win.dll	UnloadMpq	Offset	0x10742		
 Fog.dll	AllocClientMemory	Ordinal	10033		
 Fog.dll	FreeClientMemory	Ordinal	10034		
 Storm.dll	SFileCloseArchive	Ordinal	252		

--- a/1.05B.txt
+++ b/1.05B.txt
@@ -66,7 +66,7 @@ D2Win.dll	GetPopupUnicodeTextWidthAndHeight	Ordinal	10124
 D2Win.dll	GetUnicodeTextDrawWidth	Ordinal	10114		
 D2Win.dll	GetUnicodeTextNDrawWidth	Ordinal	10115		
 D2Win.dll	LoadCelFile	Ordinal	10035		
-D2Win.dll	LoadMPQ	Offset	0x10595		
+D2Win.dll	LoadMpq	Offset	0x10595		
 D2Win.dll	MainMenuMousePositionX	Offset	0x5BCB8		
 D2Win.dll	MainMenuMousePositionY	Offset	0x5BCBC		
 D2Win.dll	SetTextFont	Ordinal	10120		

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -72,7 +72,7 @@ D2Win.dll	MainMenuMousePositionY	Offset	0x618A4
 D2Win.dll	SetTextFont	Ordinal	10127		
 D2Win.dll	SetPopUpUnicodeText	Ordinal	10129		
 D2Win.dll	UnloadCelFile	Ordinal	10041		
-D2Win.dll	UnloadMPQ	Offset	0x144A6		
+D2Win.dll	UnloadMpq	Offset	0x144A6		
 Fog.dll	AllocClientMemory	Ordinal	10042		
 Fog.dll	FreeClientMemory	Ordinal	10043		
 Storm.dll	SFileCloseArchive	Ordinal	252		

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -1,6 +1,6 @@
 Library	Name	Locator Type	Locator Value	Comments	
 BNClient.dll	GatewayDomainName	Offset	0x1CB38		
-BNClient.dll	GatewayIPv4Address	Offset	0x1CC60		
+BNClient.dll	GatewayIpV4Address	Offset	0x1CC60		
 D2Client.dll	DifficultyLevel	Offset	0x110BBC	nDifficultyLevel	
 D2Client.dll	DrawCenteredUnicodeText	Offset	0x29760		
 D2Client.dll	GameType	Offset	0x110BC0	gnGameType	"0 = SP, 3 = BNet Join, 6 = OpenBNet Host, 7 = OpenBNet Join, 8 = TCP/IP Host, 9 = TCP/IP Join"

--- a/1.09D.txt
+++ b/1.09D.txt
@@ -66,7 +66,7 @@ D2Win.dll	GetPopupUnicodeTextWidthAndHeight	Ordinal	10131
 D2Win.dll	GetUnicodeTextDrawWidth	Ordinal	10121		
 D2Win.dll	GetUnicodeTextNDrawWidth	Ordinal	10122		
 D2Win.dll	LoadCelFile	Ordinal	10039		
-D2Win.dll	LoadMPQ	Offset	0x142FB		
+D2Win.dll	LoadMpq	Offset	0x142FB		
 D2Win.dll	MainMenuMousePositionX	Offset	0x618A0		
 D2Win.dll	MainMenuMousePositionY	Offset	0x618A4		
 D2Win.dll	SetTextFont	Ordinal	10127		

--- a/1.10.txt
+++ b/1.10.txt
@@ -72,7 +72,7 @@ D2Win.dll	MainMenuMousePositionY	Offset	0x5E238
 D2Win.dll	SetTextFont	Ordinal	10127		
 D2Win.dll	SetPopUpUnicodeText	Ordinal	10129		
 D2Win.dll	UnloadCelFile	Ordinal	10041		
-D2Win.dll	UnloadMPQ	Offset	0x12548		
+D2Win.dll	UnloadMpq	Offset	0x12548		
 Fog.dll	AllocClientMemory	Ordinal	10042		
 Fog.dll	FreeClientMemory	Ordinal	10043		
 Storm.dll	SFileCloseArchive	Ordinal	252		

--- a/1.10.txt
+++ b/1.10.txt
@@ -66,7 +66,7 @@ D2Win.dll	GetPopupUnicodeTextWidthAndHeight	Ordinal	10131
 D2Win.dll	GetUnicodeTextDrawWidth	Ordinal	10121		
 D2Win.dll	GetUnicodeTextNDrawWidth	Ordinal	10122		
 D2Win.dll	LoadCelFile	Ordinal	10039		
-D2Win.dll	LoadMPQ	Offset	0x12399		
+D2Win.dll	LoadMpq	Offset	0x12399		
 D2Win.dll	MainMenuMousePositionX	Offset	0x5E234		
 D2Win.dll	MainMenuMousePositionY	Offset	0x5E238		
 D2Win.dll	SetTextFont	Ordinal	10127		

--- a/1.10.txt
+++ b/1.10.txt
@@ -1,6 +1,6 @@
 Library	Name	Locator Type	Locator Value	Comments	
 BNClient.dll	GatewayDomainName	Offset	0x1CE30		
-BNClient.dll	GatewayIPv4Address	Offset	0x1CF58		
+BNClient.dll	GatewayIpV4Address	Offset	0x1CF58		
 D2Client.dll	DifficultyLevel	Offset	0x10795C	nDifficultyLevel	
 D2Client.dll	DrawCenteredUnicodeText	Offset	0x2FCD0		
 D2Client.dll	GameType	Offset	0x107960	gnGameType	"0 = SP, 3 = BNet Join, 6 = OpenBNet Host, 7 = OpenBNet Join, 8 = TCP/IP Host, 9 = TCP/IP Join"

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -72,7 +72,7 @@ D2Win.dll	MainMenuMousePositionY	Offset	0x5C704
 D2Win.dll	SetTextFont	Ordinal	10010		
 D2Win.dll	SetPopUpUnicodeText	Ordinal	10031		
 D2Win.dll	UnloadCelFile	Ordinal	10130		
-D2Win.dll	UnloadMPQ	Offset	0x78D0		
+D2Win.dll	UnloadMpq	Offset	0x78D0		
 Fog.dll	AllocClientMemory	Ordinal	10042		
 Fog.dll	FreeClientMemory	Ordinal	10043		
 Storm.dll	SFileCloseArchive	Ordinal	252		

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -66,7 +66,7 @@ D2Win.dll	GetPopupUnicodeTextWidthAndHeight	Ordinal	10096
 D2Win.dll	GetUnicodeTextDrawWidth	Ordinal	10132		
 D2Win.dll	GetUnicodeTextNDrawWidth	Ordinal	10041		
 D2Win.dll	LoadCelFile	Ordinal	10186		
-D2Win.dll	LoadMPQ	Offset	0x7E40		
+D2Win.dll	LoadMpq	Offset	0x7E40		
 D2Win.dll	MainMenuMousePositionX	Offset	0x5C700		
 D2Win.dll	MainMenuMousePositionY	Offset	0x5C704		
 D2Win.dll	SetTextFont	Ordinal	10010		

--- a/1.12A.txt
+++ b/1.12A.txt
@@ -1,6 +1,6 @@
 Library	Name	Locator Type	Locator Value	Comments	
 BNClient.dll	GatewayDomainName	Offset	0x1F1B8		
-BNClient.dll	GatewayIPv4Address	Offset	0x1F2B8		
+BNClient.dll	GatewayIpV4Address	Offset	0x1F2B8		
 D2Client.dll	DifficultyLevel	Offset	0x11BFF4	nDifficultyLevel	
 D2Client.dll	DrawCenteredUnicodeText	Offset	0x6A8C0		
 D2Client.dll	GameType	Offset	0x11BFF8	gnGameType	"0 = SP, 3 = BNet Join, 6 = OpenBNet Host, 7 = OpenBNet Join, 8 = TCP/IP Host, 9 = TCP/IP Join"

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -72,7 +72,7 @@ D2Win.dll	MainMenuMousePositionY	Offset	0x2148C
 D2Win.dll	SetTextFont	Ordinal	10184		
 D2Win.dll	SetPopUpUnicodeText	Ordinal	10085		
 D2Win.dll	UnloadCelFile	Ordinal	10126		
-D2Win.dll	UnloadMPQ	Offset	0x78F0		
+D2Win.dll	UnloadMpq	Offset	0x78F0		
 Fog.dll	AllocClientMemory	Ordinal	10042		
 Fog.dll	FreeClientMemory	Ordinal	10043		
 Storm.dll	SFileCloseArchive	Ordinal	252		

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -66,7 +66,7 @@ D2Win.dll	GetPopupUnicodeTextWidthAndHeight	Ordinal	10177
 D2Win.dll	GetUnicodeTextDrawWidth	Ordinal	10028		
 D2Win.dll	GetUnicodeTextNDrawWidth	Ordinal	10055		
 D2Win.dll	LoadCelFile	Ordinal	10111		
-D2Win.dll	LoadMPQ	Offset	0x7E60		
+D2Win.dll	LoadMpq	Offset	0x7E60		
 D2Win.dll	MainMenuMousePositionX	Offset	0x21488		
 D2Win.dll	MainMenuMousePositionY	Offset	0x2148C		
 D2Win.dll	SetTextFont	Ordinal	10184		

--- a/1.13C.txt
+++ b/1.13C.txt
@@ -1,6 +1,6 @@
 Library	Name	Locator Type	Locator Value	Comments	
 BNClient.dll	GatewayDomainName	Offset	0x1F200		
-BNClient.dll	GatewayIPv4Address	Offset	0x1F300		
+BNClient.dll	GatewayIpV4Address	Offset	0x1F300		
 D2Client.dll	DifficultyLevel	Offset	0x11C390	nDifficultyLevel	
 D2Client.dll	DrawCenteredUnicodeText	Offset	0xBC4E0		
 D2Client.dll	GameType	Offset	0x11C394	gnGameType	"0 = SP, 3 = BNet Join, 6 = OpenBNet Host, 7 = OpenBNet Join, 8 = TCP/IP Host, 9 = TCP/IP Join"

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -1,6 +1,6 @@
 Library	Name	Locator Type	Locator Value	Comments	
 BNClient.dll	GatewayDomainName	Offset	0x1EDF8		
-BNClient.dll	GatewayIPv4Address	Offset	0x1EEF8		
+BNClient.dll	GatewayIpV4Address	Offset	0x1EEF8		
 D2Client.dll	DifficultyLevel	Offset	0x11D1D8	nDifficultyLevel	
 D2Client.dll	DrawCenteredUnicodeText	Offset	0xBEC80		
 D2Client.dll	GameType	Offset	0x11D1DC	gnGameType	"0 = SP, 3 = BNet Join, 6 = OpenBNet Host, 7 = OpenBNet Join, 8 = TCP/IP Host, 9 = TCP/IP Join"

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -66,7 +66,7 @@ D2Win.dll	GetPopupUnicodeTextWidthAndHeight	Ordinal	10179
 D2Win.dll	GetUnicodeTextDrawWidth	Ordinal	10150		
 D2Win.dll	GetUnicodeTextNDrawWidth	Ordinal	10148		
 D2Win.dll	LoadCelFile	Ordinal	10023		
-D2Win.dll	LoadMPQ	Offset	0x7E50		
+D2Win.dll	LoadMpq	Offset	0x7E50		
 D2Win.dll	MainMenuMousePositionX	Offset	0x8DB1C		
 D2Win.dll	MainMenuMousePositionY	Offset	0x8DB20		
 D2Win.dll	SetDrawUnicodeTextFont	Ordinal	10047		

--- a/1.13D.txt
+++ b/1.13D.txt
@@ -72,7 +72,7 @@ D2Win.dll	MainMenuMousePositionY	Offset	0x8DB20
 D2Win.dll	SetDrawUnicodeTextFont	Ordinal	10047		
 D2Win.dll	SetPopUpUnicodeText	Ordinal	10137		
 D2Win.dll	UnloadCelFile	Ordinal	10189		
-D2Win.dll	UnloadMPQ	Offset	0x78E0		
+D2Win.dll	UnloadMpq	Offset	0x78E0		
 Fog.dll	AllocClientMemory	Ordinal	10042		
 Fog.dll	FreeClientMemory	Ordinal	10043		
 Storm.dll	SFileCloseArchive	Ordinal	252		

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -66,7 +66,7 @@ D2Win.dll	GetPopupUnicodeTextWidthAndHeight	Offset	0xFFD80
 D2Win.dll	GetUnicodeTextDrawWidth	Offset	0xFF010		
 D2Win.dll	GetUnicodeTextNDrawWidth	Offset	0xFEFD0		
 D2Win.dll	LoadCelFile	Offset	0xF7F80		
-D2Win.dll	LoadMPQ	Offset	0x114FF7		
+D2Win.dll	LoadMpq	Offset	0x114FF7		
 D2Win.dll	MainMenuMousePositionX	Offset	0x3CC62C		
 D2Win.dll	MainMenuMousePositionY	Offset	0x3CC630		
 D2Win.dll	SetTextFont	Offset	0x100750		

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -1,6 +1,6 @@
 Library	Name	Locator Type	Locator Value	Comments	
 BNClient.dll	GatewayDomainName	Offset	0x478970		
-BNClient.dll	GatewayIPv4Address	Offset	0x478A70		
+BNClient.dll	GatewayIpV4Address	Offset	0x478A70		
 D2Client.dll	DifficultyLevel	Offset	0x397694	nDifficultyLevel	
 D2Client.dll	DrawCenteredUnicodeText	Offset	0xA3750		
 D2Client.dll	GameType	Offset	0x397698	gnGameType	"0 = SP, 3 = BNet Join, 6 = OpenBNet Host, 7 = OpenBNet Join, 8 = TCP/IP Host, 9 = TCP/IP Join"

--- a/LoD 1.14C.txt
+++ b/LoD 1.14C.txt
@@ -72,7 +72,7 @@ D2Win.dll	MainMenuMousePositionY	Offset	0x3CC630
 D2Win.dll	SetTextFont	Offset	0x100750		
 D2Win.dll	SetPopUpUnicodeText	Offset	0xFFAD0		
 D2Win.dll	UnloadCelFile	Offset	0xF80B0		
-D2Win.dll	UnloadMPQ	Offset	0x115071		
+D2Win.dll	UnloadMpq	Offset	0x115071		
 Fog.dll	AllocClientMemory	Offset	0x6B90		
 Fog.dll	FreeClientMemory	Offset	0x6BD0		
 Storm.dll	SFileCloseArchive	Offset	0x15210		

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -1,6 +1,6 @@
 Library	Name	Locator Type	Locator Value	Comments	
 BNClient.dll	GatewayDomainName	Offset	0x4818E8		
-BNClient.dll	GatewayIPv4Address	Offset	0x4819E8		
+BNClient.dll	GatewayIpV4Address	Offset	0x4819E8		
 D2Client.dll	DifficultyLevel	Offset	0x3A060C	nDifficultyLevel	
 D2Client.dll	DrawCenteredUnicodeText	Offset	0xA7080		
 D2Client.dll	GameType	Offset	0x3A0610	gnGameType	"0 = SP, 3 = BNet Join, 6 = OpenBNet Host, 7 = OpenBNet Join, 8 = TCP/IP Host, 9 = TCP/IP Join"

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -72,7 +72,7 @@ D2Win.dll	MainMenuMousePositionY	Offset	0x3D55A8
 D2Win.dll	SetTextFont	Offset	0x102EF0		
 D2Win.dll	SetPopUpUnicodeText	Offset	0x102280		
 D2Win.dll	UnloadCelFile	Offset	0xFAAE0		
-D2Win.dll	UnloadMPQ	Offset	0x1173AC		
+D2Win.dll	UnloadMpq	Offset	0x1173AC		
 Fog.dll	AllocClientMemory	Offset	0xB380		
 Fog.dll	FreeClientMemory	Offset	0xB3C0		
 Storm.dll	SFileCloseArchive	Offset	0x19A80		

--- a/LoD 1.14D.txt
+++ b/LoD 1.14D.txt
@@ -66,7 +66,7 @@ D2Win.dll	GetPopupUnicodeTextWidthAndHeight	Offset	0x102520
 D2Win.dll	GetUnicodeTextDrawWidth	Offset	0x101820		
 D2Win.dll	GetUnicodeTextNDrawWidth	Offset	0x1017D0		
 D2Win.dll	LoadCelFile	Offset	0xFA9B0		
-D2Win.dll	LoadMPQ	Offset	0x117332		
+D2Win.dll	LoadMpq	Offset	0x117332		
 D2Win.dll	MainMenuMousePositionX	Offset	0x3D55A4		
 D2Win.dll	MainMenuMousePositionY	Offset	0x3D55A8		
 D2Win.dll	SetTextFont	Offset	0x102EF0		


### PR DESCRIPTION
To make names more consistent, the acronyms have been renamed.

The following addresses have been renamed:
- UnloadMPQ to UnloadMpq
- LoadMPQ to LoadMpq
- GatewayIPv4Address to GatewayIpV4Address